### PR TITLE
Add --changed flag for git-based file filtering

### DIFF
--- a/tractor/src/cli.rs
+++ b/tractor/src/cli.rs
@@ -156,6 +156,11 @@ When omitted, auto-selects: data for JSON/YAML, structure for everything else.")
     #[arg(short = 'g', long = "group", help_heading = "View")]
     pub group_by: Option<String>,
 
+    // -- Filter --
+    /// Only consider files changed in a git diff (e.g. "HEAD~3", "main..HEAD")
+    #[arg(long = "changed", help_heading = "Filter")]
+    pub changed: Option<String>,
+
     // -- Advanced --
     /// [EXPERIMENTAL] Limit tree building depth (skip parsing deeper nodes for speed)
     #[arg(long = "parse-depth", help_heading = "Advanced")]

--- a/tractor/src/executor.rs
+++ b/tractor/src/executor.rs
@@ -21,6 +21,7 @@ use tractor_core::{expand_globs, filter_supported_files, detect_language, parse_
 use tractor_core::xpath_upsert::{upsert, update_only};
 
 use crate::pipeline::run_rules;
+use crate::pipeline::git;
 
 // ---------------------------------------------------------------------------
 // Operation types (stable API)
@@ -52,6 +53,8 @@ pub struct QueryOperation {
     pub files: Vec<String>,
     /// File glob patterns to exclude.
     pub exclude: Vec<String>,
+    /// Git diff spec: only consider files changed in this diff.
+    pub changed: Option<String>,
     /// XPath queries to evaluate.
     pub queries: Vec<QueryExpr>,
     /// Tree mode override for parsing.
@@ -84,6 +87,8 @@ pub struct CheckOperation {
     pub files: Vec<String>,
     /// File glob patterns to exclude.
     pub exclude: Vec<String>,
+    /// Git diff spec: only consider files changed in this diff.
+    pub changed: Option<String>,
     /// Rules to check.
     pub rules: Vec<Rule>,
     /// Default tree mode for all rules (rules can override).
@@ -113,6 +118,8 @@ pub struct TestOperation {
     pub files: Vec<String>,
     /// File glob patterns to exclude.
     pub exclude: Vec<String>,
+    /// Git diff spec: only consider files changed in this diff.
+    pub changed: Option<String>,
     /// Assertions to evaluate.
     pub assertions: Vec<TestAssertion>,
     /// Tree mode override for parsing.
@@ -148,6 +155,8 @@ pub struct UpdateOperation {
     pub files: Vec<String>,
     /// File glob patterns to exclude.
     pub exclude: Vec<String>,
+    /// Git diff spec: only consider files changed in this diff.
+    pub changed: Option<String>,
     /// XPath expression to match nodes to update.
     pub xpath: String,
     /// New value for matched nodes.
@@ -171,6 +180,8 @@ pub struct SetOperation {
     pub files: Vec<String>,
     /// File glob patterns to exclude.
     pub exclude: Vec<String>,
+    /// Git diff spec: only consider files changed in this diff.
+    pub changed: Option<String>,
     /// Mappings to apply.
     pub mappings: Vec<SetMapping>,
     /// Language override for parsing.
@@ -199,6 +210,9 @@ pub struct ExecuteOptions {
     /// Base directory for resolving relative file paths.
     /// If None, uses the current working directory.
     pub base_dir: Option<PathBuf>,
+    /// Git diff spec for filtering to changed files (e.g. "HEAD~3", "main..HEAD").
+    /// When set, resolved files are intersected with the set of changed files.
+    pub changed: Option<String>,
 }
 
 impl Default for ExecuteOptions {
@@ -206,6 +220,7 @@ impl Default for ExecuteOptions {
         ExecuteOptions {
             verbose: false,
             base_dir: None,
+            changed: None,
         }
     }
 }
@@ -250,7 +265,7 @@ fn execute_query(
         return execute_query_inline(source, lang, op);
     }
 
-    let files = resolve_files(&op.files, &op.exclude, options);
+    let files = resolve_files(&op.files, &op.exclude, op.changed.as_deref(), options);
 
     if files.is_empty() {
         return Ok(Report::query(vec![], empty_summary()));
@@ -329,7 +344,7 @@ fn execute_check(
         return Ok(Report::check(vec![], empty_summary()));
     }
 
-    let files = resolve_files(&op.files, &op.exclude, options);
+    let files = resolve_files(&op.files, &op.exclude, op.changed.as_deref(), options);
 
     if files.is_empty() {
         return Ok(Report::check(vec![], empty_summary()));
@@ -409,7 +424,7 @@ fn execute_set(
     op: &SetOperation,
     options: &ExecuteOptions,
 ) -> Result<Report, Box<dyn std::error::Error>> {
-    let files = resolve_files(&op.files, &op.exclude, options);
+    let files = resolve_files(&op.files, &op.exclude, op.changed.as_deref(), options);
     let mut report_matches = Vec::new();
     let mut files_affected = HashSet::new();
     let mut updated_count = 0usize;
@@ -503,7 +518,7 @@ fn execute_test(
         return run_test_assertions_on_result(&mut result, &op.assertions, op.limit);
     }
 
-    let files = resolve_files(&op.files, &op.exclude, options);
+    let files = resolve_files(&op.files, &op.exclude, op.changed.as_deref(), options);
 
     if files.is_empty() {
         let mut passed = true;
@@ -595,7 +610,7 @@ fn execute_update(
     op: &UpdateOperation,
     options: &ExecuteOptions,
 ) -> Result<Report, Box<dyn std::error::Error>> {
-    let files = resolve_files(&op.files, &op.exclude, options);
+    let files = resolve_files(&op.files, &op.exclude, op.changed.as_deref(), options);
     let mut total_updated = 0usize;
     let mut files_modified = HashSet::new();
     let mut fallback_files = Vec::new();
@@ -784,6 +799,7 @@ fn query_files_multi(
 fn resolve_files(
     file_globs: &[String],
     exclude_globs: &[String],
+    op_changed: Option<&str>,
     options: &ExecuteOptions,
 ) -> Vec<String> {
     let mut files = if let Some(base) = &options.base_dir {
@@ -817,7 +833,30 @@ fn resolve_files(
         });
     }
 
-    filter_supported_files(files)
+    let files = filter_supported_files(files);
+
+    // Intersect with git changed files. Both global (ExecuteOptions) and
+    // per-operation changed specs apply — each narrows the file set further.
+    let cwd = options.base_dir.as_deref()
+        .unwrap_or_else(|| std::path::Path::new("."));
+
+    let files = apply_changed_filter(files, options.changed.as_deref(), cwd);
+    apply_changed_filter(files, op_changed, cwd)
+}
+
+fn apply_changed_filter(files: Vec<String>, spec: Option<&str>, cwd: &std::path::Path) -> Vec<String> {
+    match spec {
+        Some(spec) => {
+            match git::git_changed_files(spec, cwd) {
+                Ok(changed) => git::intersect_changed(files, &changed),
+                Err(e) => {
+                    eprintln!("warning: --changed filter failed: {}", e);
+                    files
+                }
+            }
+        }
+        None => files,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -854,6 +893,7 @@ mod tests {
         let ops = vec![Operation::Query(QueryOperation {
             files: vec![path.clone()],
             exclude: vec![],
+            changed: None,
             queries: vec![QueryExpr { xpath: "//name".into() }],
             tree_mode: None,
             language: None,
@@ -879,6 +919,7 @@ mod tests {
         let ops = vec![Operation::Query(QueryOperation {
             files: vec![path.clone()],
             exclude: vec![],
+            changed: None,
             queries: vec![QueryExpr { xpath: "//*[number(.) > 0]".into() }],
             tree_mode: None,
             language: None,
@@ -898,6 +939,7 @@ mod tests {
         let ops = vec![Operation::Query(QueryOperation {
             files: vec![],
             exclude: vec![],
+            changed: None,
             queries: vec![QueryExpr { xpath: "//x".into() }],
             tree_mode: None,
             language: None,
@@ -924,6 +966,7 @@ mod tests {
         let ops = vec![Operation::Set(SetOperation {
             files: vec![path.clone()],
             exclude: vec![],
+            changed: None,
             mappings: vec![SetMapping {
                 xpath: "//database/host".into(),
                 value: "new-host".into(),
@@ -947,6 +990,7 @@ mod tests {
         let ops = vec![Operation::Set(SetOperation {
             files: vec![path.clone()],
             exclude: vec![],
+            changed: None,
             mappings: vec![SetMapping {
                 xpath: "//database/host".into(),
                 value: "localhost".into(),
@@ -969,6 +1013,7 @@ mod tests {
         let ops = vec![Operation::Set(SetOperation {
             files: vec![path.clone()],
             exclude: vec![],
+            changed: None,
             mappings: vec![
                 SetMapping { xpath: "//database/host".into(), value: "new-host".into() },
                 SetMapping { xpath: "//database/port".into(), value: "5432".into() },
@@ -997,6 +1042,7 @@ mod tests {
         let ops = vec![Operation::Set(SetOperation {
             files: vec![path.clone()],
             exclude: vec![],
+            changed: None,
             mappings: vec![SetMapping {
                 xpath: "//database/host".into(),
                 value: "localhost".into(),
@@ -1023,6 +1069,7 @@ mod tests {
         let ops = vec![Operation::Set(SetOperation {
             files: vec![path.clone()],
             exclude: vec![],
+            changed: None,
             mappings: vec![SetMapping {
                 xpath: "//database/host".into(),
                 value: "correct".into(),
@@ -1052,6 +1099,7 @@ mod tests {
         let ops = vec![Operation::Set(SetOperation {
             files: vec![path.clone()],
             exclude: vec![],
+            changed: None,
             mappings: vec![SetMapping {
                 xpath: "//database/host".into(),
                 value: "correct".into(),
@@ -1075,6 +1123,7 @@ mod tests {
         let ops = vec![Operation::Check(CheckOperation {
             files: vec![path.clone()],
             exclude: vec![],
+            changed: None,
             rules: vec![
                 Rule::new("no-debug", "//debug[.='true']")
                     .with_reason("debug should not be enabled")
@@ -1104,6 +1153,7 @@ mod tests {
         let ops = vec![Operation::Check(CheckOperation {
             files: vec![path.clone()],
             exclude: vec![],
+            changed: None,
             rules: vec![
                 Rule::new("no-debug", "//debug[.='true']")
                     .with_reason("debug should not be enabled"),
@@ -1140,6 +1190,7 @@ mod tests {
             Operation::Check(CheckOperation {
                 files: vec![data_path.to_str().unwrap().into()],
                 exclude: vec![],
+                changed: None,
                 rules: vec![
                     Rule::new("has-name", "//name[.='missing']")
                         .with_reason("name should not be 'missing'"),
@@ -1154,6 +1205,7 @@ mod tests {
             Operation::Set(SetOperation {
                 files: vec![config_path.to_str().unwrap().into()],
                 exclude: vec![],
+                changed: None,
                 mappings: vec![SetMapping {
                     xpath: "//host".into(),
                     value: "new-host".into(),
@@ -1180,6 +1232,7 @@ mod tests {
         let ops = vec![Operation::Set(SetOperation {
             files: vec![path.clone()],
             exclude: vec![],
+            changed: None,
             mappings: vec![SetMapping {
                 xpath: "//database/host".into(),
                 value: "new-host".into(),

--- a/tractor/src/modes/check.rs
+++ b/tractor/src/modes/check.rs
@@ -49,6 +49,7 @@ pub fn run_check(args: CheckArgs) -> Result<(), Box<dyn std::error::Error>> {
     let op = Operation::Check(CheckOperation {
         files: files.clone(),
         exclude: vec![],
+        changed: None,
         rules: vec![rule],
         tree_mode: ctx.tree_mode,
         language: ctx.lang.clone(),
@@ -60,6 +61,7 @@ pub fn run_check(args: CheckArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     let options = ExecuteOptions {
         verbose: ctx.verbose,
+        changed: args.shared.changed.clone(),
         ..Default::default()
     };
 
@@ -113,6 +115,7 @@ fn run_check_rules(args: CheckArgs, rules_path: &str) -> Result<(), Box<dyn std:
     let op = Operation::Check(CheckOperation {
         files,
         exclude: vec![],
+        changed: None,
         rules: ruleset.rules.clone(),
         tree_mode: ctx.tree_mode,
         language: ctx.lang.clone(),
@@ -124,6 +127,7 @@ fn run_check_rules(args: CheckArgs, rules_path: &str) -> Result<(), Box<dyn std:
 
     let options = ExecuteOptions {
         verbose: ctx.verbose,
+        changed: args.shared.changed.clone(),
         ..Default::default()
     };
 

--- a/tractor/src/modes/query.rs
+++ b/tractor/src/modes/query.rs
@@ -37,6 +37,7 @@ pub fn run_query(args: QueryArgs) -> Result<(), Box<dyn std::error::Error>> {
         InputMode::Files(files) => Operation::Query(QueryOperation {
             files: files.clone(),
             exclude: vec![],
+            changed: None,
             queries: vec![QueryExpr { xpath: xpath_expr.to_string() }],
             tree_mode: ctx.tree_mode,
             language: ctx.lang.clone(),
@@ -49,6 +50,7 @@ pub fn run_query(args: QueryArgs) -> Result<(), Box<dyn std::error::Error>> {
         InputMode::InlineSource { source, lang } => Operation::Query(QueryOperation {
             files: vec![],
             exclude: vec![],
+            changed: None,
             queries: vec![QueryExpr { xpath: xpath_expr.to_string() }],
             tree_mode: ctx.tree_mode,
             language: None,
@@ -62,6 +64,7 @@ pub fn run_query(args: QueryArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     let options = ExecuteOptions {
         verbose: ctx.verbose,
+        changed: args.shared.changed.clone(),
         ..Default::default()
     };
 

--- a/tractor/src/modes/run.rs
+++ b/tractor/src/modes/run.rs
@@ -49,6 +49,7 @@ pub fn run_run(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     let options = ExecuteOptions {
         verbose: args.shared.verbose,
         base_dir,
+        changed: args.shared.changed.clone(),
     };
 
     let reports = executor::execute(&operations, &options)?;

--- a/tractor/src/modes/set.rs
+++ b/tractor/src/modes/set.rs
@@ -6,6 +6,7 @@ use tractor_core::declarative_set::declarative_set;
 use tractor_core::detect_language;
 use crate::cli::SetArgs;
 use crate::pipeline::{RunContext, ViewField, InputMode, query_files_batched, query_inline_source, render_set_report};
+use crate::pipeline::git;
 
 /// Separate positional args into files and an optional path expression.
 ///
@@ -34,6 +35,7 @@ fn split_files_and_expr(args: &[String], has_xpath: bool) -> (Vec<String>, Optio
 
 pub fn run_set(args: SetArgs) -> Result<(), Box<dyn std::error::Error>> {
     let has_xpath = args.shared.xpath.is_some();
+    let changed_spec = args.shared.changed.clone();
     let (files, expr) = split_files_and_expr(&args.args, has_xpath);
 
     // Declarative mode: path expression without -x
@@ -50,11 +52,12 @@ pub fn run_set(args: SetArgs) -> Result<(), Box<dyn std::error::Error>> {
             }
         };
 
+        let file_list = apply_changed_to_files(file_list.clone(), changed_spec.as_deref());
         let lang_override = ctx.lang.as_deref();
         let mut files_modified = 0;
         let mut total_ops = 0;
 
-        for file_path in file_list {
+        for file_path in &file_list {
             let lang = lang_override
                 .unwrap_or_else(|| detect_language(file_path));
 
@@ -114,11 +117,12 @@ pub fn run_set(args: SetArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     match &ctx.input {
         InputMode::Files(files) => {
-            let (_, matches) = query_files_batched(&ctx, files, xpath_expr, true)?;
+            let files = apply_changed_to_files(files.clone(), changed_spec.as_deref());
+            let (_, matches) = query_files_batched(&ctx, &files, xpath_expr, true)?;
 
             if stdout {
                 // Stdout mode: compute modified content per file without writing to disk.
-                let file_outputs = compute_set_output(files, &matches, value)?;
+                let file_outputs = compute_set_output(&files, &matches, value)?;
                 let output_map: HashMap<String, String> = file_outputs.into_iter().collect();
                 let report = build_set_report_matches(&matches, value, &ctx);
                 let report = report.with_groups().with_file_outputs(&output_map);
@@ -129,7 +133,7 @@ pub fn run_set(args: SetArgs) -> Result<(), Box<dyn std::error::Error>> {
                 let lang_override = ctx.lang.as_deref();
                 let mut fallback_files: Vec<String> = Vec::new();
 
-                for file_path in files {
+                for file_path in &files {
                     let lang = lang_override
                         .unwrap_or_else(|| detect_language(file_path));
                     let source = std::fs::read_to_string(file_path)?;
@@ -245,4 +249,21 @@ fn build_set_inline_report(modified: String, ctx: &RunContext) -> Report {
     let mut report = Report::set(vec![], summary);
     report.groups = Some(vec![group]);
     report
+}
+
+/// Apply --changed filter to a file list (set mode bypasses the executor).
+fn apply_changed_to_files(files: Vec<String>, spec: Option<&str>) -> Vec<String> {
+    match spec {
+        Some(spec) => {
+            let cwd = std::path::Path::new(".");
+            match git::git_changed_files(spec, cwd) {
+                Ok(changed) => git::intersect_changed(files, &changed),
+                Err(e) => {
+                    eprintln!("warning: --changed filter failed: {}", e);
+                    files
+                }
+            }
+        }
+        None => files,
+    }
 }

--- a/tractor/src/modes/test.rs
+++ b/tractor/src/modes/test.rs
@@ -31,6 +31,7 @@ pub fn run_test(args: TestArgs) -> Result<(), Box<dyn std::error::Error>> {
         InputMode::Files(files) => Operation::Test(TestOperation {
             files: files.clone(),
             exclude: vec![],
+            changed: None,
             assertions: vec![TestAssertion {
                 xpath: xpath_expr.to_string(),
                 expect: expect.clone(),
@@ -46,6 +47,7 @@ pub fn run_test(args: TestArgs) -> Result<(), Box<dyn std::error::Error>> {
         InputMode::InlineSource { source, lang } => Operation::Test(TestOperation {
             files: vec![],
             exclude: vec![],
+            changed: None,
             assertions: vec![TestAssertion {
                 xpath: xpath_expr.to_string(),
                 expect: expect.clone(),
@@ -62,6 +64,7 @@ pub fn run_test(args: TestArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     let options = ExecuteOptions {
         verbose: ctx.verbose,
+        changed: args.shared.changed.clone(),
         ..Default::default()
     };
 

--- a/tractor/src/modes/update.rs
+++ b/tractor/src/modes/update.rs
@@ -21,6 +21,7 @@ pub fn run_update(args: UpdateArgs) -> Result<(), Box<dyn std::error::Error>> {
     let op = Operation::Update(UpdateOperation {
         files: files.clone(),
         exclude: vec![],
+        changed: None,
         xpath: xpath_expr.clone(),
         value: args.value.clone(),
         tree_mode: ctx.tree_mode,
@@ -32,6 +33,7 @@ pub fn run_update(args: UpdateArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     let options = ExecuteOptions {
         verbose: ctx.verbose,
+        changed: args.shared.changed.clone(),
         ..Default::default()
     };
 

--- a/tractor/src/pipeline/git.rs
+++ b/tractor/src/pipeline/git.rs
@@ -1,0 +1,156 @@
+//! Git integration for filtering files by change status.
+//!
+//! Resolves changed files by invoking `git diff --name-only` with a
+//! user-provided diff specification (e.g. `HEAD~3`, `main..HEAD`).
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Run `git diff --name-only` with the given spec and return the set of
+/// changed file paths, resolved relative to `cwd`.
+///
+/// The spec is split on whitespace and passed as separate arguments to git,
+/// so `"main..HEAD"` becomes `["main..HEAD"]` and `"HEAD -- src/"` becomes
+/// `["HEAD", "--", "src/"]`.
+///
+/// Deleted files are excluded via `--diff-filter=ACMR` (Added, Copied,
+/// Modified, Renamed).
+pub fn git_changed_files(
+    spec: &str,
+    cwd: &Path,
+) -> Result<HashSet<PathBuf>, Box<dyn std::error::Error>> {
+    let args: Vec<&str> = spec.split_whitespace().collect();
+
+    let output = Command::new("git")
+        .arg("diff")
+        .arg("--name-only")
+        .arg("--diff-filter=ACMR")
+        .args(&args)
+        .current_dir(cwd)
+        .output()
+        .map_err(|e| format!("failed to run git: {} (is git installed?)", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "git diff --name-only --diff-filter=ACMR {} failed:\n{}",
+            spec,
+            stderr.trim()
+        )
+        .into());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let files: HashSet<PathBuf> = stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| cwd.join(l))
+        .collect();
+
+    Ok(files)
+}
+
+/// Filter a list of file paths to only those present in the `changed` set.
+/// Paths are canonicalized for reliable comparison.
+pub fn intersect_changed(
+    files: Vec<String>,
+    changed: &HashSet<PathBuf>,
+) -> Vec<String> {
+    // Pre-canonicalize the changed set for comparison.
+    let canonical_changed: HashSet<PathBuf> = changed
+        .iter()
+        .filter_map(|p| std::fs::canonicalize(p).ok())
+        .collect();
+
+    files
+        .into_iter()
+        .filter(|f| {
+            if let Ok(canonical) = std::fs::canonicalize(f) {
+                canonical_changed.contains(&canonical)
+            } else {
+                false
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intersect_changed_filters_to_matching_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.rs");
+        let b = dir.path().join("b.rs");
+        let c = dir.path().join("c.rs");
+        std::fs::write(&a, "").unwrap();
+        std::fs::write(&b, "").unwrap();
+        std::fs::write(&c, "").unwrap();
+
+        let files = vec![
+            a.to_str().unwrap().to_string(),
+            b.to_str().unwrap().to_string(),
+            c.to_str().unwrap().to_string(),
+        ];
+
+        // Only a.rs and c.rs are "changed"
+        let mut changed = HashSet::new();
+        changed.insert(a.clone());
+        changed.insert(c.clone());
+
+        let result = intersect_changed(files, &changed);
+        assert_eq!(result.len(), 2);
+        assert!(result.contains(&a.to_str().unwrap().to_string()));
+        assert!(result.contains(&c.to_str().unwrap().to_string()));
+    }
+
+    #[test]
+    fn intersect_changed_empty_changed_set_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.rs");
+        std::fs::write(&a, "").unwrap();
+
+        let files = vec![a.to_str().unwrap().to_string()];
+        let changed = HashSet::new();
+
+        let result = intersect_changed(files, &changed);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn intersect_changed_preserves_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.rs");
+        let b = dir.path().join("b.rs");
+        let c = dir.path().join("c.rs");
+        std::fs::write(&a, "").unwrap();
+        std::fs::write(&b, "").unwrap();
+        std::fs::write(&c, "").unwrap();
+
+        let files = vec![
+            c.to_str().unwrap().to_string(),
+            a.to_str().unwrap().to_string(),
+            b.to_str().unwrap().to_string(),
+        ];
+
+        let mut changed = HashSet::new();
+        changed.insert(a.clone());
+        changed.insert(b.clone());
+        changed.insert(c.clone());
+
+        let result = intersect_changed(files.clone(), &changed);
+        assert_eq!(result, files);
+    }
+
+    #[test]
+    fn git_changed_files_in_repo() {
+        // This test runs in the tractor repo itself.
+        // It verifies that git_changed_files returns successfully for a valid spec.
+        let cwd = Path::new(".");
+        let result = git_changed_files("HEAD~1 HEAD", cwd);
+        // Should succeed (we're in a git repo)
+        assert!(result.is_ok(), "git_changed_files should succeed: {:?}", result.err());
+    }
+}

--- a/tractor/src/pipeline/mod.rs
+++ b/tractor/src/pipeline/mod.rs
@@ -2,6 +2,7 @@ pub mod input;
 pub mod context;
 pub mod matcher;
 pub mod format;
+pub mod git;
 
 pub use input::InputMode;
 pub use context::RunContext;

--- a/tractor/src/tractor_config.rs
+++ b/tractor/src/tractor_config.rs
@@ -44,6 +44,20 @@ use crate::executor::{
 
 #[derive(Deserialize, Debug)]
 struct ConfigFile {
+    /// Root-level file scope: glob patterns that constrain all operations.
+    /// Intersected with each operation's own `files`.
+    #[serde(default)]
+    files: Vec<String>,
+
+    /// Root-level exclude patterns applied to all operations.
+    #[serde(default)]
+    exclude: Vec<String>,
+
+    /// Root-level git diff spec: only consider files changed in this diff.
+    /// Intersected with every operation's resolved file set.
+    #[serde(default)]
+    changed: Option<String>,
+
     /// Root-level check shorthand (single check operation).
     #[serde(default)]
     check: Option<CheckConfig>,
@@ -94,6 +108,8 @@ struct CheckConfig {
     #[serde(default)]
     exclude: Vec<String>,
     #[serde(default)]
+    changed: Option<String>,
+    #[serde(default)]
     rules: Vec<CheckRuleConfig>,
     #[serde(default)]
     tree_mode: Option<String>,
@@ -123,6 +139,8 @@ struct SetConfig {
     files: Vec<String>,
     #[serde(default)]
     exclude: Vec<String>,
+    #[serde(default)]
+    changed: Option<String>,
     mappings: Vec<SetMappingConfig>,
     #[serde(default)]
     tree_mode: Option<String>,
@@ -142,6 +160,8 @@ struct QueryConfig {
     files: Vec<String>,
     #[serde(default)]
     exclude: Vec<String>,
+    #[serde(default)]
+    changed: Option<String>,
     #[serde(default)]
     queries: Vec<QueryExprConfig>,
     #[serde(default)]
@@ -163,6 +183,8 @@ struct TestConfig {
     files: Vec<String>,
     #[serde(default)]
     exclude: Vec<String>,
+    #[serde(default)]
+    changed: Option<String>,
     #[serde(default)]
     assertions: Vec<TestAssertionConfig>,
     #[serde(default)]
@@ -212,7 +234,15 @@ fn parse_tree_mode(s: &str) -> Result<TreeMode, String> {
     }
 }
 
-fn convert_check(config: CheckConfig) -> Result<Operation, Box<dyn std::error::Error>> {
+/// Root-level scope fields that constrain all operations.
+#[derive(Debug, Clone, Default)]
+struct RootScope {
+    files: Vec<String>,
+    exclude: Vec<String>,
+    changed: Option<String>,
+}
+
+fn convert_check(config: CheckConfig, scope: &RootScope) -> Result<Operation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let rules: Vec<Rule> = config.rules.into_iter().map(|r| {
@@ -233,9 +263,12 @@ fn convert_check(config: CheckConfig) -> Result<Operation, Box<dyn std::error::E
         Ok::<Rule, Box<dyn std::error::Error>>(rule)
     }).collect::<Result<_, _>>()?;
 
+    let (files, exclude, changed) = merge_scope(scope, config.files, config.exclude, config.changed);
+
     Ok(Operation::Check(CheckOperation {
-        files: config.files,
-        exclude: config.exclude,
+        files,
+        exclude,
+        changed,
         rules,
         tree_mode,
         language: config.language,
@@ -246,7 +279,7 @@ fn convert_check(config: CheckConfig) -> Result<Operation, Box<dyn std::error::E
     }))
 }
 
-fn convert_set(config: SetConfig) -> Result<Operation, Box<dyn std::error::Error>> {
+fn convert_set(config: SetConfig, scope: &RootScope) -> Result<Operation, Box<dyn std::error::Error>> {
     // Validate tree_mode if provided (even though set doesn't use it yet)
     if let Some(ref tm) = config.tree_mode {
         parse_tree_mode(tm)?;
@@ -259,25 +292,31 @@ fn convert_set(config: SetConfig) -> Result<Operation, Box<dyn std::error::Error
         }
     }).collect();
 
+    let (files, exclude, changed) = merge_scope(scope, config.files, config.exclude, config.changed);
+
     Ok(Operation::Set(SetOperation {
-        files: config.files,
-        exclude: config.exclude,
+        files,
+        exclude,
+        changed,
         mappings,
         language: config.language,
         verify: false,
     }))
 }
 
-fn convert_query(config: QueryConfig) -> Result<Operation, Box<dyn std::error::Error>> {
+fn convert_query(config: QueryConfig, scope: &RootScope) -> Result<Operation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let queries = config.queries.into_iter().map(|q| {
         QueryExpr { xpath: q.xpath }
     }).collect();
 
+    let (files, exclude, changed) = merge_scope(scope, config.files, config.exclude, config.changed);
+
     Ok(Operation::Query(QueryOperation {
-        files: config.files,
-        exclude: config.exclude,
+        files,
+        exclude,
+        changed,
         queries,
         tree_mode,
         language: config.language,
@@ -289,7 +328,7 @@ fn convert_query(config: QueryConfig) -> Result<Operation, Box<dyn std::error::E
     }))
 }
 
-fn convert_test(config: TestConfig) -> Result<Operation, Box<dyn std::error::Error>> {
+fn convert_test(config: TestConfig, scope: &RootScope) -> Result<Operation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let assertions = config.assertions.into_iter().map(|a| {
@@ -299,9 +338,12 @@ fn convert_test(config: TestConfig) -> Result<Operation, Box<dyn std::error::Err
         }
     }).collect();
 
+    let (files, exclude, changed) = merge_scope(scope, config.files, config.exclude, config.changed);
+
     Ok(Operation::Test(TestOperation {
-        files: config.files,
-        exclude: config.exclude,
+        files,
+        exclude,
+        changed,
         assertions,
         tree_mode,
         language: config.language,
@@ -313,36 +355,69 @@ fn convert_test(config: TestConfig) -> Result<Operation, Box<dyn std::error::Err
     }))
 }
 
+/// Merge root-level scope with per-operation scope.
+///
+/// - `files`: operation files take precedence; root files are the fallback
+///   when an operation doesn't specify its own.
+/// - `exclude`: union of root and operation excludes (both narrow the scope).
+/// - `changed`: operation changed takes precedence; root changed is the
+///   fallback. CLI `--changed` is applied separately via `ExecuteOptions`.
+fn merge_scope(
+    scope: &RootScope,
+    op_files: Vec<String>,
+    op_exclude: Vec<String>,
+    op_changed: Option<String>,
+) -> (Vec<String>, Vec<String>, Option<String>) {
+    let files = if op_files.is_empty() {
+        scope.files.clone()
+    } else {
+        op_files
+    };
+
+    let mut exclude = scope.exclude.clone();
+    exclude.extend(op_exclude);
+
+    let changed = op_changed.or_else(|| scope.changed.clone());
+
+    (files, exclude, changed)
+}
+
 fn config_to_operations(config: ConfigFile) -> Result<Vec<Operation>, Box<dyn std::error::Error>> {
+    let scope = RootScope {
+        files: config.files,
+        exclude: config.exclude,
+        changed: config.changed,
+    };
+
     let mut ops = Vec::new();
 
     // Root-level shorthand keys first
     if let Some(check) = config.check {
-        ops.push(convert_check(check)?);
+        ops.push(convert_check(check, &scope)?);
     }
     if let Some(set) = config.set {
-        ops.push(convert_set(set)?);
+        ops.push(convert_set(set, &scope)?);
     }
     if let Some(query) = config.query {
-        ops.push(convert_query(query)?);
+        ops.push(convert_query(query, &scope)?);
     }
     if let Some(test) = config.test {
-        ops.push(convert_test(test)?);
+        ops.push(convert_test(test, &scope)?);
     }
 
     // Then explicit operations list
     for entry in config.operations {
         if let Some(c) = entry.check {
-            ops.push(convert_check(c)?);
+            ops.push(convert_check(c, &scope)?);
         }
         if let Some(s) = entry.set {
-            ops.push(convert_set(s)?);
+            ops.push(convert_set(s, &scope)?);
         }
         if let Some(q) = entry.query {
-            ops.push(convert_query(q)?);
+            ops.push(convert_query(q, &scope)?);
         }
         if let Some(t) = entry.test {
-            ops.push(convert_test(t)?);
+            ops.push(convert_test(t, &scope)?);
         }
     }
 
@@ -675,6 +750,136 @@ value = "localhost"
                 assert_eq!(s.mappings[0].value, "localhost");
             }
             _ => panic!("expected Set operation"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Root-level scope tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn root_files_inherited_when_operation_has_none() {
+        let yaml = r#"
+files: ["src/**/*.rs"]
+check:
+  rules:
+    - id: no-todo
+      xpath: "//comment"
+"#;
+        let ops = parse_config_yaml(yaml).unwrap();
+        if let Operation::Check(c) = &ops[0] {
+            assert_eq!(c.files, vec!["src/**/*.rs"]);
+        } else {
+            panic!("expected Check");
+        }
+    }
+
+    #[test]
+    fn root_files_overridden_by_operation_files() {
+        let yaml = r#"
+files: ["src/**/*.rs"]
+check:
+  files: ["test/**/*.rs"]
+  rules:
+    - id: no-todo
+      xpath: "//comment"
+"#;
+        let ops = parse_config_yaml(yaml).unwrap();
+        if let Operation::Check(c) = &ops[0] {
+            assert_eq!(c.files, vec!["test/**/*.rs"]);
+        } else {
+            panic!("expected Check");
+        }
+    }
+
+    #[test]
+    fn root_exclude_merged_with_operation_exclude() {
+        let yaml = r#"
+exclude: ["target/**"]
+check:
+  files: ["src/**/*.rs"]
+  exclude: ["src/generated/**"]
+  rules:
+    - id: no-todo
+      xpath: "//comment"
+"#;
+        let ops = parse_config_yaml(yaml).unwrap();
+        if let Operation::Check(c) = &ops[0] {
+            assert_eq!(c.exclude, vec!["target/**", "src/generated/**"]);
+        } else {
+            panic!("expected Check");
+        }
+    }
+
+    #[test]
+    fn root_changed_inherited_by_operations() {
+        let yaml = r#"
+changed: "main..HEAD"
+check:
+  files: ["src/**/*.rs"]
+  rules:
+    - id: no-todo
+      xpath: "//comment"
+"#;
+        let ops = parse_config_yaml(yaml).unwrap();
+        if let Operation::Check(c) = &ops[0] {
+            assert_eq!(c.changed.as_deref(), Some("main..HEAD"));
+        } else {
+            panic!("expected Check");
+        }
+    }
+
+    #[test]
+    fn operation_changed_overrides_root_changed() {
+        let yaml = r#"
+changed: "main..HEAD"
+check:
+  files: ["src/**/*.rs"]
+  changed: "HEAD~3"
+  rules:
+    - id: no-todo
+      xpath: "//comment"
+"#;
+        let ops = parse_config_yaml(yaml).unwrap();
+        if let Operation::Check(c) = &ops[0] {
+            assert_eq!(c.changed.as_deref(), Some("HEAD~3"));
+        } else {
+            panic!("expected Check");
+        }
+    }
+
+    #[test]
+    fn root_scope_applies_to_operations_list() {
+        let yaml = r#"
+files: ["src/**/*.rs"]
+exclude: ["vendor/**"]
+changed: "main..HEAD"
+operations:
+  - check:
+      rules:
+        - id: rule-a
+          xpath: "//a"
+  - query:
+      queries:
+        - xpath: "//b"
+"#;
+        let ops = parse_config_yaml(yaml).unwrap();
+        assert_eq!(ops.len(), 2);
+
+        if let Operation::Check(c) = &ops[0] {
+            assert_eq!(c.files, vec!["src/**/*.rs"]);
+            assert_eq!(c.exclude, vec!["vendor/**"]);
+            assert_eq!(c.changed.as_deref(), Some("main..HEAD"));
+        } else {
+            panic!("expected Check");
+        }
+
+        if let Operation::Query(q) = &ops[1] {
+            assert_eq!(q.files, vec!["src/**/*.rs"]);
+            assert_eq!(q.exclude, vec!["vendor/**"]);
+            assert_eq!(q.changed.as_deref(), Some("main..HEAD"));
+        } else {
+            panic!("expected Query");
         }
     }
 }


### PR DESCRIPTION
Add a `--changed` CLI parameter and config field that restricts tractor's
file scope to only files changed in a git diff. The value accepts any git
diff specification (e.g. "HEAD~3", "main..HEAD", "HEAD").

Implementation:
- New `pipeline/git.rs` module that shells out to `git diff --name-only`
- `--changed` on SharedArgs (available on all commands)
- `changed` field on all operation structs for per-operation filtering
- Root-level `files`, `exclude`, `changed` in config files that scope
  all operations (exclude merges, files/changed inherit as fallback)
- Both global (CLI) and per-operation changed specs apply in sequence,
  each narrowing the file set via intersection

https://claude.ai/code/session_013pgjXrFTy1L85xQeqCaDm2