### PR TITLE
Add on-demand Fly.io deploy workflow

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,46 @@
+name: Deploy Web
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-web
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+
+      - name: Install dependencies
+        run: task web:install
+
+      - name: Fetch grammars
+        run: task web:grammars
+
+      - name: Build
+        run: task web:build
+
+      - name: Deploy to Fly.io
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - run: flyctl deploy
+        working-directory: web
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -141,6 +141,13 @@ tasks:
       - cargo build --release
       - cp target/release/tractor.exe {{.DIST_DIR}}/windows-x64/
 
+  # === Setup ===
+
+  setup:fly-deploy:
+    desc: Configure Fly.io deploy token as GitHub Actions secret
+    cmds:
+      - fly tokens create deploy -a tractor | gh secret set FLY_API_TOKEN
+
   # === Maintenance ===
 
   clean:


### PR DESCRIPTION
## Summary
- Adds `deploy-web.yml` workflow triggered via `workflow_dispatch` (on-demand) that builds the web app and deploys to Fly.io
- Adds `setup:fly-deploy` task to configure the `FLY_API_TOKEN` GitHub secret in one command

## Setup
Run `task setup:fly-deploy` once to create and store the deploy token, then trigger deploys from the GitHub Actions UI or `gh workflow run deploy-web.yml`.

## Test plan
- [ ] Run `task setup:fly-deploy` to configure the secret
- [ ] Trigger the workflow via GitHub UI or `gh workflow run deploy-web.yml`
- [ ] Verify the deploy completes and the app is live on Fly.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)