### PR TITLE
Add documentation for set operations in run command

### DIFF
--- a/web/src/pages/docs/RunCommand.tsx
+++ b/web/src/pages/docs/RunCommand.tsx
@@ -156,6 +156,48 @@ operations:
           message: "At least one class expected"`}
       />
 
+      <h2>Set Operations</h2>
+      <p>
+        Use <code>set</code> to apply multiple value changes in a config file. Each mapping specifies an XPath expression and the value to set. This is the batch equivalent of the <Link to="/docs/commands/set">set command</Link>:
+      </p>
+      <CodeBlock
+        language="yaml"
+        title=".tractor.yml"
+        code={`set:
+  files: ["app-config.json"]
+  mappings:
+    - xpath: "//database/host"
+      value: "db.prod.internal"
+    - xpath: "//database/port"
+      value: "5432"
+    - xpath: "//cache/ttl"
+      value: "600"`}
+      />
+      <p>
+        All mappings apply to the matched files in a single operation. This is the recommended way to set multiple values at once — instead of running <code>tractor set</code> repeatedly for each value.
+      </p>
+      <p>
+        Set operations can also be mixed with other operation types using the <code>operations</code> list:
+      </p>
+      <CodeBlock
+        language="yaml"
+        title=".tractor.yml"
+        code={`operations:
+  - check:
+      files: ["settings.yaml"]
+      rules:
+        - id: no-debug
+          xpath: "//debug[.='true']"
+          reason: "debug should be disabled"
+  - set:
+      files: ["app-config.json"]
+      mappings:
+        - xpath: "//database/host"
+          value: "db.prod.internal"
+        - xpath: "//cache/ttl"
+          value: "600"`}
+      />
+
       <h2>Scope and File Resolution</h2>
       <p>
         File patterns can be set at the root level (shared) or per-operation. Nested file scopes are intersections — the operation scope narrows the root scope, it does not replace it.

--- a/web/src/pages/docs/SetCommand.tsx
+++ b/web/src/pages/docs/SetCommand.tsx
@@ -182,6 +182,28 @@ Set 2 values in 1 file`}
         <li><strong>CI/CD variable injection</strong> — replace placeholder values with environment-specific settings before deployment</li>
       </ul>
 
+      <h2>Multiple Mappings with tractor run</h2>
+      <p>
+        The <code>set</code> CLI command applies one XPath + value per invocation. To set multiple values at once, use <Link to="/docs/commands/run">tractor run</Link> with a config file:
+      </p>
+      <CodeBlock
+        language="yaml"
+        title=".tractor.yml"
+        code={`set:
+  files: ["config.json"]
+  mappings:
+    - xpath: "//database/host"
+      value: "db.prod.internal"
+    - xpath: "//database/port"
+      value: "5432"
+    - xpath: "//cache/ttl"
+      value: "600"`}
+      />
+      <CodeBlock language="bash" code={`tractor run .tractor.yml`} />
+      <p>
+        This applies all mappings to the matched files in a single operation. See the <Link to="/docs/commands/run">run command</Link> for more details on config files.
+      </p>
+
       <h2>Options Reference</h2>
       <table className="doc-table">
         <thead>


### PR DESCRIPTION
## Summary
Added comprehensive documentation for using the `set` operation within `tractor run` config files, including examples of both standalone and mixed operation usage.

## Key Changes
- **RunCommand.tsx**: Added new "Set Operations" section with:
  - Explanation of the `set` operation for batch value changes
  - Example showing multiple XPath mappings in a single operation
  - Example demonstrating how to mix `set` with other operations (e.g., `check`)
  - Clarification that this is the recommended approach over repeated CLI invocations

- **SetCommand.tsx**: Added new "Multiple Mappings with tractor run" section with:
  - Explanation of the limitation of the CLI command (one mapping per invocation)
  - Example config file showing multiple mappings
  - Cross-reference to the run command documentation
  - Guidance on using config files for batch operations

## Implementation Details
- Both sections use consistent code block formatting with YAML examples
- Added cross-references between documentation pages using the `Link` component
- Examples follow the same structure and style as existing documentation
- Clarifies the relationship between the `set` CLI command and the `set` operation in config files

https://claude.ai/code/session_01K7xHQRsq4mMyBhRFEW8N4H