### PR TITLE
Improve truncation messages and fix depth calculation for root nodes

### DIFF
--- a/tractor-core/src/output/schema.rs
+++ b/tractor-core/src/output/schema.rs
@@ -269,9 +269,9 @@ fn format_node(
         if depth >= max && !node.children.is_empty() {
             let child_count = count_descendants(node);
             if use_color {
-                output.push_str(&format!("{}\u{2514}\u{2500} \x1b[2m\u{2026} ({} more)\x1b[0m\n", prefix, child_count));
+                output.push_str(&format!("{}\u{2514}\u{2500} \x1b[2m\u{2026} ({} children)\x1b[0m\n", prefix, child_count));
             } else {
-                output.push_str(&format!("{}\u{2514}\u{2500} \u{2026} ({} more)\n", prefix, child_count));
+                output.push_str(&format!("{}\u{2514}\u{2500} \u{2026} ({} children)\n", prefix, child_count));
             }
             *truncated = true;
             return;
@@ -342,11 +342,14 @@ fn format_node(
             format!("{}\u{2502}  ", prefix)
         };
 
+        // Don't increment depth for the invisible root node, matching
+        // how the XML renderer treats Document nodes transparently.
+        let child_depth = if is_root { depth } else { depth + 1 };
         format_node(
             child,
             &new_prefix,
             false,
-            depth + 1,
+            child_depth,
             max_depth,
             use_color,
             output,

--- a/tractor-core/src/output/xml_renderer.rs
+++ b/tractor-core/src/output/xml_renderer.rs
@@ -257,7 +257,7 @@ fn render_node_recursive(
                     if options.use_color {
                         output.push_str(ansi::DIM);
                     }
-                    output.push_str(&format!("<!-- ... ({} more) -->\n", child_count));
+                    output.push_str(&format!("<!-- ... ({} children) -->\n", child_count));
                     if options.use_color {
                         output.push_str(ansi::RESET);
                     }
@@ -544,7 +544,7 @@ mod tests {
         let output = render_xml_string(xml, &opts);
 
         // Should contain truncation comment with count
-        assert!(output.contains("<!-- ... (2 more) -->"));
+        assert!(output.contains("<!-- ... (2 children) -->"));
         // Should not contain the deeply nested elements
         assert!(!output.contains("<b>"));
         assert!(!output.contains("<c>"));


### PR DESCRIPTION
## Summary
This PR improves the clarity of truncation messages in tree output and fixes a depth calculation issue that affects how deeply nested children are rendered when the root node is invisible.

## Key Changes
- **Truncation message clarity**: Changed truncation messages from "({} more)" to "({} children)" in both schema and XML renderers to better communicate that the count represents child nodes, not additional siblings
- **Root node depth handling**: Fixed depth calculation in the schema renderer to not increment depth for invisible root nodes, matching the behavior of the XML renderer's transparent Document node handling
- **Test update**: Updated corresponding test assertion to match the new truncation message format

## Implementation Details
The depth calculation fix ensures that when rendering tree structures with an invisible root node, child nodes are rendered at the correct depth level. This prevents unnecessary depth increments that would cause children to be truncated prematurely. The change aligns the schema renderer's behavior with how the XML renderer already handles Document nodes transparently.

https://claude.ai/code/session_014R6tf8wS3y3WFeMqP6Udmx