### PR TITLE
Add CheatSheet page and update tree output format in docs

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import { SchemaGuide } from './pages/docs/SchemaGuide';
 import { LintRulesGuide } from './pages/docs/LintRulesGuide';
 import { CiCdGuide } from './pages/docs/CiCdGuide';
 import { UseCases } from './pages/docs/UseCases';
+import { CheatSheet } from './pages/docs/CheatSheet';
 
 export function App() {
   return (
@@ -34,6 +35,7 @@ export function App() {
         <Route path="/docs/languages/documents" element={<DocumentLanguages />} />
         <Route path="/docs/languages/data" element={<DataLanguages />} />
         <Route path="/docs/reference/cli" element={<CliReference />} />
+        <Route path="/docs/guides/cheat-sheet" element={<CheatSheet />} />
         <Route path="/docs/guides/query-syntax" element={<QuerySyntax />} />
         <Route path="/docs/guides/writing-queries" element={<WritingQueries />} />
         <Route path="/docs/guides/schema" element={<SchemaGuide />} />

--- a/web/src/components/DocLayout.tsx
+++ b/web/src/components/DocLayout.tsx
@@ -41,6 +41,7 @@ const SIDEBAR_SECTIONS: SidebarSection[] = [
   {
     title: 'Guides',
     items: [
+      { label: 'Cheat Sheet', path: '/docs/guides/cheat-sheet' },
       { label: 'Query Syntax', path: '/docs/guides/query-syntax' },
       { label: 'Writing Queries', path: '/docs/guides/writing-queries' },
       { label: 'Exploring with Schema', path: '/docs/guides/schema' },

--- a/web/src/pages/docs/CheatSheet.tsx
+++ b/web/src/pages/docs/CheatSheet.tsx
@@ -1,0 +1,193 @@
+import { Link } from 'react-router-dom';
+import { DocLayout } from '../../components/DocLayout';
+import { CodeBlock } from '../../components/CodeBlock';
+
+export function CheatSheet() {
+  return (
+    <DocLayout>
+      <h1>Cheat Sheet</h1>
+      <p className="doc-lead">
+        Quick reference for tractor's query syntax and CLI. The query language is <a href="https://www.w3.org/TR/xpath-31/" target="_blank" rel="noopener noreferrer">XPath 3.1</a> — any XPath resource applies.
+      </p>
+
+      <h2>Path Expressions</h2>
+      <table className="doc-table">
+        <thead>
+          <tr><th>Expression</th><th>Meaning</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>function</code></td><td>All <code>function</code> elements anywhere (implicit <code>//</code>)</td></tr>
+          <tr><td><code>function/name</code></td><td>Direct <code>name</code> child of every function</td></tr>
+          <tr><td><code>class//method</code></td><td>All methods anywhere inside a class</td></tr>
+          <tr><td><code>class/body/method</code></td><td>Methods that are direct children of class body</td></tr>
+          <tr><td><code>.</code></td><td>Current element (flattened text content)</td></tr>
+          <tr><td><code>.//method</code></td><td>Any method descendant of current element</td></tr>
+          <tr><td><code>parent::class</code></td><td>Parent class element</td></tr>
+          <tr><td><code>ancestor::class</code></td><td>Nearest class ancestor</td></tr>
+        </tbody>
+      </table>
+
+      <h2>Predicates</h2>
+      <table className="doc-table">
+        <thead>
+          <tr><th>Predicate</th><th>Meaning</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>[public]</code></td><td>Has a <code>public</code> child element</td></tr>
+          <tr><td><code>[not(static)]</code></td><td>Does not have a <code>static</code> child</td></tr>
+          <tr><td><code>[name='Foo']</code></td><td>Has name equal to "Foo"</td></tr>
+          <tr><td><code>[contains(name,'get')]</code></td><td>Name contains "get"</td></tr>
+          <tr><td><code>[contains(.,'orderBy')]</code></td><td>Full text contains "orderBy"</td></tr>
+          <tr><td><code>[starts-with(name,'test')]</code></td><td>Name starts with "test"</td></tr>
+          <tr><td><code>[matches(name,'^[a-z]')]</code></td><td>Name matches regex</td></tr>
+          <tr><td><code>[count(params/type) &gt; 3]</code></td><td>Has more than 3 parameters</td></tr>
+          <tr><td><code>[string-length(name) &gt; 20]</code></td><td>Name is longer than 20 characters</td></tr>
+          <tr><td><code>[position() = 1]</code></td><td>First match only</td></tr>
+        </tbody>
+      </table>
+
+      <h2>Combining Predicates</h2>
+      <table className="doc-table">
+        <thead>
+          <tr><th>Pattern</th><th>Meaning</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>[public][not(static)]</code></td><td>AND — both must be true</td></tr>
+          <tr><td><code>[public or static]</code></td><td>OR — either is true</td></tr>
+          <tr><td><code>[not(public or static)]</code></td><td>NOR — neither is true</td></tr>
+        </tbody>
+      </table>
+
+      <h2>Functions</h2>
+      <table className="doc-table">
+        <thead>
+          <tr><th>Function</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>contains(a, b)</code></td><td>String <code>a</code> contains <code>b</code></td></tr>
+          <tr><td><code>starts-with(a, b)</code></td><td>String <code>a</code> starts with <code>b</code></td></tr>
+          <tr><td><code>ends-with(a, b)</code></td><td>String <code>a</code> ends with <code>b</code></td></tr>
+          <tr><td><code>matches(a, regex)</code></td><td>String <code>a</code> matches regex</td></tr>
+          <tr><td><code>not(expr)</code></td><td>Negates a condition</td></tr>
+          <tr><td><code>count(nodes)</code></td><td>Count matching nodes</td></tr>
+          <tr><td><code>string-length(s)</code></td><td>Length of a string</td></tr>
+          <tr><td><code>concat(a, b, ...)</code></td><td>Concatenate strings</td></tr>
+          <tr><td><code>translate(s, from, to)</code></td><td>Character-by-character replacement</td></tr>
+          <tr><td><code>normalize-space(s)</code></td><td>Collapse whitespace</td></tr>
+          <tr><td><code>string(node)</code></td><td>Convert node to string</td></tr>
+        </tbody>
+      </table>
+
+      <h2>Axes</h2>
+      <table className="doc-table">
+        <thead>
+          <tr><th>Axis</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>child::</code></td><td>Direct children (default, same as <code>/</code>)</td></tr>
+          <tr><td><code>descendant::</code></td><td>All descendants (same as <code>//</code>)</td></tr>
+          <tr><td><code>parent::</code></td><td>Parent element</td></tr>
+          <tr><td><code>ancestor::</code></td><td>All ancestors up to root</td></tr>
+          <tr><td><code>following-sibling::</code></td><td>Siblings after this element</td></tr>
+          <tr><td><code>preceding-sibling::</code></td><td>Siblings before this element</td></tr>
+          <tr><td><code>self::</code></td><td>Current element (with type test)</td></tr>
+        </tbody>
+      </table>
+
+      <h2>Views (<code>-v</code>)</h2>
+      <table className="doc-table">
+        <thead>
+          <tr><th>View</th><th>Shows</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>tree</code></td><td>Tree structure (default)</td></tr>
+          <tr><td><code>value</code></td><td>Text content of matched nodes</td></tr>
+          <tr><td><code>source</code></td><td>Exact source code</td></tr>
+          <tr><td><code>lines</code></td><td>Full source lines with markers</td></tr>
+          <tr><td><code>count</code></td><td>Number of matches</td></tr>
+          <tr><td><code>schema</code></td><td>Structural overview of element types</td></tr>
+        </tbody>
+      </table>
+
+      <h2>Output Formats (<code>-f</code>)</h2>
+      <table className="doc-table">
+        <thead>
+          <tr><th>Format</th><th>Use case</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>text</code></td><td>Human-readable (default for query)</td></tr>
+          <tr><td><code>gcc</code></td><td><code>file:line:col</code> for editors and CI (default for check)</td></tr>
+          <tr><td><code>json</code></td><td>Machine-readable reports</td></tr>
+          <tr><td><code>yaml</code></td><td>Machine-readable reports</td></tr>
+          <tr><td><code>github</code></td><td>GitHub Actions annotations</td></tr>
+          <tr><td><code>claude-code</code></td><td>Claude Code hook format</td></tr>
+        </tbody>
+      </table>
+
+      <h2>Common Recipes</h2>
+      <CodeBlock language="bash" code={`# Explore the tree
+tractor file.js                          # see tree structure
+tractor file.js -v schema                # see element types
+tractor file.js -x "//function" -v schema  # zoom into functions
+
+# Extract
+tractor file.js -x "//function/name" -v value      # function names
+tractor file.js -x "//class" -v source              # full class source
+tractor file.js -x "//function" -v count            # count functions
+
+# Filter
+tractor file.js -x "//method[public][not(static)]/name" -v value
+tractor file.js -x "//method[contains(name,'get')]/name" -v value
+tractor file.js -x "//function[count(parameters//type) > 5]/name" -v value
+
+# Check (lint)
+tractor check "src/**/*.js" -x "//comment[contains(.,'TODO')]" \\
+    --reason "Resolve TODOs before merging"
+
+# Set (modify)
+tractor set config.json -x "//database/host" --value "localhost"
+
+# Multi-file
+tractor "src/**/*.js" -x "//function/name" -v value
+tractor "src/**/*.js" --diff-lines "main..HEAD" -x "//function" -v count`} />
+
+      <h2>Variables</h2>
+      <table className="doc-table">
+        <thead>
+          <tr><th>Variable</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>$file</code></td><td>Path of the current file being queried</td></tr>
+        </tbody>
+      </table>
+
+      <h2>Key CLI Flags</h2>
+      <table className="doc-table">
+        <thead>
+          <tr><th>Flag</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>-x</code></td><td>Query expression</td></tr>
+          <tr><td><code>-v</code></td><td>View mode (tree, value, source, lines, count, schema)</td></tr>
+          <tr><td><code>-f</code></td><td>Output format (text, gcc, json, yaml, github)</td></tr>
+          <tr><td><code>-d</code></td><td>Limit tree depth</td></tr>
+          <tr><td><code>-n</code></td><td>Limit number of matches</td></tr>
+          <tr><td><code>-W</code></td><td>Ignore whitespace in string matching</td></tr>
+          <tr><td><code>-t</code></td><td>Tree mode (structure, data, raw)</td></tr>
+          <tr><td><code>--meta</code></td><td>Include position and kind metadata</td></tr>
+          <tr><td><code>--diff-files</code></td><td>Only files changed in a git range</td></tr>
+          <tr><td><code>--diff-lines</code></td><td>Only matches in changed hunks</td></tr>
+        </tbody>
+      </table>
+
+      <h2>More Resources</h2>
+      <ul>
+        <li><Link to="/docs/guides/query-syntax">Query Syntax</Link> — full guide with examples and explanations</li>
+        <li><Link to="/docs/guides/writing-queries">Writing Queries</Link> — step-by-step tutorial</li>
+        <li><Link to="/docs/reference/cli">CLI Reference</Link> — every option with examples</li>
+        <li><a href="https://devhints.io/xpath" target="_blank" rel="noopener noreferrer">XPath Cheat Sheet</a> — quick reference for the underlying query language</li>
+        <li><a href="https://www.w3.org/TR/xpath-31/" target="_blank" rel="noopener noreferrer">XPath 3.1 Specification</a> — complete W3C spec</li>
+      </ul>
+    </DocLayout>
+  );
+}

--- a/web/src/pages/docs/CheatSheet.tsx
+++ b/web/src/pages/docs/CheatSheet.tsx
@@ -168,7 +168,7 @@ tractor "src/**/*.js" --diff-lines "main..HEAD" -x "//function" -v count`} />
           <tr><th>Flag</th><th>Description</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>-x</code></td><td>Query expression</td></tr>
+          <tr><td><code>-x</code></td><td>Query to match</td></tr>
           <tr><td><code>-v</code></td><td>View mode (tree, value, source, lines, count, schema)</td></tr>
           <tr><td><code>-f</code></td><td>Output format (text, gcc, json, yaml, github)</td></tr>
           <tr><td><code>-d</code></td><td>Limit tree depth</td></tr>

--- a/web/src/pages/docs/CheatSheet.tsx
+++ b/web/src/pages/docs/CheatSheet.tsx
@@ -52,7 +52,8 @@ export function CheatSheet() {
           <tr><th>Pattern</th><th>Meaning</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>[public][not(static)]</code></td><td>AND — both must be true</td></tr>
+          <tr><td><code>[public][not(static)]</code></td><td>AND — both must be true (chained)</td></tr>
+          <tr><td><code>[public and not(static)]</code></td><td>AND — both must be true (single predicate)</td></tr>
           <tr><td><code>[public or static]</code></td><td>OR — either is true</td></tr>
           <tr><td><code>[not(public or static)]</code></td><td>NOR — neither is true</td></tr>
         </tbody>

--- a/web/src/pages/docs/CheatSheet.tsx
+++ b/web/src/pages/docs/CheatSheet.tsx
@@ -79,6 +79,31 @@ export function CheatSheet() {
         </tbody>
       </table>
 
+      <h2>Maps &amp; Arrays</h2>
+      <p>
+        Build structured output with <a href="https://www.w3.org/TR/xpath-31/#id-maps-and-arrays" target="_blank" rel="noopener noreferrer">XPath 3.1 maps and arrays</a>. Useful with <code>-f json</code> or <code>-f yaml</code>.
+      </p>
+      <table className="doc-table">
+        <thead>
+          <tr><th>Syntax</th><th>Result</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>{'map { "k": "v" }'}</code></td><td>{'{ "k": "v" }'}</td></tr>
+          <tr><td><code>{'map { "name": string(name), "line": string(@line) }'}</code></td><td>Map with computed values</td></tr>
+          <tr><td><code>{'array { "a", "b", "c" }'}</code></td><td>{'["a", "b", "c"]'}</td></tr>
+          <tr><td><code>{'array { //function/name/string(.) }'}</code></td><td>Array from query results</td></tr>
+        </tbody>
+      </table>
+      <h3>Example: extract structured data</h3>
+      <CodeBlock language="bash" code={`# Build a JSON array of objects from code
+tractor file.cs -f json -x '//class ! map {
+  "name": string(name),
+  "methods": array { body/method/name/string(.) }
+}'`} />
+      <p>
+        When a map value produces multiple items, tractor automatically wraps them in an array.
+      </p>
+
       <h2>Axes</h2>
       <table className="doc-table">
         <thead>

--- a/web/src/pages/docs/CheckCommand.tsx
+++ b/web/src/pages/docs/CheckCommand.tsx
@@ -16,7 +16,7 @@ export function CheckCommand() {
       </p>
 
       <h2>Usage</h2>
-      <CodeBlock code={`tractor check [FILES] -x <XPATH> --reason <REASON> [OPTIONS]`} language="bash" />
+      <CodeBlock code={`tractor check [FILES] -x <EXPRESSION> --reason <REASON> [OPTIONS]`} language="bash" />
 
       <h2>Basic Check</h2>
       <p>
@@ -185,7 +185,7 @@ echo 'class Foo { void Bar() { } }' | \\
           <tr><th>Option</th><th>Description</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>-x, --extract</code></td><td>XPath expression — each match is a violation</td></tr>
+          <tr><td><code>-x, --extract</code></td><td>Expression — each match is a violation</td></tr>
           <tr><td><code>-s, --string</code></td><td>Inline source code (alternative to file/stdin)</td></tr>
           <tr><td><code>-l, --lang</code></td><td>Language for stdin/string input</td></tr>
           <tr><td><code>--reason</code></td><td>Reason message for each violation</td></tr>

--- a/web/src/pages/docs/CheckCommand.tsx
+++ b/web/src/pages/docs/CheckCommand.tsx
@@ -16,7 +16,7 @@ export function CheckCommand() {
       </p>
 
       <h2>Usage</h2>
-      <CodeBlock code={`tractor check [FILES] -x <EXPRESSION> --reason <REASON> [OPTIONS]`} language="bash" />
+      <CodeBlock code={`tractor check [FILES] -x <QUERY> --reason <REASON> [OPTIONS]`} language="bash" />
 
       <h2>Basic Check</h2>
       <p>
@@ -185,7 +185,7 @@ echo 'class Foo { void Bar() { } }' | \\
           <tr><th>Option</th><th>Description</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>-x, --extract</code></td><td>Expression — each match is a violation</td></tr>
+          <tr><td><code>-x, --extract</code></td><td><Link to="/docs/guides/query-syntax">Query</Link> — each match is a violation</td></tr>
           <tr><td><code>-s, --string</code></td><td>Inline source code (alternative to file/stdin)</td></tr>
           <tr><td><code>-l, --lang</code></td><td>Language for stdin/string input</td></tr>
           <tr><td><code>--reason</code></td><td>Reason message for each violation</td></tr>

--- a/web/src/pages/docs/CliReference.tsx
+++ b/web/src/pages/docs/CliReference.tsx
@@ -40,7 +40,7 @@ tractor file1.js file2.js`} />
       <h2>Extract</h2>
 
       <h3>-x, --extract</h3>
-      <p>XPath expression to select matching AST nodes. Without this, the full tree is shown.</p>
+      <p>Expression to select matching nodes. Without this, the full tree is shown.</p>
       <Example
         file={{ name: 'greeter.js', language: 'js', content: GREETER_JS }}
         command={`tractor greeter.js -x "//function/name" -v value`}
@@ -65,44 +65,26 @@ tractor file1.js file2.js`} />
       <Example
         file={{ name: 'config.json', language: 'json', content: '{"host": "localhost", "port": 5432}' }}
         command={`tractor config.json -t structure`}
-        outputLanguage="xml"
         output={`config.json:1
-<Files>
-  <file>config.json</file>
-  <object>
-    <property>
-      <key>
-        <string>host</string>
-      </key>
-      <value>
-        <string>localhost</string>
-      </value>
-    </property>
-    <property>
-      <key>
-        <string>port</string>
-      </key>
-      <value>
-        <number>5432</number>
-      </value>
-    </property>
-  </object>
-</Files>`}
+object/
+  ├─ property/
+  │   ├─ key/string = "host"
+  │   └─ value/string = "localhost"
+  └─ property/
+      ├─ key/string = "port"
+      └─ value/number = "5432"`}
       />
       <p>Compare with the default <code>data</code> mode, where the same JSON becomes a clean data tree:</p>
       <Example
         command={`tractor config.json`}
-        outputLanguage="xml"
         output={`config.json:1
-<Files>
-  <file>config.json</file>
-  <host>localhost</host>
-  <port>5432</port>
-</Files>`}
+document/
+  ├─ host = "localhost"
+  └─ port = "5432"`}
       />
 
       <h3>-W, --ignore-whitespace</h3>
-      <p>Ignore whitespace when comparing strings in XPath. Useful when source code has varying formatting.</p>
+      <p>Ignore whitespace when comparing strings. Useful when source code has varying formatting.</p>
       <Example
         command={`echo 'function greet( name ) { return name; }' | tractor -l javascript -x "//params[.='(name)']" -v value -W`}
         output="(name)"
@@ -118,13 +100,13 @@ tractor file1.js file2.js`} />
           <tr><th>View</th><th>Description</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>tree</code></td><td>Full parsed XML (default)</td></tr>
+          <tr><td><code>tree</code></td><td>Query-oriented tree view (default)</td></tr>
           <tr><td><code>value</code></td><td>Text content of matched nodes</td></tr>
           <tr><td><code>source</code></td><td>Exact matched source code</td></tr>
           <tr><td><code>lines</code></td><td>Full source lines containing each match</td></tr>
           <tr><td><code>count</code></td><td>Total number of matches</td></tr>
           <tr><td><code>schema</code></td><td>Structural overview of element types</td></tr>
-          <tr><td><code>query</code></td><td>Echo the XPath query (useful for debugging shell escaping)</td></tr>
+          <tr><td><code>query</code></td><td>Echo the query (useful for debugging shell escaping)</td></tr>
         </tbody>
       </table>
       <Example
@@ -176,48 +158,36 @@ greeter.js:5:1: error: function found
       />
 
       <h3>-d, --depth</h3>
-      <p>Limit XML output depth. Deeper elements are collapsed into comments. Default is 4 for schema view.</p>
+      <p>Limit tree output depth. Deeper elements are collapsed with a child count. Default is 4 for schema view.</p>
       <Example
         command={`tractor greeter.js -d 3`}
-        outputLanguage="xml"
         output={`greeter.js:1
-<Files>
-  <file>greeter.js</file>
-  <program>
-    <function>
-      function
-      <name>greet</name>
-      <parameters>
-        <!-- ... (2 children) -->
-      </parameters>
-      <body>
-        <!-- ... (10 children) -->
-      </body>
-    </function>
-    <function>
-      function
-      <name>add</name>
-      <parameters>
-        <!-- ... (3 children) -->
-      </parameters>
-      <body>
-        <!-- ... (9 children) -->
-      </body>
-    </function>
-  </program>
-</Files>`}
+program/
+  ├─ function/
+  │   ├─ "function"
+  │   ├─ name = "greet"
+  │   ├─ parameters/
+  │   │   └─ ... (2 children)
+  │   └─ body/
+  │       └─ ... (10 children)
+  └─ function/
+      ├─ "function"
+      ├─ name = "add"
+      ├─ parameters/
+      │   └─ ... (3 children)
+      └─ body/
+          └─ ... (9 children)`}
       />
 
       <h3>--meta</h3>
-      <p>Include metadata attributes in XML output: source positions (<code>line</code>, <code>column</code>, <code>end_line</code>, <code>end_column</code>), node <code>kind</code>, and <code>field</code> name.</p>
+      <p>Include metadata in tree output: source positions (<code>line</code>, <code>column</code>, <code>end_line</code>, <code>end_column</code>), node <code>kind</code>, and <code>field</code> name. These appear as predicates in the tree view.</p>
       <Example
         command={`tractor greeter.js -x "//function/name" --meta`}
-        outputLanguage="xml"
         output={`greeter.js:1
-<name line="1" column="10" end_line="1" end_column="15" field="name">greet</name>
+name[line=1][column=10][end_line=1][end_column=15][field=name] = "greet"
 
 greeter.js:5
-<name line="5" column="10" end_line="5" end_column="13" field="name">add</name>`}
+name[line=5][column=10][end_line=5][end_column=13][field=name] = "add"`}
       />
 
       <h3>-g, --group</h3>
@@ -319,7 +289,7 @@ greeter.js:5
       />
 
       <h3>--no-pretty</h3>
-      <p>Disable pretty printing. Shows compact XML without indentation.</p>
+      <p>Disable pretty printing. Shows compact output without indentation.</p>
       <Example
         file={{ name: 'small.json', language: 'json', content: '{"host": "localhost"}' }}
         command={`tractor small.json --no-pretty`}
@@ -357,7 +327,7 @@ tractor check "src/**/*.js" --diff-lines "main..HEAD" -x "//comment[contains(.,'
       <CodeBlock language="bash" code={`tractor "src/**/*.js" -x "//function" --verbose`} />
 
       <h3>--debug</h3>
-      <p>Show the full XML with match highlights and metadata attributes. Useful for debugging XPath queries.</p>
+      <p>Show the full tree with match highlights and metadata. Useful for debugging queries. Debug mode uses XML output to show all internal detail.</p>
       <Example
         command={`echo 'function f() {}' | tractor -l javascript -x "//function" --debug`}
         outputLanguage="xml"

--- a/web/src/pages/docs/CliReference.tsx
+++ b/web/src/pages/docs/CliReference.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { DocLayout } from '../../components/DocLayout';
 import { CodeBlock, OutputBlock, Example } from '../../components/CodeBlock';
 
@@ -40,7 +41,7 @@ tractor file1.js file2.js`} />
       <h2>Extract</h2>
 
       <h3>-x, --extract</h3>
-      <p>Expression to select matching nodes. Without this, the full tree is shown.</p>
+      <p><Link to="/docs/guides/query-syntax">Query</Link> to select matching nodes. Without this, the full tree is shown.</p>
       <Example
         file={{ name: 'greeter.js', language: 'js', content: GREETER_JS }}
         command={`tractor greeter.js -x "//function/name" -v value`}

--- a/web/src/pages/docs/DataLanguages.tsx
+++ b/web/src/pages/docs/DataLanguages.tsx
@@ -37,19 +37,15 @@ export function DataLanguages() {
       <Example
         file={{ name: 'config.json', language: 'json', content: CONFIG_JSON }}
         command="tractor config.json"
-        outputLanguage="xml"
         output={`config.json:1
-<Files>
-  <file>config.json</file>
-  <database>
-    <host>localhost</host>
-    <port>5432</port>
-  </database>
-  <debug>true</debug>
-</Files>`}
+document/
+  ├─ database/
+  │   ├─ host = "localhost"
+  │   └─ port = "5432"
+  └─ debug = "true"`}
       />
       <p>
-        The JSON structure maps directly: <code>database.host</code> becomes <code>&lt;database&gt;&lt;host&gt;</code>. Querying is intuitive:
+        The JSON structure maps directly: <code>database.host</code> becomes <code>database/host</code> in the tree. Querying is intuitive:
       </p>
       <Example
         command={`tractor config.json -x "//database/host" -v value`}
@@ -60,22 +56,16 @@ export function DataLanguages() {
       <Example
         file={{ name: 'settings.yaml', language: 'yaml', content: SETTINGS_YAML }}
         command="tractor settings.yaml"
-        outputLanguage="xml"
         output={`settings.yaml:1
-<Files>
-  <file>settings.yaml</file>
-  <document>
-    <database>
-      <host>localhost</host>
-      <port>5432</port>
-    </database>
-    <debug>true</debug>
-    <log_level>verbose</log_level>
-  </document>
-</Files>`}
+document/
+  ├─ database/
+  │   ├─ host = "localhost"
+  │   └─ port = "5432"
+  ├─ debug = "true"
+  └─ log_level = "verbose"`}
       />
       <p>
-        YAML files have a <code>&lt;document&gt;</code> wrapper. Queries work the same:
+        YAML files have a <code>document</code> wrapper. Queries work the same:
       </p>
       <Example
         command={`tractor settings.yaml -x "//database/port" -v value`}
@@ -86,17 +76,11 @@ export function DataLanguages() {
       <Example
         file={{ name: 'config.toml', language: 'toml', content: CONFIG_TOML }}
         command="tractor config.toml"
-        outputLanguage="xml"
         output={`config.toml:1
-<Files>
-  <file>config.toml</file>
-  <document>
-    <database>
-      <host>localhost</host>
-      <port>5432</port>
-    </database>
-  </document>
-</Files>`}
+document/
+  └─ database/
+      ├─ host = "localhost"
+      └─ port = "5432"`}
       />
       <Example
         command={`tractor config.toml -x "//database/host" -v value`}
@@ -119,22 +103,17 @@ export function DataLanguages() {
   ]
 }` }}
         command="tractor servers.json"
-        outputLanguage="xml"
         output={`servers.json:1
-<Files>
-  <file>servers.json</file>
-  <servers>
-    <host>web1</host>
-    <port>80</port>
-  </servers>
-  <servers>
-    <host>web2</host>
-    <port>443</port>
-  </servers>
-</Files>`}
+document/
+  ├─ servers/
+  │   ├─ host = "web1"
+  │   └─ port = "80"
+  └─ servers/
+      ├─ host = "web2"
+      └─ port = "443"`}
       />
       <p>
-        Each array item becomes a separate <code>&lt;servers&gt;</code> element. You can query across all of them or filter:
+        Each array item becomes a separate <code>servers</code> element. You can query across all of them or filter:
       </p>
       <Example
         command={`tractor servers.json -x "//servers/host" -v value`}

--- a/web/src/pages/docs/DocsOverview.tsx
+++ b/web/src/pages/docs/DocsOverview.tsx
@@ -25,7 +25,7 @@ export function DocsOverview() {
 
       <h2>What is Tractor?</h2>
       <p>
-        Tractor parses your source code into a tree, then lets you query it using standard expressions. You see exactly what you're querying — no hidden structure, no guessing. One tool, one syntax, 20+ languages.
+        Tractor parses your source code into a tree, then lets you query it using <a href="https://www.w3.org/TR/xpath-31/" target="_blank" rel="noopener noreferrer">standard expressions</a>. You see exactly what you're querying — no hidden structure, no guessing. One tool, one syntax, 20+ languages.
       </p>
 
       <h2>Quick Start</h2>

--- a/web/src/pages/docs/DocsOverview.tsx
+++ b/web/src/pages/docs/DocsOverview.tsx
@@ -144,7 +144,7 @@ program/
         </Link>
         <Link to="/docs/guides/query-syntax" className="doc-card">
           <h3>Query Syntax</h3>
-          <p>Reference for path expressions, predicates, functions, and text matching.</p>
+          <p>Reference for query syntax, predicates, functions, and text matching.</p>
         </Link>
         <Link to="/docs/guides/writing-queries" className="doc-card">
           <h3>Writing Queries</h3>

--- a/web/src/pages/docs/DocsOverview.tsx
+++ b/web/src/pages/docs/DocsOverview.tsx
@@ -42,40 +42,23 @@ export function DocsOverview() {
       <Example
         file={{ name: 'greeter.js', language: 'js', content: GREETER_JS }}
         command="tractor greeter.js"
-        outputLanguage="xml"
         output={`greeter.js:1
-<Files>
-  <file>greeter.js</file>
-  <program>
-    <function>
-      function
-      <name>greet</name>
-      <parameters>
-        <params>
-          (
-          <type>name</type>
-          )
-        </params>
-      </parameters>
-      <body>
-        <block>
-          {
-          <return>
-            return
-            <binary>...</binary>
-            ;
-          </return>
-          }
-        </block>
-      </body>
-    </function>
-    <function>
-      function
-      <name>add</name>
-      ...
-    </function>
-  </program>
-</Files>`}
+program/
+  ├─ function/
+  │   ├─ "function"
+  │   ├─ name = "greet"
+  │   ├─ parameters/
+  │   │   └─ params/
+  │   │       ├─ "("
+  │   │       ├─ type = "name"
+  │   │       └─ ")"
+  │   └─ body/
+  │       └─ block/
+  │           └─ ... (5 children)
+  └─ function/
+      ├─ "function"
+      ├─ name = "add"
+      └─ ... (3 children)`}
       />
 
       <h3>3. Query for patterns</h3>
@@ -110,7 +93,7 @@ export function DocsOverview() {
       </p>
       <ul>
         <li><strong>Everything is a node</strong> — you match by element name, not attributes. Modifiers like <code>public</code> or <code>static</code> are empty marker elements, so you can filter with <code>[public]</code> or <code>[not(static)]</code>.</li>
-        <li><strong>Text content is the source code</strong> — when you compare a node to a string, tractor ignores the XML tags and matches against the flattened source text. This means you can write <code>{'//method[contains(.,"exit(1)")]'}</code> and it matches even though the source code spans multiple nested elements.</li>
+        <li><strong>Text content is the source code</strong> — when you compare a node to a string, tractor matches against the flattened source text. This means you can write <code>{'//method[contains(.,"exit(1)")]'}</code> and it matches even though the source code spans multiple nested elements.</li>
         <li><strong>No attributes needed</strong> — the tree is structured so that nearly everything you'd want to query is a named element or text content, not a hidden attribute.</li>
       </ul>
       <p>

--- a/web/src/pages/docs/DocsOverview.tsx
+++ b/web/src/pages/docs/DocsOverview.tsx
@@ -138,6 +138,10 @@ program/
 
       <h2>Guides</h2>
       <div className="doc-cards">
+        <Link to="/docs/guides/cheat-sheet" className="doc-card">
+          <h3>Cheat Sheet</h3>
+          <p>Quick reference for query syntax, views, formats, and CLI flags.</p>
+        </Link>
         <Link to="/docs/guides/query-syntax" className="doc-card">
           <h3>Query Syntax</h3>
           <p>Reference for path expressions, predicates, functions, and text matching.</p>

--- a/web/src/pages/docs/DocumentLanguages.tsx
+++ b/web/src/pages/docs/DocumentLanguages.tsx
@@ -96,7 +96,7 @@ More text` }}
         HTML is parsed into a syntax tree with <code>element</code>, <code>start_tag</code>, <code>tag_name</code>, <code>attribute</code>, and <code>text</code> nodes.
       </p>
       <p>
-        <strong>Note:</strong> HTML support is basic. The tree exposes the parser's syntax structure, which means you query through nodes like <code>start_tag/tag_name</code> rather than directly by tag name. For example, you can't write <code>//h1</code> — you need <code>//element[.//tag_name='h1']</code>. If you're working with well-formed HTML, consider treating it as XML (<code>-l xml</code> or <code>-t raw</code>) where you can query the tag structure directly.
+        <strong>Note:</strong> HTML support is basic. The tree exposes the parser's syntax structure, which means you query through nodes like <code>start_tag/tag_name</code> rather than directly by tag name. For example, you can't write <code>//h1</code> — you need <code>//element[.//tag_name='h1']</code>.
       </p>
       <Example
         file={{ name: 'page.html', language: 'xml', content: `<div class="app">

--- a/web/src/pages/docs/QueryCommand.tsx
+++ b/web/src/pages/docs/QueryCommand.tsx
@@ -207,7 +207,7 @@ fn add(a: i32, b: i32) -> i32 {
           <tr><th>Option</th><th>Description</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>-x, --extract</code></td><td>Expression to match</td></tr>
+          <tr><td><code>-x, --extract</code></td><td><Link to="/docs/guides/query-syntax">Query</Link> to match</td></tr>
           <tr><td><code>-v, --view</code></td><td>View mode: tree, value, source, lines, count, schema</td></tr>
           <tr><td><code>-f, --format</code></td><td>Output format: text, json, yaml, xml, gcc, github, claude-code</td></tr>
           <tr><td><code>-l, --lang</code></td><td>Language override (auto-detected from file extension)</td></tr>

--- a/web/src/pages/docs/QueryCommand.tsx
+++ b/web/src/pages/docs/QueryCommand.tsx
@@ -31,87 +31,48 @@ tractor query [FILES] [OPTIONS]`} language="bash" />
       <Example
         file={{ name: 'greeter.js', language: 'js', content: GREETER_JS }}
         command="tractor greeter.js"
-        outputLanguage="xml"
         output={`greeter.js:1
-<Files>
-  <file>greeter.js</file>
-  <program>
-    <function>
-      function
-      <name>greet</name>
-      <parameters>
-        <params>
-          (
-          <type>name</type>
-          )
-        </params>
-      </parameters>
-      <body>
-        <block>
-          {
-          <return>
-            return
-            <binary>
-              <op>
-                <plus/>
-                +
-              </op>
-              <left>
-                <string>
-                  &quot;
-                  <string_fragment>Hello, </string_fragment>
-                  &quot;
-                </string>
-              </left>
-              +
-              <right>
-                <type>name</type>
-              </right>
-            </binary>
-            ;
-          </return>
-          }
-        </block>
-      </body>
-    </function>
-    <function>
-      function
-      <name>add</name>
-      <parameters>
-        <params>
-          (
-          <type>a</type>
-          ,
-          <type>b</type>
-          )
-        </params>
-      </parameters>
-      <body>
-        <block>
-          {
-          <return>
-            return
-            <binary>
-              <op>
-                <plus/>
-                +
-              </op>
-              <left>
-                <type>a</type>
-              </left>
-              +
-              <right>
-                <type>b</type>
-              </right>
-            </binary>
-            ;
-          </return>
-          }
-        </block>
-      </body>
-    </function>
-  </program>
-</Files>`}
+program/
+  ├─ function/
+  │   ├─ "function"
+  │   ├─ name = "greet"
+  │   ├─ parameters/
+  │   │   └─ params/
+  │   │       ├─ "("
+  │   │       ├─ type = "name"
+  │   │       └─ ")"
+  │   └─ body/
+  │       └─ block/
+  │           ├─ "{"
+  │           ├─ return/
+  │           │   ├─ "return"
+  │           │   ├─ binary/
+  │           │   │   ├─ op/plus = "+"
+  │           │   │   ├─ left/string = "\\"Hello, \\""
+  │           │   │   └─ right/type = "name"
+  │           │   └─ ";"
+  │           └─ "}"
+  └─ function/
+      ├─ "function"
+      ├─ name = "add"
+      ├─ parameters/
+      │   └─ params/
+      │       ├─ "("
+      │       ├─ type = "a"
+      │       ├─ ","
+      │       ├─ type = "b"
+      │       └─ ")"
+      └─ body/
+          └─ block/
+              ├─ "{"
+              ├─ return/
+              │   ├─ "return"
+              │   ├─ binary/
+              │   │   ├─ op/plus = "+"
+              │   │   ├─ left/type = "a"
+              │   │   └─ right/type = "b"
+              │   └─ ";"
+              └─ "}"`}
       />
 
       <h2>Extract with -x</h2>
@@ -125,7 +86,7 @@ tractor query [FILES] [OPTIONS]`} language="bash" />
 
       <h2>Views</h2>
       <p>
-        Use <code>-v</code> to control what you see. The default is <code>tree</code> (full XML), but other views are more useful for specific tasks.
+        Use <code>-v</code> to control what you see. The default is <code>tree</code>, which shows the query-oriented tree view. Other views are more useful for specific tasks.
       </p>
 
       <h3>value</h3>
@@ -246,7 +207,7 @@ fn add(a: i32, b: i32) -> i32 {
           <tr><th>Option</th><th>Description</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>-x, --extract</code></td><td>XPath expression to match</td></tr>
+          <tr><td><code>-x, --extract</code></td><td>Expression to match</td></tr>
           <tr><td><code>-v, --view</code></td><td>View mode: tree, value, source, lines, count, schema</td></tr>
           <tr><td><code>-f, --format</code></td><td>Output format: text, json, yaml, xml, gcc, github, claude-code</td></tr>
           <tr><td><code>-l, --lang</code></td><td>Language override (auto-detected from file extension)</td></tr>

--- a/web/src/pages/docs/QuerySyntax.tsx
+++ b/web/src/pages/docs/QuerySyntax.tsx
@@ -29,7 +29,7 @@ export function QuerySyntax() {
     <DocLayout>
       <h1>Query Syntax</h1>
       <p className="doc-lead">
-        Tractor uses path expressions to query code. Just name the element you want — tractor searches the whole tree. Use <code>/</code> to navigate to children, <code>//</code> to search deeper.
+        Tractor uses <a href="https://www.w3.org/TR/xpath-31/" target="_blank" rel="noopener noreferrer">path expressions</a> to query code. Just name the element you want — tractor searches the whole tree. Use <code>/</code> to navigate to children, <code>//</code> to search deeper.
       </p>
 
       <h2>Path Basics</h2>
@@ -296,6 +296,7 @@ tractor "src/**/*.cs" -x "$file" -v value`} />
         <li><strong>The dot <code>.</code> is your friend</strong> — <code>contains(.,'text')</code> matches against the flattened source code of any element.</li>
         <li><strong>No attributes</strong> — tractor models everything as elements and text. You won't need <code>@attr</code> syntax.</li>
         <li><strong>AI tools know the syntax</strong> — ChatGPT and Claude can write tractor queries. Show them the schema output and ask for a query.</li>
+        <li><strong>Full reference</strong> — the query language is XPath 3.1. See the <a href="https://devhints.io/xpath" target="_blank" rel="noopener noreferrer">XPath cheat sheet</a> for a quick overview or the <a href="https://www.w3.org/TR/xpath-31/" target="_blank" rel="noopener noreferrer">W3C spec</a> for the complete reference.</li>
       </ul>
 
       <div className="doc-next">

--- a/web/src/pages/docs/QuerySyntax.tsx
+++ b/web/src/pages/docs/QuerySyntax.tsx
@@ -29,7 +29,7 @@ export function QuerySyntax() {
     <DocLayout>
       <h1>Query Syntax</h1>
       <p className="doc-lead">
-        Tractor uses XPath expressions to query code. Just name the element you want — tractor searches the whole tree. Use <code>/</code> to navigate to children, <code>//</code> to search deeper.
+        Tractor uses path expressions to query code. Just name the element you want — tractor searches the whole tree. Use <code>/</code> to navigate to children, <code>//</code> to search deeper.
       </p>
 
       <h2>Path Basics</h2>
@@ -48,7 +48,7 @@ export function QuerySyntax() {
         output={`greet\nadd`}
       />
       <p>
-        Here <code>function</code> finds all functions anywhere in the tree, and <code>/name</code> selects their direct <code>&lt;name&gt;</code> child.
+        Here <code>function</code> finds all functions anywhere in the tree, and <code>/name</code> selects their direct <code>name</code> child.
       </p>
 
       <h3>/ — Direct child</h3>
@@ -139,12 +139,12 @@ tractor user-service.js -x "//method/name[contains(.,'find')]" -v value`} />
 
       <h3>The dot (.) — Current node's text</h3>
       <p>
-        The dot <code>.</code> refers to the full text content of the current element — all nested text concatenated together, ignoring XML tags. This is powerful because it lets you match against the source code as a flat string:
+        The dot <code>.</code> refers to the full text content of the current element — all nested text concatenated together. This is powerful because it lets you match against the source code as a flat string:
       </p>
       <CodeBlock language="bash" code={`# Find methods that call console.log
 tractor user-service.js -x "//method[contains(.,'console.log')]/name" -v value`} />
       <p>
-        Even though <code>console.log(msg)</code> is represented as nested elements in the tree (<code>&lt;call&gt;</code>, <code>&lt;function&gt;</code>, <code>&lt;arguments&gt;</code>, etc.), the dot flattens all the text together and matches <code>"console.log"</code> against it.
+        Even though <code>console.log(msg)</code> is represented as nested elements in the tree (<code>call</code>, <code>function</code>, <code>arguments</code>, etc.), the dot flattens all the text together and matches <code>"console.log"</code> against it.
       </p>
 
       <h3>Negation with not()</h3>
@@ -246,7 +246,7 @@ tractor file.js -x "//method[contains(name,'getAll')][not(contains(.,'orderBy'))
 
       <h2>Axes</h2>
       <p>
-        XPath axes let you navigate the tree in different directions:
+        Axes let you navigate the tree in different directions:
       </p>
       <table className="doc-table">
         <thead>
@@ -266,7 +266,7 @@ tractor file.js -x "//method[name='save']/ancestor::class/name" -v value`} />
 
       <h2>Context Variables</h2>
       <p>
-        Tractor provides built-in variables you can use in any XPath expression:
+        Tractor provides built-in variables you can use in any expression:
       </p>
       <table className="doc-table">
         <thead>
@@ -295,7 +295,7 @@ tractor "src/**/*.cs" -x "$file" -v value`} />
         <li><strong>Use <code>-v schema</code></strong> to discover element names before writing queries.</li>
         <li><strong>The dot <code>.</code> is your friend</strong> — <code>contains(.,'text')</code> matches against the flattened source code of any element.</li>
         <li><strong>No attributes</strong> — tractor models everything as elements and text. You won't need <code>@attr</code> syntax.</li>
-        <li><strong>AI tools know XPath</strong> — ChatGPT and Claude can write tractor queries. Show them the schema output and ask for a query.</li>
+        <li><strong>AI tools know the syntax</strong> — ChatGPT and Claude can write tractor queries. Show them the schema output and ask for a query.</li>
       </ul>
 
       <div className="doc-next">

--- a/web/src/pages/docs/QuerySyntax.tsx
+++ b/web/src/pages/docs/QuerySyntax.tsx
@@ -29,7 +29,7 @@ export function QuerySyntax() {
     <DocLayout>
       <h1>Query Syntax</h1>
       <p className="doc-lead">
-        Tractor uses <a href="https://www.w3.org/TR/xpath-31/" target="_blank" rel="noopener noreferrer">path expressions</a> to query code. Just name the element you want — tractor searches the whole tree. Use <code>/</code> to navigate to children, <code>//</code> to search deeper.
+        Tractor queries use <a href="https://www.w3.org/TR/xpath-31/" target="_blank" rel="noopener noreferrer">XPath</a> syntax. Just name the element you want — tractor searches the whole tree. Use <code>/</code> to navigate to children, <code>//</code> to search deeper.
       </p>
 
       <h2>Path Basics</h2>

--- a/web/src/pages/docs/RunCommand.tsx
+++ b/web/src/pages/docs/RunCommand.tsx
@@ -98,7 +98,7 @@ example.js:3:3: error: getAll methods in repositories should use orderBy
         </thead>
         <tbody>
           <tr><td><code>id</code></td><td>Yes</td><td>Unique identifier for the rule</td></tr>
-          <tr><td><code>xpath</code></td><td>Yes</td><td>Expression — each match is a violation</td></tr>
+          <tr><td><code>xpath</code></td><td>Yes</td><td><Link to="/docs/guides/query-syntax">Query</Link> — each match is a violation</td></tr>
           <tr><td><code>reason</code></td><td>Yes</td><td>Explanation shown for each violation</td></tr>
           <tr><td><code>severity</code></td><td>No</td><td><code>error</code> (default) or <code>warning</code></td></tr>
           <tr><td><code>message</code></td><td>No</td><td>Custom message template (<code>{'{value}'}</code>, <code>{'{line}'}</code>, etc.)</td></tr>

--- a/web/src/pages/docs/RunCommand.tsx
+++ b/web/src/pages/docs/RunCommand.tsx
@@ -98,7 +98,7 @@ example.js:3:3: error: getAll methods in repositories should use orderBy
         </thead>
         <tbody>
           <tr><td><code>id</code></td><td>Yes</td><td>Unique identifier for the rule</td></tr>
-          <tr><td><code>xpath</code></td><td>Yes</td><td>XPath expression — each match is a violation</td></tr>
+          <tr><td><code>xpath</code></td><td>Yes</td><td>Expression — each match is a violation</td></tr>
           <tr><td><code>reason</code></td><td>Yes</td><td>Explanation shown for each violation</td></tr>
           <tr><td><code>severity</code></td><td>No</td><td><code>error</code> (default) or <code>warning</code></td></tr>
           <tr><td><code>message</code></td><td>No</td><td>Custom message template (<code>{'{value}'}</code>, <code>{'{line}'}</code>, etc.)</td></tr>
@@ -158,7 +158,7 @@ operations:
 
       <h2>Set Operations</h2>
       <p>
-        Use <code>set</code> to apply multiple value changes in a config file. Each mapping specifies an XPath expression and the value to set. This is the batch equivalent of the <Link to="/docs/commands/set">set command</Link>:
+        Use <code>set</code> to apply multiple value changes in a config file. Each mapping specifies an expression and the value to set. This is the batch equivalent of the <Link to="/docs/commands/set">set command</Link>:
       </p>
       <CodeBlock
         language="yaml"

--- a/web/src/pages/docs/SetCommand.tsx
+++ b/web/src/pages/docs/SetCommand.tsx
@@ -23,7 +23,7 @@ export function SetCommand() {
       </p>
 
       <h2>Usage</h2>
-      <CodeBlock code={`tractor set [FILES] -x <EXPRESSION> --value <VALUE> [OPTIONS]
+      <CodeBlock code={`tractor set [FILES] -x <QUERY> --value <VALUE> [OPTIONS]
 tractor set [FILES] <PATH_EXPRESSION> [--value <VALUE>] [OPTIONS]`} language="bash" />
 
       <h2>Update Config Values</h2>
@@ -206,7 +206,7 @@ Set 2 values in 1 file`}
 
       <h2>Multiple Mappings with tractor run</h2>
       <p>
-        The <code>set</code> CLI command applies one expression + value per invocation. To set multiple values at once, use <Link to="/docs/commands/run">tractor run</Link> with a config file:
+        The <code>set</code> CLI command applies one query + value per invocation. To set multiple values at once, use <Link to="/docs/commands/run">tractor run</Link> with a config file:
       </p>
       <CodeBlock
         language="yaml"
@@ -232,7 +232,7 @@ Set 2 values in 1 file`}
           <tr><th>Option</th><th>Description</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>-x, --extract</code></td><td>Expression to match nodes</td></tr>
+          <tr><td><code>-x, --extract</code></td><td><Link to="/docs/guides/query-syntax">Query</Link> to match nodes</td></tr>
           <tr><td><code>--value</code></td><td>New value to set (optional with path expressions)</td></tr>
           <tr><td><code>--stdout</code></td><td>Output to stdout instead of modifying in-place</td></tr>
           <tr><td><code>-v, --view</code></td><td>View: status (default), output, file, line, value, source, lines</td></tr>

--- a/web/src/pages/docs/SetCommand.tsx
+++ b/web/src/pages/docs/SetCommand.tsx
@@ -23,7 +23,7 @@ export function SetCommand() {
       </p>
 
       <h2>Usage</h2>
-      <CodeBlock code={`tractor set [FILES] -x <XPATH> --value <VALUE> [OPTIONS]
+      <CodeBlock code={`tractor set [FILES] -x <EXPRESSION> --value <VALUE> [OPTIONS]
 tractor set [FILES] <PATH_EXPRESSION> [--value <VALUE>] [OPTIONS]`} language="bash" />
 
       <h2>Update Config Values</h2>
@@ -94,7 +94,7 @@ Set 3 matches in 3 files`}
     port: 5432`}
       />
       <p>
-        This is equivalent in spirit to an XPath update such as <code>-x "//servers[host='localhost']/port"</code>: the predicate filters the target nodes; it is not stripped away.
+        This is equivalent to <code>-x "//servers[host='localhost']/port"</code>: the predicate filters the target nodes; it is not stripped away.
       </p>
 
       <h2>Patch Source Code</h2>
@@ -206,7 +206,7 @@ Set 2 values in 1 file`}
 
       <h2>Multiple Mappings with tractor run</h2>
       <p>
-        The <code>set</code> CLI command applies one XPath + value per invocation. To set multiple values at once, use <Link to="/docs/commands/run">tractor run</Link> with a config file:
+        The <code>set</code> CLI command applies one expression + value per invocation. To set multiple values at once, use <Link to="/docs/commands/run">tractor run</Link> with a config file:
       </p>
       <CodeBlock
         language="yaml"
@@ -232,7 +232,7 @@ Set 2 values in 1 file`}
           <tr><th>Option</th><th>Description</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>-x, --extract</code></td><td>XPath expression to match nodes</td></tr>
+          <tr><td><code>-x, --extract</code></td><td>Expression to match nodes</td></tr>
           <tr><td><code>--value</code></td><td>New value to set (optional with path expressions)</td></tr>
           <tr><td><code>--stdout</code></td><td>Output to stdout instead of modifying in-place</td></tr>
           <tr><td><code>-v, --view</code></td><td>View: status (default), output, file, line, value, source, lines</td></tr>

--- a/web/src/pages/docs/TestCommand.tsx
+++ b/web/src/pages/docs/TestCommand.tsx
@@ -19,7 +19,7 @@ export function TestCommand() {
       </p>
 
       <h2>Usage</h2>
-      <CodeBlock code={`tractor test [FILES] -x <EXPRESSION> --expect <EXPECT> [OPTIONS]`} language="bash" />
+      <CodeBlock code={`tractor test [FILES] -x <QUERY> --expect <EXPECT> [OPTIONS]`} language="bash" />
 
       <h2>Basic Test</h2>
       <p>
@@ -76,7 +76,7 @@ export function TestCommand() {
           <tr><th>Option</th><th>Description</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>-x, --extract</code></td><td>Expression to match</td></tr>
+          <tr><td><code>-x, --extract</code></td><td><Link to="/docs/guides/query-syntax">Query</Link> to match</td></tr>
           <tr><td><code>-e, --expect</code></td><td>Expected result: <code>none</code>, <code>some</code>, or a number</td></tr>
           <tr><td><code>-m, --message</code></td><td>Custom message for the assertion</td></tr>
           <tr><td><code>-s, --string</code></td><td>Inline source code to test</td></tr>

--- a/web/src/pages/docs/TestCommand.tsx
+++ b/web/src/pages/docs/TestCommand.tsx
@@ -19,7 +19,7 @@ export function TestCommand() {
       </p>
 
       <h2>Usage</h2>
-      <CodeBlock code={`tractor test [FILES] -x <XPATH> --expect <EXPECT> [OPTIONS]`} language="bash" />
+      <CodeBlock code={`tractor test [FILES] -x <EXPRESSION> --expect <EXPECT> [OPTIONS]`} language="bash" />
 
       <h2>Basic Test</h2>
       <p>
@@ -76,7 +76,7 @@ export function TestCommand() {
           <tr><th>Option</th><th>Description</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>-x, --extract</code></td><td>XPath expression to match</td></tr>
+          <tr><td><code>-x, --extract</code></td><td>Expression to match</td></tr>
           <tr><td><code>-e, --expect</code></td><td>Expected result: <code>none</code>, <code>some</code>, or a number</td></tr>
           <tr><td><code>-m, --message</code></td><td>Custom message for the assertion</td></tr>
           <tr><td><code>-s, --string</code></td><td>Inline source code to test</td></tr>

--- a/web/src/pages/docs/WritingQueries.tsx
+++ b/web/src/pages/docs/WritingQueries.tsx
@@ -92,7 +92,7 @@ export function WritingQueries() {
 
       <h2>Step 3: Select Elements</h2>
       <p>
-        Use <code>-x</code> with a path expression to select elements. The syntax uses path expressions, similar to file paths:
+        Use <code>-x</code> with a <a href="https://www.w3.org/TR/xpath-31/" target="_blank" rel="noopener noreferrer">path expression</a> to select elements. The syntax is similar to file paths:
       </p>
 
       <h3>Select all method names</h3>

--- a/web/src/pages/docs/WritingQueries.tsx
+++ b/web/src/pages/docs/WritingQueries.tsx
@@ -92,7 +92,7 @@ export function WritingQueries() {
 
       <h2>Step 3: Select Elements</h2>
       <p>
-        Use <code>-x</code> with a <a href="https://www.w3.org/TR/xpath-31/" target="_blank" rel="noopener noreferrer">path expression</a> to select elements. The syntax is similar to file paths:
+        Use <code>-x</code> with a <Link to="/docs/guides/query-syntax">query</Link> to select elements. The syntax is similar to file paths:
       </p>
 
       <h3>Select all method names</h3>

--- a/web/src/pages/docs/WritingQueries.tsx
+++ b/web/src/pages/docs/WritingQueries.tsx
@@ -38,7 +38,7 @@ export function WritingQueries() {
       </p>
       <ol>
         <li><strong>See the structure</strong> — explore with schema view</li>
-        <li><strong>View the tree</strong> — inspect the full XML of specific code</li>
+        <li><strong>View the tree</strong> — inspect the full tree of specific code</li>
         <li><strong>Select elements</strong> — use <code>-x</code> to pick elements</li>
         <li><strong>Add predicates</strong> — filter by conditions</li>
         <li><strong>Choose a view</strong> — pick the output that fits your use case</li>
@@ -126,7 +126,7 @@ export function WritingQueries() {
         output={`findById\nsave\n_log`}
       />
       <p>
-        <code>[not(static)]</code> means "does not have a <code>&lt;static/&gt;</code> child".
+        <code>[not(static)]</code> means "does not have a <code>static</code> child element".
       </p>
 
       <h3>Filter by text content</h3>
@@ -141,8 +141,8 @@ export function WritingQueries() {
           <tr><th>Predicate</th><th>Meaning</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>[public]</code></td><td>Has a <code>&lt;public/&gt;</code> child element</td></tr>
-          <tr><td><code>[not(static)]</code></td><td>Does not have a <code>&lt;static/&gt;</code> child</td></tr>
+          <tr><td><code>[public]</code></td><td>Has a <code>public</code> child element</td></tr>
+          <tr><td><code>[not(static)]</code></td><td>Does not have a <code>static</code> child</td></tr>
           <tr><td><code>[name='Foo']</code></td><td>Has name equal to "Foo"</td></tr>
           <tr><td><code>[contains(name,'get')]</code></td><td>Name contains "get"</td></tr>
           <tr><td><code>[contains(.,'orderBy')]</code></td><td>Full text of element contains "orderBy"</td></tr>
@@ -160,7 +160,7 @@ export function WritingQueries() {
           <tr><th>View</th><th>Use case</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>-v tree</code></td><td>Full XML (default) — see the structure</td></tr>
+          <tr><td><code>-v tree</code></td><td>Tree view (default) — see the structure</td></tr>
           <tr><td><code>-v value</code></td><td>Text content — get names, values</td></tr>
           <tr><td><code>-v source</code></td><td>Exact source code — copy-paste ready</td></tr>
           <tr><td><code>-v lines</code></td><td>Source lines with context</td></tr>
@@ -190,7 +190,7 @@ export function WritingQueries() {
         <li>Use <code>-v schema</code> when querying multiple files to see element types at a glance.</li>
         <li>Use <code>-W</code> to ignore whitespace when matching formatted code.</li>
         <li>The <Link to="/playground">Playground</Link> lets you build queries visually.</li>
-        <li>AI tools like ChatGPT and Claude can write tractor queries — the syntax is standard XPath that they already know.</li>
+        <li>AI tools like ChatGPT and Claude can write tractor queries — the syntax is standard and they already know it.</li>
       </ul>
 
       <div className="doc-next">


### PR DESCRIPTION
## Summary
This PR adds a new CheatSheet documentation page and updates documentation examples throughout the site to reflect a new tree-based output format instead of XML. The changes modernize the documentation to better represent how tractor actually displays query results.

## Key Changes

- **New CheatSheet page** (`web/src/pages/docs/CheatSheet.tsx`): Comprehensive quick reference guide covering:
  - Path expressions and predicates
  - XPath functions and axes
  - CLI views and output formats
  - Common query recipes with examples
  - Key CLI flags and variables
  - Links to related documentation

- **Updated output format in documentation examples**: Changed all example outputs from XML format (e.g., `<Files><file>...</file></Files>`) to a cleaner tree-based format with ASCII art (e.g., `program/ ├─ function/ │ ├─ "function"...`). This affects:
  - `QueryCommand.tsx`: Updated default tree view examples
  - `CliReference.tsx`: Updated tree depth and metadata examples
  - `DataLanguages.tsx`: Updated JSON, YAML, and TOML examples
  - `DocsOverview.tsx`: Updated quick start example
  - `WritingQueries.tsx`: Updated tree inspection examples

- **Terminology updates**: Changed references from "XPath" to more general "expression" or "path expression" in several places to be more user-friendly while maintaining accuracy

- **Documentation improvements**:
  - Added link to XPath 3.1 specification in `DocsOverview.tsx` and `QuerySyntax.tsx`
  - Updated descriptions of tree views to clarify they show "query-oriented tree view" rather than "full XML"
  - Added CheatSheet to the guides section in `DocLayout.tsx` and `DocsOverview.tsx`
  - Clarified that debug mode uses XML output for internal detail

## Implementation Details

The CheatSheet page is structured as a comprehensive reference with multiple tables covering different aspects of the query language and CLI, followed by practical recipes and links to more detailed guides. It serves as a landing point for users who need quick answers without diving into full documentation.

The output format changes are purely documentation updates—they don't affect the actual CLI behavior, only how examples are presented to users. The new tree format is more readable and better represents the actual output users will see.

https://claude.ai/code/session_01NDuSQpt1ciRxZk3ipne4d1