### PR TITLE
Add +field/-field relative view modifiers to -v flag

### DIFF
--- a/tests/integration/test.sh
+++ b/tests/integration/test.sh
@@ -18,7 +18,7 @@ for suite in rust python typescript javascript go java csharp ruby xml yaml mark
 done
 
 # Feature tests
-for suite in string-input replace update xpath-expressions; do
+for suite in string-input replace update xpath-expressions view-modifiers; do
     bash "tests/integration/$suite/test.sh" || exit 1
     echo ""
 done

--- a/tests/integration/view-modifiers/test.sh
+++ b/tests/integration/view-modifiers/test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Integration tests for additive/subtractive view field modifiers (-v +field, -v -field)
+source "$(dirname "$0")/../common.sh"
+
+SAMPLE_CS="$REPO_ROOT/tests/integration/formats/sample.cs"
+
+echo "View modifiers (+field / -field):"
+
+# ---------------------------------------------------------------------------
+# -field: remove a field from the default view
+# ---------------------------------------------------------------------------
+
+# check -f gcc default includes lines; -lines should drop the source block
+run_test bash -c "
+  actual=\$(tractor check '$SAMPLE_CS' -x '//class' --reason 'class found' --no-color -f gcc '-v=-lines' 2>/dev/null)
+  # With lines removed, each match should produce exactly one line (the header).
+  # Count output lines (2 classes → 2 header lines, plus empty summary line from stderr)
+  lines=\$(echo \"\$actual\" | grep -c ':.*error:')
+  [ \"\$lines\" -eq 2 ]
+" -m "check -f gcc -v=-lines removes source line blocks"
+
+# Ensure the source-block content is absent (no gutter lines like "1 >| ...")
+run_test bash -c "
+  actual=\$(tractor check '$SAMPLE_CS' -x '//class' --reason 'class found' --no-color -f gcc '-v=-lines' 2>/dev/null || true)
+  ! echo \"\$actual\" | grep -qE '^[[:space:]]*[0-9]+ [>|]'
+" -m "check -f gcc -v=-lines produces no line-number gutter output"
+
+# Removing severity from check default still produces output
+run_test bash -c "
+  actual=\$(tractor check '$SAMPLE_CS' -x '//class' --reason 'class found' --no-color '-v=-severity' 2>/dev/null || true)
+  echo \"\$actual\" | grep -q 'class found'
+" -m "check -v=-severity keeps other fields intact"
+
+# Remove tree from query default: output should have no XML tags
+run_test bash -c "
+  actual=\$(tractor '$SAMPLE_CS' -x '//class/name' --no-color '-v=-tree' 2>/dev/null)
+  ! echo \"\$actual\" | grep -q '<'
+" -m "query -v=-tree removes XML tree from output"
+
+# ---------------------------------------------------------------------------
+# +field: add a field to the default view
+# ---------------------------------------------------------------------------
+
+# Adding source to query default (default: file,line,tree) should produce source text lines
+run_test bash -c "
+  actual=\$(tractor '$SAMPLE_CS' -x '//class/name' --no-color '-v=+source' 2>/dev/null)
+  echo \"\$actual\" | grep -qE '^(Foo|Qux)$'
+" -m "query -v=+source adds source text to output"
+
+# ---------------------------------------------------------------------------
+# Combining + and - modifiers
+# ---------------------------------------------------------------------------
+
+# Remove lines and add source in one -v expression (text format check)
+run_test bash -c "
+  actual=\$(tractor check '$SAMPLE_CS' -x '//class/name' --reason 'found' --no-color -f text '-v=-lines,+source' 2>/dev/null)
+  # Should have source text (class names) in text format output
+  echo \"\$actual\" | grep -qE '(Foo|Qux)'
+" -m "check -f text -v=-lines,+source adds source but drops lines"
+
+# ---------------------------------------------------------------------------
+# No-op and idempotency
+# ---------------------------------------------------------------------------
+
+# Adding a field that is already in the default is a no-op (tree is in default)
+run_test bash -c "
+  default_out=\$(tractor '$SAMPLE_CS' -x '//class/name' --no-color 2>/dev/null)
+  modifier_out=\$(tractor '$SAMPLE_CS' -x '//class/name' --no-color '-v=+tree' 2>/dev/null)
+  [ \"\$default_out\" = \"\$modifier_out\" ]
+" -m "query -v=+field already in default is a no-op"
+
+# Removing a field that is not in the default is a no-op
+run_test bash -c "
+  default_out=\$(tractor '$SAMPLE_CS' -x '//class/name' --no-color -v value 2>/dev/null)
+  modifier_out=\$(tractor '$SAMPLE_CS' -x '//class/name' --no-color '-v=-source' 2>/dev/null)
+  # Both should list class names (source was not in default anyway)
+  echo \"\$modifier_out\" | grep -q 'Foo'
+" -m "query -v=-field not in default is a no-op"
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+# Mixing plain and modifier fields should fail with an error message
+run_test bash -c "
+  ! tractor '$SAMPLE_CS' -x '//class' '-v=tree,+source' 2>/dev/null
+" -m "mixing plain fields with +/- modifiers fails"
+
+# Removing all fields should fail
+run_test bash -c "
+  ! tractor '$SAMPLE_CS' -x '//class/name' '-v=-file,-line,-tree' 2>/dev/null
+" -m "removing all default fields produces an error"
+
+# Invalid field name in modifier position should fail
+run_test bash -c "
+  ! tractor '$SAMPLE_CS' -x '//class' '-v=-nosuchfield' 2>/dev/null
+" -m "invalid field name in -field modifier produces an error"
+
+report

--- a/tractor/src/pipeline/context.rs
+++ b/tractor/src/pipeline/context.rs
@@ -50,7 +50,7 @@ impl RunContext {
         let output_format = OutputFormat::from_str(format)?;
 
         let view = if let Some(s) = user_view {
-            parse_view_set(s)?
+            parse_view_set(s, default_view)?
         } else {
             ViewSet::from_fields(default_view.to_vec())
         };

--- a/tractor/src/pipeline/format/options.rs
+++ b/tractor/src/pipeline/format/options.rs
@@ -149,22 +149,68 @@ impl ViewSet {
 }
 
 /// Parse a comma-separated view expression into a `ViewSet`, preserving order.
-/// Duplicate fields are silently ignored.
-pub fn parse_view_set(s: &str) -> Result<ViewSet, String> {
-    let mut fields = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    for part in s.split(',') {
-        let part = part.trim().to_lowercase();
-        if part.is_empty() { continue; }
-        let field = ViewField::from_str(&part)?;
-        if seen.insert(field) {
-            fields.push(field);
-        }
-    }
-    if fields.is_empty() {
+///
+/// If every non-empty token starts with `+` or `-`, the expression is treated
+/// as a modifier list applied to `default_fields`:
+/// - `+field` — add `field` if not already present
+/// - `-field` — remove `field` if present
+///
+/// Otherwise the expression is treated as an explicit full field list and
+/// `default_fields` is ignored. Duplicate fields are silently ignored.
+///
+/// Mixing plain field names with `+`/`-` prefixed modifiers is an error.
+pub fn parse_view_set(s: &str, default_fields: &[ViewField]) -> Result<ViewSet, String> {
+    let tokens: Vec<&str> = s.split(',')
+        .map(|p| p.trim())
+        .filter(|p| !p.is_empty())
+        .collect();
+
+    if tokens.is_empty() {
         return Err("view cannot be empty".to_string());
     }
-    Ok(ViewSet::new(fields))
+
+    let has_modifier = tokens.iter().any(|p| p.starts_with('+') || p.starts_with('-'));
+    let has_plain = tokens.iter().any(|p| !p.starts_with('+') && !p.starts_with('-'));
+
+    if has_modifier && has_plain {
+        return Err(
+            "cannot mix plain field names with +/- modifiers in -v. \
+             Use either an explicit list (e.g. -v file,line,reason) \
+             or only modifiers (e.g. -v -lines,+source)."
+                .to_string(),
+        );
+    }
+
+    if has_modifier {
+        // Modifier mode: start from the defaults and apply each +/- token.
+        let mut fields: Vec<ViewField> = default_fields.to_vec();
+        for token in &tokens {
+            if let Some(field_str) = token.strip_prefix('+') {
+                let field = ViewField::from_str(&field_str.to_lowercase())?;
+                if !fields.contains(&field) {
+                    fields.push(field);
+                }
+            } else if let Some(field_str) = token.strip_prefix('-') {
+                let field = ViewField::from_str(&field_str.to_lowercase())?;
+                fields.retain(|f| *f != field);
+            }
+        }
+        if fields.is_empty() {
+            return Err("view cannot be empty after applying modifiers".to_string());
+        }
+        Ok(ViewSet::new(fields))
+    } else {
+        // Explicit list mode: ignore defaults, parse the fields directly.
+        let mut fields = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for token in &tokens {
+            let field = ViewField::from_str(&token.to_lowercase())?;
+            if seen.insert(field) {
+                fields.push(field);
+            }
+        }
+        Ok(ViewSet::new(fields))
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extends `parse_view_set` to support `+field`/`-field` modifier syntax, allowing users to add or remove fields relative to the mode's default view (e.g. `-v -lines,+source`)
- Explicit field lists (e.g. `-v file,line,reason`) continue to work as before
- Mixing plain and modifier tokens is rejected with a clear error message

## Examples

```bash
# Remove source lines from gcc check output
tractor check file.cs -x '//class' -f gcc -v=-lines

# Add source text to query output
tractor file.cs -x '//class/name' -v=+source

# Combine modifiers
tractor check file.cs -x '//class' -f text -v=-lines,+source
```

## Test plan

- [x] 11 integration tests covering add, remove, combine, no-op, and error cases
- [x] All existing integration tests still pass

https://claude.ai/code/session_0128NdrYX23D3khncsvpeJcD