### PR TITLE
Promote field names to role elements for JS/TS

### DIFF
--- a/tests/integration/languages/javascript/sample.js.xml
+++ b/tests/integration/languages/javascript/sample.js.xml
@@ -57,7 +57,10 @@ tests/integration/languages/javascript/sample.js:1
             =
             <value>
               <call>
-                <type>add</type>
+                <function>
+                  <ref/>
+                  add
+                </function>
                 <arguments>
                   <arguments>
                     (
@@ -72,11 +75,19 @@ tests/integration/languages/javascript/sample.js:1
             ;
           </variable>
           <call>
-            <member>
-              <type>console</type>
-              .
-              <type>log</type>
-            </member>
+            <function>
+              <member>
+                <object>
+                  <ref/>
+                  console
+                </object>
+                .
+                <property>
+                  <ref/>
+                  log
+                </property>
+              </member>
+            </function>
             <arguments>
               <arguments>
                 (
@@ -100,7 +111,10 @@ tests/integration/languages/javascript/sample.js:1
       </body>
     </function>
     <call>
-      <type>main</type>
+      <function>
+        <ref/>
+        main
+      </function>
       <arguments>
         <arguments>()</arguments>
       </arguments>

--- a/tests/integration/languages/javascript/test.sh
+++ b/tests/integration/languages/javascript/test.sh
@@ -3,7 +3,7 @@
 source "$(dirname "$0")/../../common.sh"
 
 echo "JavaScript:"
-run_test tractor test sample.js -x "function" --expect 2 -m "function declarations become function elements"
+run_test tractor test sample.js -x "function[name]" --expect 2 -m "function declarations become function elements"
 run_test tractor test sample.js -x "function[name='add']" --expect 1 -m "function names are directly queryable"
 run_test tractor test sample.js -x "function[name='main']" --expect 1 -m "main function is recognized"
 run_test tractor test sample.js -x "program" --expect 1 -m "program element exists"
@@ -11,7 +11,7 @@ run_test tractor test sample.js -x "call" --expect 3 -m "call expressions rename
 
 # Call structure: function references should not be <type>
 run_test tractor test sample.js -x "call/function" --expect 3 -m "call has function child for callee"
-run_test tractor test sample.js -x "call/function[identifier]" --expect 2 -m "direct calls have identifier marker"
+run_test tractor test sample.js -x "call/function[ref]" --expect 2 -m "direct calls have ref marker"
 run_test tractor test sample.js -x "call/function/member" --expect 1 -m "member call has member inside function"
 
 # Member expression structure: object/property roles should be distinct

--- a/tests/integration/languages/markdown/test.sh
+++ b/tests/integration/languages/markdown/test.sh
@@ -20,7 +20,7 @@ run_test tractor test sample.md -x "//hr" --expect 1 -m "horizontal rule found"
 echo ""
 echo "  Round-trip: extract JS code block from markdown, parse as JavaScript..."
 JS_CODE=$(tractor sample.md -x "//code_block[language='javascript']/code" -v value)
-JS_FUNCTIONS=$(echo "$JS_CODE" | tractor -l javascript -x "//function" -v count)
+JS_FUNCTIONS=$(echo "$JS_CODE" | tractor -l javascript -x "//function[name]" -v count)
 if [ "$JS_FUNCTIONS" = "1" ]; then
     echo "  ✓ round-trip: extracted JS code parses as JavaScript with 1 function"
     ((PASSED++))

--- a/tests/integration/languages/typescript/sample.ts.xml
+++ b/tests/integration/languages/typescript/sample.ts.xml
@@ -79,7 +79,10 @@ tests/integration/languages/typescript/sample.ts:1
             =
             <value>
               <call>
-                <type>add</type>
+                <function>
+                  <ref/>
+                  add
+                </function>
                 <arguments>
                   <arguments>
                     (
@@ -94,11 +97,19 @@ tests/integration/languages/typescript/sample.ts:1
             ;
           </variable>
           <call>
-            <member>
-              <type>console</type>
-              .
-              <type>log</type>
-            </member>
+            <function>
+              <member>
+                <object>
+                  <ref/>
+                  console
+                </object>
+                .
+                <property>
+                  <ref/>
+                  log
+                </property>
+              </member>
+            </function>
             <arguments>
               <arguments>
                 (
@@ -122,7 +133,10 @@ tests/integration/languages/typescript/sample.ts:1
       </body>
     </function>
     <call>
-      <type>main</type>
+      <function>
+        <ref/>
+        main
+      </function>
       <arguments>
         <arguments>()</arguments>
       </arguments>
@@ -292,11 +306,19 @@ tests/integration/languages/typescript/sample.ts:1
         <block>
           {
           <call>
-            <member>
-              <type>console</type>
-              .
-              <type>log</type>
-            </member>
+            <function>
+              <member>
+                <object>
+                  <ref/>
+                  console
+                </object>
+                .
+                <property>
+                  <ref/>
+                  log
+                </property>
+              </member>
+            </function>
             <arguments>
               <arguments>
                 (

--- a/tests/integration/languages/typescript/test.sh
+++ b/tests/integration/languages/typescript/test.sh
@@ -3,7 +3,7 @@
 source "$(dirname "$0")/../../common.sh"
 
 echo "TypeScript:"
-run_test tractor test sample.ts -x "function" --expect 4 -m "function declarations become function elements"
+run_test tractor test sample.ts -x "function[name]" --expect 4 -m "function declarations become function elements"
 run_test tractor test sample.ts -x "function[name='add']" --expect 1 -m "function names are directly queryable"
 run_test tractor test sample.ts -x "function[name='main']" --expect 1 -m "main function is recognized"
 run_test tractor test sample.ts -x "program" --expect 1 -m "program element exists"

--- a/todo/12-field-role-elements-all-languages.md
+++ b/todo/12-field-role-elements-all-languages.md
@@ -1,0 +1,23 @@
+# Field-as-role-element for all languages
+
+JS/TS now promotes tree-sitter field names (`function`, `object`, `property`) to
+wrapper elements in call/member expressions, replacing the global `identifier` →
+`type` rename with a `<ref/>` marker for simple references.
+
+Apply the same pattern to other languages:
+
+- [ ] C# (`csharp.rs`) — `classify_identifier` returns `"type"`, `"name"`, or `"ref"`
+- [ ] Java (`java.rs`) — same pattern
+- [ ] Python (`python.rs`) — same pattern
+- [ ] Go (`go.rs`) — same pattern
+- [ ] Rust (`rust_lang.rs`) — same pattern
+- [ ] T-SQL (`tsql.rs`) — uses `transform_identifier` with different categories
+
+Each language should:
+1. Identify which field names to promote (language-specific — may differ from JS/TS)
+2. Call `promote_field_to_wrapper` on appropriate parent nodes
+3. Add `inline_identifier_with_ref` handler for the new wrapper elements
+4. Stop renaming identifiers to `<type>` in non-type contexts
+5. Update integration tests and snapshots
+
+The shared helper `promote_field_to_wrapper` in `xot_transform::helpers` is ready.

--- a/tractor-core/src/languages/typescript.rs
+++ b/tractor-core/src/languages/typescript.rs
@@ -61,6 +61,26 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
         }
 
         // ---------------------------------------------------------------------
+        // Call/member expressions - promote field attributes to role wrappers
+        // ---------------------------------------------------------------------
+        "call_expression" | "member_expression" => {
+            promote_children_fields(xot, node)?;
+            if let Some(new_name) = map_element_name(&kind) {
+                rename(xot, node, new_name);
+            }
+            Ok(TransformAction::Continue)
+        }
+
+        // ---------------------------------------------------------------------
+        // Role wrappers (created by field promotion above)
+        // Inline identifiers with <ref/> marker
+        // ---------------------------------------------------------------------
+        "function" | "object" | "property" if !has_kind(xot, node) => {
+            inline_identifier_with_ref(xot, node)?;
+            Ok(TransformAction::Continue)
+        }
+
+        // ---------------------------------------------------------------------
         // Binary/unary expressions - extract operator
         // ---------------------------------------------------------------------
         "binary_expression" | "unary_expression" | "assignment_expression"
@@ -159,6 +179,8 @@ fn map_element_name(kind: &str) -> Option<&'static str> {
         "call_expression" => Some("call"),
         "new_expression" => Some("new"),
         "member_expression" => Some("member"),
+        // Note: call_expression and member_expression are also handled explicitly
+        // in the transform match for field promotion, then renamed via map_element_name.
         "assignment_expression" => Some("assign"),
         "binary_expression" => Some("binary"),
         "unary_expression" => Some("unary"),
@@ -220,6 +242,54 @@ fn extract_keyword_modifiers(xot: &mut Xot, node: XotNode) -> Result<(), xot::Er
     Ok(())
 }
 
+/// Fields to promote to wrapper elements for call/member expressions
+const PROMOTED_FIELDS: &[&str] = &["function", "object", "property"];
+
+/// Check if a node has a `kind` attribute (i.e., it's a tree-sitter node, not a wrapper)
+fn has_kind(xot: &Xot, node: XotNode) -> bool {
+    get_kind(xot, node).is_some()
+}
+
+/// Promote field attributes on children to wrapper elements
+fn promote_children_fields(xot: &mut Xot, node: XotNode) -> Result<(), xot::Error> {
+    let children: Vec<XotNode> = xot.children(node)
+        .filter(|&c| xot.element(c).is_some())
+        .collect();
+    for child in children {
+        promote_field_to_wrapper(xot, child, PROMOTED_FIELDS)?;
+    }
+    Ok(())
+}
+
+/// Inline an identifier child into the role wrapper with a `<ref/>` marker.
+///
+/// `<function><identifier>require</identifier></function>`
+/// becomes `<function><ref/>require</function>`
+///
+/// If the child is not an identifier (e.g., member_expression), does nothing.
+fn inline_identifier_with_ref(xot: &mut Xot, wrapper: XotNode) -> Result<(), xot::Error> {
+    let children: Vec<_> = xot.children(wrapper).collect();
+    for child in children {
+        if let Some(child_name) = get_element_name(xot, child) {
+            if child_name == "identifier" || child_name == "property_identifier" {
+                if let Some(text) = get_text_content(xot, child) {
+                    // Remove all children from wrapper
+                    let all_children: Vec<_> = xot.children(wrapper).collect();
+                    for c in all_children {
+                        xot.detach(c)?;
+                    }
+                    // Add <ref/> marker and text
+                    prepend_empty_element(xot, wrapper, "ref")?;
+                    let text_node = xot.new_text(&text);
+                    xot.append(wrapper, text_node)?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Classify an identifier as "name" or "type" based on context
 fn classify_identifier(xot: &Xot, node: XotNode) -> &'static str {
     let parent = match get_parent(xot, node) {
@@ -265,6 +335,7 @@ pub fn syntax_category(element: &str) -> SyntaxCategory {
         // Identifiers
         "name" => SyntaxCategory::Identifier,
         "type" => SyntaxCategory::Type,
+        "ref" => SyntaxCategory::Identifier,
 
         // Literals
         "string" => SyntaxCategory::String,

--- a/tractor-core/src/xot_transform.rs
+++ b/tractor-core/src/xot_transform.rs
@@ -603,6 +603,49 @@ pub mod helpers {
         false
     }
 
+    /// Promote a `field` attribute to a wrapper element.
+    ///
+    /// Given `<identifier field="function">require</identifier>`, produces
+    /// `<function><identifier>require</identifier></function>`.
+    ///
+    /// - Creates a wrapper element named after the field value
+    /// - Copies source location attributes to the wrapper
+    /// - Marks the wrapper with `field` for JSON property lifting
+    /// - Removes `field` from the inner element
+    /// - Returns the wrapper node, or `None` if the node has no matching field
+    ///
+    /// The caller specifies which field values to promote (e.g., `&["function", "object", "property"]`).
+    pub fn promote_field_to_wrapper(
+        xot: &mut Xot,
+        node: XotNode,
+        fields: &[&str],
+    ) -> Result<Option<XotNode>, xot::Error> {
+        let field_value = match get_attr(xot, node, "field") {
+            Some(f) if fields.contains(&f.as_str()) => f,
+            _ => return Ok(None),
+        };
+
+        // Create wrapper element
+        let wrapper_name = get_name(xot, &field_value);
+        let wrapper = xot.new_element(wrapper_name);
+
+        // Copy source location to wrapper
+        copy_source_location(xot, node, wrapper);
+
+        // Mark wrapper as field-backed for JSON property lifting
+        set_attr(xot, wrapper, "field", &field_value);
+
+        // Remove field from inner element
+        remove_attr(xot, node, "field");
+
+        // Insert wrapper where node is, then move node inside
+        xot.insert_before(node, wrapper)?;
+        xot.detach(node)?;
+        xot.append(wrapper, node)?;
+
+        Ok(Some(wrapper))
+    }
+
     /// Rename an element to a marker: renames, removes text children.
     /// Preserves `start`/`end` and `kind` attributes (source location for keyword-based markers).
     pub fn rename_to_marker(xot: &mut Xot, node: XotNode, name: &str) -> Result<(), xot::Error> {


### PR DESCRIPTION
## Summary

- Tree-sitter field names (`function`, `object`, `property`) are promoted to wrapper elements in JS/TS call/member expressions
- Replaces the incorrect global `identifier` → `<type>` rename for non-type contexts (call targets, member access)
- Adds `<ref/>` self-closing marker for simple identifier references inside role wrappers
- Adds shared `promote_field_to_wrapper` helper in `xot_transform::helpers` for reuse by other languages

### Before
```xml
<call>
  <type>require</type>          <!-- wrong: not a type -->
  <arguments>('fs')</arguments>
</call>
<call>
  <member>
    <type>console</type>        <!-- ambiguous: same element for object and property -->
    .
    <type>log</type>
  </member>
  <arguments>("hello")</arguments>
</call>
```

### After
```xml
<call>
  <function><ref/>require</function>
  <arguments>('fs')</arguments>
</call>
<call>
  <function>
    <member>
      <object><ref/>console</object>
      .
      <property><ref/>log</property>
    </member>
  </function>
  <arguments>("hello")</arguments>
</call>
```

### New XPath queries
- `//call/function` — all callees
- `//call/function[ref]` — direct calls (not method calls)
- `//call/function/member` — method calls
- `//member/object` — what's being accessed
- `//member/property` — what property is accessed

## Test plan
- [x] All cargo tests pass (197 tests)
- [x] All integration tests pass (all languages)
- [x] Snapshots regenerated and verified
- [x] JS/TS structural tests added for new call/member structure
- [ ] Review snapshot diffs for JS and TS

🤖 Generated with [Claude Code](https://claude.com/claude-code)