### PR TITLE
Harden file resolution: typed paths, walker pruning, Windows canonicalisation

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,20 @@
+#
+# Tractor: path-invariant lints.
+#
+# `NormalizedPath` is the universal container for file paths throughout the
+# pipeline (glob walker, CLI resolution, diff intersection, result filtering).
+# The methods listed below re-enter the path domain through non-standard
+# channels and bypass the invariant — they are disallowed so that any
+# alternative path construction has to be a conscious, annotated boundary.
+#
+# To make a legitimate boundary call, annotate the specific call site with
+# `#[allow(clippy::disallowed_methods)]` and add a short comment explaining
+# why this site is the input/output edge of the type.
+#
+# See docs/design-file-resolver.md for the path invariant rationale.
+#
+disallowed-methods = [
+  { path = "std::fs::canonicalize", reason = "follows symlinks and re-adds `\\\\?\\` on Windows; use `NormalizedPath::absolute` instead" },
+  { path = "std::path::Path::canonicalize", reason = "follows symlinks and re-adds `\\\\?\\` on Windows; use `NormalizedPath::absolute` instead" },
+  { path = "std::path::PathBuf::canonicalize", reason = "follows symlinks and re-adds `\\\\?\\` on Windows; use `NormalizedPath::absolute` instead" },
+]

--- a/docs/design-file-resolver.md
+++ b/docs/design-file-resolver.md
@@ -2,7 +2,8 @@
 
 **Status**: Implemented
 **Related PR**: #82 (root intersection, SharedFileScope, module split),
-#128 (canonical glob walker, path intersection fix)
+#128 (canonical glob walker, path intersection fix),
+#134 (typed paths, walker pruning, Windows canonicalization)
 **Related issue**: #78 (implicit // in config), #127 (path filter intersection)
 
 ---
@@ -54,8 +55,9 @@ distinction.
 All discovered paths are canonical from the moment of creation. The
 custom glob walker (`expand_canonical`) achieves this by:
 
-- Canonicalizing the root prefix once (resolves symlinks, 8.3 short
-  names on Windows, and true filesystem casing)
+- Canonicalizing the root prefix once (resolves 8.3 short names on
+  Windows and true filesystem casing — symlinks are deliberately NOT
+  resolved so CLI paths using link names still intersect correctly)
 - Building child paths by appending `read_dir` entry names (which have
   true filesystem casing) with `/` separators
 - Never constructing intermediate `PathBuf` values that could introduce
@@ -132,7 +134,9 @@ codebases (1.5s vs 10s on 205K files). The speedup comes from:
   pattern-matching pass)
 - Building paths as strings by appending entry names (no `PathBuf`
   allocation per entry)
-- Single `canonicalize()` call at the root instead of per-file
+- Single `NormalizedPath::absolute()` call at the root instead of per-file
+- Walker pruning (`FilePrune`) skips entire subtrees when sibling
+  patterns constrain the scope
 
 ---
 
@@ -216,23 +220,56 @@ matching, path construction, and canonicalization happen in a single
 recursive pass.
 
 1. Split pattern at first wildcard → literal root prefix + wildcard suffix
-2. Canonicalize root prefix once (`std::fs::canonicalize`)
+2. Canonicalize root prefix once via `NormalizedPath::absolute()` (resolves
+   8.3 short names and case on Windows; does NOT follow symlinks)
 3. Compile wildcard suffix into `CompiledPattern`
-4. Walk with `std::fs::read_dir` recursively:
+4. If a `FilePrune` predicate is provided, check that the canonical root
+   is compatible with every prune group — short-circuit with `Ok(vec![])`
+   if not
+5. Walk with `std::fs::read_dir` recursively:
    - Build each path by appending `entry.file_name()` (true casing) to
      parent path string with `/`
+   - If `FilePrune` is active, skip directories/files that aren't
+     compatible with every prune group
    - Match each file's relative path against compiled suffix
    - Return `Vec<NormalizedPath>` — canonical by construction
-5. Symlinks: traversed using link name (not target); depth limit (100)
-   prevents cycles
-6. Permission-denied directories: skipped silently
+6. Symlinks: traversed using link name (not target); depth limit (100)
+   prevents cycles; warning emitted when MAX_DEPTH is reached
+7. Permission-denied directories: skipped silently
 
 Pattern syntax: `*` (any characters within one segment) and `**` (zero
 or more whole segments). Character classes (`[...]`) and the
-single-character wildcard (`?`) are rejected with a compile error —
-file patterns in tractor are overwhelmingly expressed by extension and
-directory, and we can introduce richer syntax when a real need shows
-up. Case-insensitive on Windows.
+single-character wildcard (`?`) are rejected with a compile error when
+used in a glob pattern (alongside `*`). In non-glob patterns (no `*`)
+they are treated as literal filename characters with a warning — this
+supports the edge case of actual brackets in filenames while flagging
+likely mistakes. Case-insensitive on Windows.
+
+### Walker pruning (`FilePrune`)
+
+When the file resolver intersects root / CLI / operation pattern sets,
+it used to expand each independently and intersect downstream — walking
+subtrees that could never appear in the final result. Now each pattern
+contributes its literal (wildcard-free) path prefix via
+`pattern_literal_prefix()`. The resolver bundles prefixes from sibling
+sets into a `FilePrune` predicate (AND-of-OR groups) and passes it to
+`expand_canonical`. The walker refuses to descend into any directory that
+isn't path-compatible with every group.
+
+Two primary use cases:
+
+- **Scoping to a directory**: CLI passes `backend/**/*.cs`, rule says
+  `**/*.cs` → walker only enters `backend/`.
+- **Scoping to a single file**: CLI passes `src/foo.cs` → every
+  rule-side expansion resolves to just that file.
+
+`FilePrune` uses path-segment-prefix compatibility (not substring): the
+walker at `/proj` can descend *toward* a constraint `/proj/backend`,
+and once it reaches `/proj/backend/` it continues unrestricted below.
+Case-insensitive on Windows.
+
+Future work (Option B): prune further by using already-expanded sets
+to filter unfinished walks.
 
 ## Not in Scope
 

--- a/docs/design-file-resolver.md
+++ b/docs/design-file-resolver.md
@@ -227,9 +227,12 @@ recursive pass.
    prevents cycles
 6. Permission-denied directories: skipped silently
 
-Pattern syntax: `*` (single segment), `**` (zero or more segments),
-`?` (single character). `[...]` rejected with error. Case-insensitive
-on Windows.
+Pattern syntax: `*` (any characters within one segment) and `**` (zero
+or more whole segments). Character classes (`[...]`) and the
+single-character wildcard (`?`) are rejected with a compile error —
+file patterns in tractor are overwhelmingly expressed by extension and
+directory, and we can introduce richer syntax when a real need shows
+up. Case-insensitive on Windows.
 
 ## Not in Scope
 

--- a/specs/codexpath/cli/input-options/glob-patterns.md
+++ b/specs/codexpath/cli/input-options/glob-patterns.md
@@ -4,8 +4,12 @@ priority: 1
 ---
 
 Expand glob patterns in file arguments:
-- * matches files in current directory
-- ** enables recursive directory search
-- ? matches single character
+- `*` matches any characters within a single path component
+- `**` matches zero or more path components (recursive)
 
-Example: "**/*.cs" matches all C# files recursively
+Unsupported syntax: `?` (single-character wildcard) and `[...]`
+(character classes) are rejected at compile time when used in a glob
+pattern (i.e. alongside `*`). In a non-glob pattern (no `*`), they
+are treated as literal filename characters with a warning.
+
+Example: `"**/*.cs"` matches all C# files recursively

--- a/tractor-core/src/files.rs
+++ b/tractor-core/src/files.rs
@@ -82,6 +82,20 @@ pub fn expand_globs_checked(
             // Not a glob, use as-is (normalized). Non-glob patterns bypass
             // the walker entirely, so prune doesn't apply here — sibling-set
             // intersection still runs downstream.
+            //
+            // Brackets and question marks are valid in literal filenames
+            // (at least on Unix), so we don't reject them — but they are
+            // much more likely to be a glob-syntax mistake (e.g. `[abc]`
+            // character class or `?` single-char wildcard) than an actual
+            // filename, so warn.
+            if pattern.contains('[') || pattern.contains('?') {
+                eprintln!(
+                    "warning: pattern '{}' contains '?' or '[' but no '*' — \
+                     treating as a literal file path; if you intended glob syntax, \
+                     add a '*' or '**/' prefix",
+                    pattern
+                );
+            }
             files.push(NormalizedPath::new(pattern));
         }
     }

--- a/tractor-core/src/files.rs
+++ b/tractor-core/src/files.rs
@@ -40,7 +40,7 @@ pub fn expand_globs_checked(
     let mut empty_patterns = Vec::new();
 
     for pattern in patterns {
-        if pattern.contains('*') || pattern.contains('?') {
+        if pattern.contains('*') {
             let remaining = expansion_limit.saturating_sub(files.len());
             match crate::glob_match::expand_canonical(pattern, remaining) {
                 Ok(paths) => {
@@ -57,15 +57,17 @@ pub fn expand_globs_checked(
                         }
                     }
                 }
-                Err(e) => {
-                    if e.message.contains("limit") {
+                Err(e) => match e.kind {
+                    crate::glob_match::GlobExpandErrorKind::LimitExceeded => {
                         return Err(GlobExpansionError {
                             pattern: pattern.clone(),
                             limit: expansion_limit,
                         });
                     }
-                    eprintln!("Invalid glob pattern '{}': {}", pattern, e);
-                }
+                    crate::glob_match::GlobExpandErrorKind::InvalidPattern => {
+                        eprintln!("Invalid glob pattern '{}': {}", pattern, e);
+                    }
+                },
             }
         } else {
             // Not a glob, use as-is

--- a/tractor-core/src/files.rs
+++ b/tractor-core/src/files.rs
@@ -1,5 +1,6 @@
 //! File discovery: glob expansion, language filtering, and safety limits.
 
+use crate::glob_match::FilePrune;
 use crate::NormalizedPath;
 
 /// Error returned when glob expansion exceeds the path limit.
@@ -32,11 +33,17 @@ pub struct GlobExpansion {
 /// Uses a custom canonical filesystem walker that produces correctly-cased
 /// paths on Windows by building paths from `read_dir` entry names.
 ///
+/// `prune`, if provided, narrows the walk to subtrees compatible with the
+/// given prefix groups — typically the literal prefixes of *sibling*
+/// pattern sets that will be intersected with this one (e.g. CLI ∩ rule).
+/// See [`FilePrune`] for the compatibility model.
+///
 /// Returns the expanded file list and a list of patterns that matched 0 files.
 /// Returns `Err` if any single pattern exceeds `expansion_limit` matches.
 pub fn expand_globs_checked(
     patterns: &[String],
     expansion_limit: usize,
+    prune: Option<&FilePrune>,
 ) -> Result<GlobExpansion, GlobExpansionError> {
     let mut files: Vec<NormalizedPath> = Vec::new();
     let mut empty_patterns = Vec::new();
@@ -44,7 +51,7 @@ pub fn expand_globs_checked(
     for pattern in patterns {
         if pattern.contains('*') {
             let remaining = expansion_limit.saturating_sub(files.len());
-            match crate::glob_match::expand_canonical(pattern, remaining) {
+            match crate::glob_match::expand_canonical(pattern, remaining, prune) {
                 Ok(paths) => {
                     if paths.is_empty() {
                         empty_patterns.push(pattern.clone());
@@ -72,7 +79,9 @@ pub fn expand_globs_checked(
                 },
             }
         } else {
-            // Not a glob, use as-is (normalized).
+            // Not a glob, use as-is (normalized). Non-glob patterns bypass
+            // the walker entirely, so prune doesn't apply here — sibling-set
+            // intersection still runs downstream.
             files.push(NormalizedPath::new(pattern));
         }
     }
@@ -82,7 +91,7 @@ pub fn expand_globs_checked(
 
 /// Expand glob patterns to file paths (convenience wrapper with no limit).
 pub fn expand_globs(patterns: &[String]) -> Vec<NormalizedPath> {
-    match expand_globs_checked(patterns, usize::MAX) {
+    match expand_globs_checked(patterns, usize::MAX, None) {
         Ok(result) => result.files,
         Err(_) => unreachable!("usize::MAX limit cannot be exceeded"),
     }

--- a/tractor-core/src/files.rs
+++ b/tractor-core/src/files.rs
@@ -1,5 +1,7 @@
 //! File discovery: glob expansion, language filtering, and safety limits.
 
+use crate::NormalizedPath;
+
 /// Error returned when glob expansion exceeds the path limit.
 #[derive(Debug, Clone)]
 pub struct GlobExpansionError {
@@ -21,7 +23,7 @@ impl std::fmt::Display for GlobExpansionError {
 
 /// Result of expanding glob patterns: files and any patterns that matched nothing.
 pub struct GlobExpansion {
-    pub files: Vec<String>,
+    pub files: Vec<NormalizedPath>,
     pub empty_patterns: Vec<String>,
 }
 
@@ -36,7 +38,7 @@ pub fn expand_globs_checked(
     patterns: &[String],
     expansion_limit: usize,
 ) -> Result<GlobExpansion, GlobExpansionError> {
-    let mut files = Vec::new();
+    let mut files: Vec<NormalizedPath> = Vec::new();
     let mut empty_patterns = Vec::new();
 
     for pattern in patterns {
@@ -48,7 +50,7 @@ pub fn expand_globs_checked(
                         empty_patterns.push(pattern.clone());
                     }
                     for path in paths {
-                        files.push(path.into_string());
+                        files.push(path);
                         if files.len() > expansion_limit {
                             return Err(GlobExpansionError {
                                 pattern: pattern.clone(),
@@ -70,8 +72,8 @@ pub fn expand_globs_checked(
                 },
             }
         } else {
-            // Not a glob, use as-is
-            files.push(pattern.clone());
+            // Not a glob, use as-is (normalized).
+            files.push(NormalizedPath::new(pattern));
         }
     }
 
@@ -79,21 +81,11 @@ pub fn expand_globs_checked(
 }
 
 /// Expand glob patterns to file paths (convenience wrapper with no limit).
-pub fn expand_globs(patterns: &[String]) -> Vec<String> {
+pub fn expand_globs(patterns: &[String]) -> Vec<NormalizedPath> {
     match expand_globs_checked(patterns, usize::MAX) {
         Ok(result) => result.files,
         Err(_) => unreachable!("usize::MAX limit cannot be exceeded"),
     }
-}
-
-/// Filter files by supported languages
-pub fn filter_supported_files(files: Vec<String>) -> Vec<String> {
-    use crate::parser::detect_language;
-
-    files
-        .into_iter()
-        .filter(|f| detect_language(f) != "unknown")
-        .collect()
 }
 
 #[cfg(test)]
@@ -104,19 +96,7 @@ mod tests {
     fn test_expand_globs_non_glob() {
         let patterns = vec!["test.cs".to_string()];
         let files = expand_globs(&patterns);
-        assert_eq!(files, vec!["test.cs"]);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0], "test.cs");
     }
-
-    #[test]
-    fn test_filter_supported_files() {
-        let files = vec![
-            "test.cs".to_string(),
-            "test.rs".to_string(),
-            "test.unknown".to_string(),
-            "readme.md".to_string(),
-        ];
-        let filtered = filter_supported_files(files);
-        assert_eq!(filtered, vec!["test.cs", "test.rs", "readme.md"]);
-    }
-
 }

--- a/tractor-core/src/glob_match.rs
+++ b/tractor-core/src/glob_match.rs
@@ -470,8 +470,19 @@ mod walk {
     ) -> Result<Vec<NormalizedPath>, GlobExpandError> {
         let normalized = normalize_path(pattern);
 
-        // Non-glob pattern: return as-is
+        // Non-glob pattern: return as-is. Brackets and question marks
+        // are valid literal filename characters (at least on Unix), so
+        // we don't reject — but warn because they're more likely a
+        // glob-syntax mistake than an actual filename.
         if !normalized.contains('*') {
+            if normalized.contains('[') || normalized.contains('?') {
+                eprintln!(
+                    "warning: pattern '{}' contains '?' or '[' but no '*' — \
+                     treating as a literal file path; if you intended glob syntax, \
+                     add a '*' or '**/' prefix",
+                    normalized
+                );
+            }
             return Ok(vec![NormalizedPath::new(&normalized)]);
         }
 

--- a/tractor-core/src/glob_match.rs
+++ b/tractor-core/src/glob_match.rs
@@ -695,12 +695,14 @@ mod tests {
 
         /// `expand_canonical` must classify a malformed wildcard suffix as
         /// `InvalidPattern` so callers (e.g. `expand_globs_checked`) don't
-        /// confuse it with a limit overflow. Pattern below puts a `[...]`
+        /// confuse it with a limit overflow. The pattern below puts a `[...]`
         /// character class after the first `*`, so it lands in the
-        /// `CompiledPattern::new()` failure path.
+        /// `CompiledPattern::new()` failure path. Uses `./*` so the literal
+        /// root is always the cwd — otherwise on Windows `/tmp` doesn't exist
+        /// and expansion short-circuits before the pattern is compiled.
         #[test]
         fn expand_invalid_pattern_kind() {
-            let result = expand_canonical("/tmp/*/[abc]/*.rs", 100);
+            let result = expand_canonical("./*/[abc]/*.rs", 100);
             let err = result.expect_err("invalid pattern must surface as Err");
             assert!(matches!(err.kind, GlobExpandErrorKind::InvalidPattern),
                 "expected InvalidPattern, got {:?}", err.kind);

--- a/tractor-core/src/glob_match.rs
+++ b/tractor-core/src/glob_match.rs
@@ -754,6 +754,7 @@ mod tests {
             let result = expand_canonical(&pattern, 10000).unwrap();
             // Verify paths match what canonicalize would return
             for p in result.iter().take(3) {
+                #[allow(clippy::disallowed_methods)] // test verifies canonical walker output
                 let canonical = std::fs::canonicalize(p.as_str())
                     .map(|c| normalize_path(&c.to_string_lossy()))
                     .unwrap_or_else(|_| p.as_str().to_string());

--- a/tractor-core/src/glob_match.rs
+++ b/tractor-core/src/glob_match.rs
@@ -336,6 +336,106 @@ mod walk {
         InvalidPattern,
     }
 
+    /// Extract the literal (wildcard-free) path prefix of a glob pattern.
+    ///
+    /// * `backend/**/tests/*.cs` → `backend/`
+    /// * `/abs/backend/foo.cs`   → `/abs/backend/foo.cs` (no wildcards → full path)
+    /// * `**/*.cs`               → `` (pattern starts with a wildcard)
+    /// * `foo*bar/baz.cs`        → `` (wildcard inside the first segment)
+    ///
+    /// The returned prefix is always a path-segment boundary (ends at `/`
+    /// or is the full pattern). Used to build [`FilePrune`] constraints.
+    pub fn pattern_literal_prefix(pattern: &str) -> String {
+        let norm = normalize_path(pattern);
+        match norm.find(|c: char| c == '*' || c == '?' || c == '[') {
+            None => norm,
+            Some(0) => String::new(),
+            Some(idx) => {
+                let before = &norm[..idx];
+                match before.rfind('/') {
+                    Some(slash) => norm[..=slash].to_string(),
+                    None => String::new(),
+                }
+            }
+        }
+    }
+
+    /// Subtree pruning filter for [`expand_canonical`].
+    ///
+    /// Holds an AND of OR-groups: each inner group is a list of absolute
+    /// literal path prefixes; a path passes if, for every group, at least
+    /// one prefix is *compatible* with it. "Compatible" means the two
+    /// paths lie on the same path branch — either is a path-segment
+    /// prefix of the other. This lets the walker descend *toward* a
+    /// constraint before reaching it, and keep walking *below* it once
+    /// reached.
+    ///
+    /// Typical construction:
+    ///
+    /// ```ignore
+    /// // CLI passed `backend/**/tests/*.cs`; config-root has its own patterns.
+    /// // When expanding config-root globs, prune by CLI prefixes:
+    /// let prune = FilePrune::new()
+    ///     .with_group([NormalizedPath::absolute("backend")]);
+    /// ```
+    ///
+    /// Prefixes MUST be absolute and case-canonical (i.e. produced by
+    /// [`NormalizedPath::absolute`]) so they match the walker's current
+    /// path, which is built from `read_dir` entries.
+    #[derive(Debug, Default, Clone)]
+    pub struct FilePrune {
+        groups: Vec<Vec<NormalizedPath>>,
+    }
+
+    impl FilePrune {
+        pub fn new() -> Self { Self::default() }
+
+        /// Add an OR-group. An empty group (no constraint) is dropped so
+        /// it doesn't reject all paths vacuously.
+        pub fn with_group(mut self, prefixes: impl IntoIterator<Item = NormalizedPath>) -> Self {
+            let g: Vec<NormalizedPath> = prefixes.into_iter()
+                .filter(|p| !p.as_str().is_empty())
+                .collect();
+            if !g.is_empty() {
+                self.groups.push(g);
+            }
+            self
+        }
+
+        /// True if `path` passes every OR-group.
+        pub fn allows(&self, path: &NormalizedPath) -> bool {
+            self.groups.iter().all(|group| {
+                group.iter().any(|prefix| paths_compatible(path.as_str(), prefix.as_str()))
+            })
+        }
+
+        /// True if this predicate has no constraints (accepts everything).
+        pub fn is_empty(&self) -> bool { self.groups.is_empty() }
+    }
+
+    /// Two paths are compatible if one is a path-segment-prefix of the
+    /// other. This allows a walker at `/proj` to descend toward a
+    /// constraint `/proj/backend/foo.cs`, and a walker that has already
+    /// reached `/proj/backend/` to emit `/proj/backend/foo.cs`.
+    fn paths_compatible(a: &str, b: &str) -> bool {
+        is_path_prefix(a, b) || is_path_prefix(b, a)
+    }
+
+    fn is_path_prefix(prefix: &str, path: &str) -> bool {
+        if prefix.is_empty() { return true; }
+        if path.len() < prefix.len() { return false; }
+        if !path.as_bytes()[..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes()) {
+            // Use case-insensitive comparison because on Windows the walker's
+            // canonical casing may differ from a user-typed pattern prefix
+            // even after `NormalizedPath::absolute`. On case-sensitive Unix
+            // this is a no-op since both sides already agree.
+            return false;
+        }
+        if prefix.ends_with('/') { return true; }
+        let rest = &path[prefix.len()..];
+        rest.is_empty() || rest.starts_with('/')
+    }
+
     /// Error from canonical glob expansion.
     #[derive(Debug, Clone)]
     pub struct GlobExpandError {
@@ -359,9 +459,14 @@ mod walk {
     /// Symlinks are traversed but use the link name, not the target path.
     ///
     /// Returns at most `limit` files. Returns an error if the limit is exceeded.
+    ///
+    /// If `prune` is `Some`, subtrees that can't contain any path compatible
+    /// with *every* prune group are skipped. This is how sibling patterns
+    /// (e.g. CLI ∩ operation) narrow each other's walk — see [`FilePrune`].
     pub fn expand_canonical(
         pattern: &str,
         limit: usize,
+        prune: Option<&FilePrune>,
     ) -> Result<Vec<NormalizedPath>, GlobExpandError> {
         let normalized = normalize_path(pattern);
 
@@ -393,6 +498,14 @@ mod walk {
         }
         let canonical_root = NormalizedPath::absolute(&root);
 
+        // If a prune predicate is set and doesn't even permit the root, we
+        // can't produce any results — short-circuit before the walk.
+        if let Some(p) = prune {
+            if !p.allows(&canonical_root) {
+                return Ok(vec![]);
+            }
+        }
+
         // Compile the wildcard suffix for matching
         let compiled = CompiledPattern::new(&suffix_pattern).map_err(|e| GlobExpandError {
             pattern: pattern.to_string(),
@@ -401,7 +514,7 @@ mod walk {
         })?;
 
         let mut results = Vec::new();
-        walk_dir(&canonical_root, &canonical_root, "", &compiled, limit, &mut results, 0)
+        walk_dir(&canonical_root, &canonical_root, "", &compiled, limit, prune, &mut results, 0)
             .map_err(|_| GlobExpandError {
                 pattern: pattern.to_string(),
                 message: format!("exceeded {} file limit", limit),
@@ -422,12 +535,14 @@ mod walk {
     /// scanned — each child is built by `current.join_segment(entry_name)`,
     /// reusing the validated parent string without re-normalization.
     /// `relative` is the path relative to `root` used for pattern matching.
+    #[allow(clippy::too_many_arguments)] // recursion state — flattening further would be worse
     fn walk_dir(
         root: &NormalizedPath,
         current: &NormalizedPath,
         relative: &str,
         pattern: &CompiledPattern,
         limit: usize,
+        prune: Option<&FilePrune>,
         results: &mut Vec<NormalizedPath>,
         depth: usize,
     ) -> Result<(), WalkLimitExceeded> {
@@ -455,6 +570,17 @@ mod walk {
             // this preserves the NormalizedPath invariant by construction.
             let child_path = current.join_segment(&name_str);
 
+            // Prune subtrees / files that no prune group admits. For a file,
+            // this is an exact-allows check; for a directory, `allows` still
+            // returns true when the directory is only a path-*prefix* of the
+            // constraint — so walking continues toward the constraint and
+            // resumes unrestricted below it.
+            if let Some(p) = prune {
+                if !p.allows(&child_path) {
+                    continue;
+                }
+            }
+
             let child_relative = if relative.is_empty() {
                 name_str.to_string()
             } else {
@@ -476,7 +602,7 @@ mod walk {
             }
 
             if file_type.is_dir() || (file_type.is_symlink() && entry.path().is_dir()) {
-                walk_dir(root, &child_path, &child_relative, pattern, limit, results, depth + 1)?;
+                walk_dir(root, &child_path, &child_relative, pattern, limit, prune, results, depth + 1)?;
             }
         }
 
@@ -485,7 +611,7 @@ mod walk {
 }
 
 #[cfg(feature = "native")]
-pub use walk::{expand_canonical, GlobExpandError, GlobExpandErrorKind};
+pub use walk::{expand_canonical, pattern_literal_prefix, FilePrune, GlobExpandError, GlobExpandErrorKind};
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -635,17 +761,18 @@ mod tests {
     #[cfg(feature = "native")]
     mod walk_tests {
         use super::super::*;
+        use crate::NormalizedPath;
 
         #[test]
         fn expand_non_glob_returns_as_is() {
-            let result = expand_canonical("some/literal/path.rs", 100).unwrap();
+            let result = expand_canonical("some/literal/path.rs", 100, None).unwrap();
             assert_eq!(result.len(), 1);
             assert_eq!(result[0].as_str(), "some/literal/path.rs");
         }
 
         #[test]
         fn expand_nonexistent_root_returns_empty() {
-            let result = expand_canonical("/nonexistent/path/**/*.rs", 100).unwrap();
+            let result = expand_canonical("/nonexistent/path/**/*.rs", 100, None).unwrap();
             assert!(result.is_empty());
         }
 
@@ -661,7 +788,7 @@ mod tests {
                 return;
             }
 
-            let result = expand_canonical(&pattern, 10000).unwrap();
+            let result = expand_canonical(&pattern, 10000, None).unwrap();
             assert!(!result.is_empty(), "should find .rs files");
 
             // All paths should be normalized (forward slashes, no \\?\)
@@ -687,7 +814,7 @@ mod tests {
                 return;
             }
 
-            let result = expand_canonical(&pattern, 1);
+            let result = expand_canonical(&pattern, 1, None);
             let err = result.expect_err("should fail when exceeding limit of 1");
             assert!(matches!(err.kind, GlobExpandErrorKind::LimitExceeded),
                 "limit overflow must be classified as LimitExceeded, got {:?}", err.kind);
@@ -702,7 +829,7 @@ mod tests {
         /// and expansion short-circuits before the pattern is compiled.
         #[test]
         fn expand_invalid_pattern_kind() {
-            let result = expand_canonical("./*/[abc]/*.rs", 100);
+            let result = expand_canonical("./*/[abc]/*.rs", 100, None);
             let err = result.expect_err("invalid pattern must surface as Err");
             assert!(matches!(err.kind, GlobExpandErrorKind::InvalidPattern),
                 "expected InvalidPattern, got {:?}", err.kind);
@@ -727,7 +854,7 @@ mod tests {
             symlink(&a, a.join("loop")).unwrap();
 
             let pattern = format!("{}/**/*.rs", dir.to_string_lossy());
-            let result = expand_canonical(&pattern, 10_000)
+            let result = expand_canonical(&pattern, 10_000, None)
                 .expect("walker must terminate without returning an error");
 
             // MAX_DEPTH stops the recursion; the real file (at every depth
@@ -737,6 +864,233 @@ mod tests {
                 "walker should still find real.rs before hitting MAX_DEPTH; got: {:?}",
                 result.iter().map(|p| p.as_str()).collect::<Vec<_>>()
             );
+
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        // -- pattern_literal_prefix tests --
+
+        #[test]
+        fn literal_prefix_for_glob_with_dir_prefix() {
+            assert_eq!(pattern_literal_prefix("backend/**/tests/*.cs"), "backend/");
+        }
+
+        #[test]
+        fn literal_prefix_for_deep_dir_prefix() {
+            assert_eq!(
+                pattern_literal_prefix("src/app/modules/*.ts"),
+                "src/app/modules/"
+            );
+        }
+
+        #[test]
+        fn literal_prefix_for_non_glob_returns_full_path() {
+            // Non-glob path — the whole thing is literal (the caller can
+            // choose to treat it as a file-scope constraint).
+            assert_eq!(pattern_literal_prefix("backend/foo.cs"), "backend/foo.cs");
+        }
+
+        #[test]
+        fn literal_prefix_for_leading_wildcard_is_empty() {
+            assert_eq!(pattern_literal_prefix("**/*.cs"), "");
+            assert_eq!(pattern_literal_prefix("*.cs"), "");
+        }
+
+        #[test]
+        fn literal_prefix_stops_at_segment_boundary() {
+            // A wildcard *inside* the first segment yields no literal prefix —
+            // we can't prune to `foo` because `foobar/` also matches.
+            assert_eq!(pattern_literal_prefix("foo*/bar.cs"), "");
+        }
+
+        #[test]
+        fn literal_prefix_normalizes_separators() {
+            // Windows-style separators get normalized to forward slashes
+            // before prefix extraction.
+            assert_eq!(
+                pattern_literal_prefix("backend\\**\\*.cs"),
+                "backend/"
+            );
+        }
+
+        // -- FilePrune tests --
+
+        #[test]
+        fn file_prune_empty_accepts_everything() {
+            let p = FilePrune::new();
+            assert!(p.is_empty());
+            assert!(p.allows(&NormalizedPath::new("/anything/goes/here.cs")));
+            assert!(p.allows(&NormalizedPath::new("")));
+        }
+
+        #[test]
+        fn file_prune_empty_group_is_dropped() {
+            // An empty constraint group would otherwise reject everything
+            // (the any() over zero prefixes is false) — guard against that.
+            let p = FilePrune::new().with_group(std::iter::empty());
+            assert!(p.is_empty(), "empty group must be dropped");
+            assert!(p.allows(&NormalizedPath::new("/foo.cs")));
+        }
+
+        #[test]
+        fn file_prune_accepts_descendants_of_prefix() {
+            let p = FilePrune::new().with_group([NormalizedPath::new("/proj/backend")]);
+            assert!(p.allows(&NormalizedPath::new("/proj/backend")));
+            assert!(p.allows(&NormalizedPath::new("/proj/backend/a.cs")));
+            assert!(p.allows(&NormalizedPath::new("/proj/backend/sub/b.cs")));
+        }
+
+        #[test]
+        fn file_prune_accepts_ancestors_of_prefix() {
+            // Walking *toward* a constraint must be allowed — otherwise
+            // we'd never reach `/proj/backend/` from `/proj/`.
+            let p = FilePrune::new().with_group([NormalizedPath::new("/proj/backend")]);
+            assert!(p.allows(&NormalizedPath::new("/proj")));
+            assert!(p.allows(&NormalizedPath::new("/")));
+        }
+
+        #[test]
+        fn file_prune_rejects_sibling_directories() {
+            let p = FilePrune::new().with_group([NormalizedPath::new("/proj/backend")]);
+            assert!(!p.allows(&NormalizedPath::new("/proj/frontend")));
+            assert!(!p.allows(&NormalizedPath::new("/proj/frontend/a.cs")));
+        }
+
+        #[test]
+        fn file_prune_rejects_segment_boundary_lookalikes() {
+            // `/proj/back` must not accept `/proj/backend` — the prefix
+            // check must split at path segment boundaries.
+            let p = FilePrune::new().with_group([NormalizedPath::new("/proj/back")]);
+            assert!(!p.allows(&NormalizedPath::new("/proj/backend")));
+            assert!(p.allows(&NormalizedPath::new("/proj/back")));
+            assert!(p.allows(&NormalizedPath::new("/proj/back/a.cs")));
+        }
+
+        #[test]
+        fn file_prune_or_within_group() {
+            // Single group with two prefixes — either one satisfies the group.
+            let p = FilePrune::new().with_group([
+                NormalizedPath::new("/proj/backend"),
+                NormalizedPath::new("/proj/frontend"),
+            ]);
+            assert!(p.allows(&NormalizedPath::new("/proj/backend/a.cs")));
+            assert!(p.allows(&NormalizedPath::new("/proj/frontend/b.cs")));
+            assert!(!p.allows(&NormalizedPath::new("/proj/docs/c.md")));
+        }
+
+        #[test]
+        fn file_prune_and_across_groups() {
+            // Two groups — path must satisfy both. Group 1 restricts to
+            // `/proj/backend` OR `/proj/frontend`; group 2 restricts to
+            // `/proj/backend` OR `/proj/docs`. Only `/proj/backend` is
+            // compatible with both groups.
+            let p = FilePrune::new()
+                .with_group([
+                    NormalizedPath::new("/proj/backend"),
+                    NormalizedPath::new("/proj/frontend"),
+                ])
+                .with_group([
+                    NormalizedPath::new("/proj/backend"),
+                    NormalizedPath::new("/proj/docs"),
+                ]);
+            assert!(p.allows(&NormalizedPath::new("/proj/backend/a.cs")));
+            assert!(!p.allows(&NormalizedPath::new("/proj/frontend/a.cs")));
+            assert!(!p.allows(&NormalizedPath::new("/proj/docs/a.cs")));
+            // Ancestor — compatible with both groups.
+            assert!(p.allows(&NormalizedPath::new("/proj")));
+        }
+
+        // -- pruning walker integration tests --
+
+        /// The user's primary use case 1: scope to a directory. A CLI
+        /// constraint of `backend/**/*.cs` should prevent the walker from
+        /// ever descending into `frontend/`, even when expanding a broad
+        /// rule-side pattern like `**/*.cs`.
+        #[test]
+        fn walk_with_prune_skips_non_compatible_subtrees() {
+            let dir = std::env::temp_dir().join("tractor_prune_dir_scope");
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(dir.join("backend")).unwrap();
+            std::fs::create_dir_all(dir.join("frontend")).unwrap();
+            std::fs::write(dir.join("backend/a.cs"), "").unwrap();
+            std::fs::write(dir.join("frontend/b.cs"), "").unwrap();
+
+            let backend_prefix = NormalizedPath::absolute(
+                dir.join("backend").to_string_lossy().as_ref(),
+            );
+            let prune = FilePrune::new().with_group([backend_prefix]);
+
+            let pattern = format!(
+                "{}/**/*.cs",
+                normalize_path(&dir.to_string_lossy())
+            );
+            let result = expand_canonical(&pattern, 100, Some(&prune)).unwrap();
+
+            let names: Vec<&str> = result.iter()
+                .map(|p| p.as_str().rsplit('/').next().unwrap())
+                .collect();
+            assert!(names.contains(&"a.cs"), "backend/a.cs must be found: {:?}", names);
+            assert!(!names.contains(&"b.cs"), "frontend/b.cs must be pruned: {:?}", names);
+
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        /// The user's primary use case 2: scope to a single file. A CLI
+        /// constraint pointing at one specific file should narrow a broad
+        /// rule-side `**/*.cs` pattern to just that file.
+        #[test]
+        fn walk_with_prune_scopes_to_single_file() {
+            let dir = std::env::temp_dir().join("tractor_prune_file_scope");
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(dir.join("src")).unwrap();
+            std::fs::write(dir.join("src/a.cs"), "").unwrap();
+            std::fs::write(dir.join("src/b.cs"), "").unwrap();
+            std::fs::write(dir.join("src/c.cs"), "").unwrap();
+
+            let single_file = NormalizedPath::absolute(
+                dir.join("src/b.cs").to_string_lossy().as_ref(),
+            );
+            let prune = FilePrune::new().with_group([single_file]);
+
+            let pattern = format!(
+                "{}/**/*.cs",
+                normalize_path(&dir.to_string_lossy())
+            );
+            let result = expand_canonical(&pattern, 100, Some(&prune)).unwrap();
+
+            assert_eq!(result.len(), 1, "only the scoped file should be returned: {:?}",
+                result.iter().map(|p| p.as_str()).collect::<Vec<_>>());
+            assert!(result[0].as_str().ends_with("/src/b.cs"),
+                "expected src/b.cs, got {}", result[0].as_str());
+
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        /// When the prune prefix points outside the expansion root entirely,
+        /// the walker must short-circuit (return empty) rather than produce
+        /// stray matches — otherwise the intersection semantics would leak.
+        #[test]
+        fn walk_with_prune_outside_root_returns_empty() {
+            let dir = std::env::temp_dir().join("tractor_prune_disjoint");
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(dir.join("backend")).unwrap();
+            std::fs::write(dir.join("backend/a.cs"), "").unwrap();
+
+            // Prune prefix points at a sibling directory that doesn't even
+            // exist in the walk — no path the walker produces can satisfy it.
+            let disjoint = NormalizedPath::absolute(
+                std::env::temp_dir().join("some_other_unrelated_tree").to_string_lossy().as_ref(),
+            );
+            let prune = FilePrune::new().with_group([disjoint]);
+
+            let pattern = format!(
+                "{}/**/*.cs",
+                normalize_path(&dir.to_string_lossy())
+            );
+            let result = expand_canonical(&pattern, 100, Some(&prune)).unwrap();
+            assert!(result.is_empty(),
+                "disjoint prune must short-circuit the walk: {:?}",
+                result.iter().map(|p| p.as_str()).collect::<Vec<_>>());
 
             std::fs::remove_dir_all(&dir).ok();
         }
@@ -753,7 +1107,7 @@ mod tests {
                 return;
             }
 
-            let result = expand_canonical(&pattern, 10000).unwrap();
+            let result = expand_canonical(&pattern, 10000, None).unwrap();
             // Verify paths match what canonicalize would return
             for p in result.iter().take(3) {
                 #[allow(clippy::disallowed_methods)] // test verifies canonical walker output

--- a/tractor-core/src/glob_match.rs
+++ b/tractor-core/src/glob_match.rs
@@ -683,7 +683,22 @@ mod tests {
             }
 
             let result = expand_canonical(&pattern, 1);
-            assert!(result.is_err(), "should fail when exceeding limit of 1");
+            let err = result.expect_err("should fail when exceeding limit of 1");
+            assert!(matches!(err.kind, GlobExpandErrorKind::LimitExceeded),
+                "limit overflow must be classified as LimitExceeded, got {:?}", err.kind);
+        }
+
+        /// `expand_canonical` must classify a malformed wildcard suffix as
+        /// `InvalidPattern` so callers (e.g. `expand_globs_checked`) don't
+        /// confuse it with a limit overflow. Pattern below puts a `[...]`
+        /// character class after the first `*`, so it lands in the
+        /// `CompiledPattern::new()` failure path.
+        #[test]
+        fn expand_invalid_pattern_kind() {
+            let result = expand_canonical("/tmp/*/[abc]/*.rs", 100);
+            let err = result.expect_err("invalid pattern must surface as Err");
+            assert!(matches!(err.kind, GlobExpandErrorKind::InvalidPattern),
+                "expected InvalidPattern, got {:?}", err.kind);
         }
 
         #[cfg(target_os = "windows")]

--- a/tractor-core/src/glob_match.rs
+++ b/tractor-core/src/glob_match.rs
@@ -59,9 +59,8 @@ enum Segment {
 
 /// A compiled glob pattern for matching against normalized path strings.
 ///
-/// Supports `*` (single-segment wildcard), `**` (recursive), and `?`
-/// (single character). Case sensitivity is determined at compile time
-/// based on the target OS.
+/// Supports `*` (single-segment wildcard) and `**` (recursive).
+/// Case sensitivity is determined at compile time based on the target OS.
 #[derive(Debug, Clone)]
 pub struct CompiledPattern {
     segments: Vec<Segment>,
@@ -74,9 +73,9 @@ impl CompiledPattern {
     /// The pattern uses `/` as separator (normalized). Supported wildcards:
     /// - `*` matches any characters within a single path component
     /// - `**` matches zero or more path components
-    /// - `?` matches exactly one character (not `/`)
     ///
-    /// Returns an error for unsupported syntax (`[...]`).
+    /// Returns an error for unsupported syntax: character classes (`[...]`)
+    /// and single-character wildcards (`?`).
     pub fn new(pattern: &str) -> Result<Self, GlobCompileError> {
         let normalized = normalize_path(pattern);
 
@@ -84,6 +83,13 @@ impl CompiledPattern {
             return Err(GlobCompileError {
                 pattern: normalized,
                 message: "character classes [...] are not supported".into(),
+            });
+        }
+
+        if normalized.contains('?') {
+            return Err(GlobCompileError {
+                pattern: normalized,
+                message: "`?` single-character wildcard is not supported; use `*` instead".into(),
             });
         }
 
@@ -104,7 +110,7 @@ impl CompiledPattern {
                 if !matches!(segments.last(), Some(Segment::DoubleStar)) {
                     segments.push(Segment::DoubleStar);
                 }
-            } else if part.contains('*') || part.contains('?') {
+            } else if part.contains('*') {
                 segments.push(compile_wild_segment(part, case_insensitive));
             } else {
                 let lit = if case_insensitive {
@@ -130,7 +136,7 @@ impl CompiledPattern {
                     if !matches!(abs_segments.last(), Some(Segment::DoubleStar)) {
                         abs_segments.push(Segment::DoubleStar);
                     }
-                } else if part.contains('*') || part.contains('?') {
+                } else if part.contains('*') {
                     abs_segments.push(compile_wild_segment(part, case_insensitive));
                 } else {
                     let lit = if case_insensitive {
@@ -158,10 +164,8 @@ impl CompiledPattern {
     }
 }
 
-/// Compile a single wildcard segment (contains `*` or `?`).
+/// Compile a single wildcard segment (contains `*`).
 fn compile_wild_segment(part: &str, case_insensitive: bool) -> Segment {
-    // Expand `?` into a representation we can match.
-    // For simplicity, store the raw pattern and match character-by-character.
     let part = if case_insensitive {
         part.to_ascii_lowercase()
     } else {
@@ -322,11 +326,22 @@ mod walk {
     /// Maximum directory depth to prevent symlink cycle hangs.
     const MAX_DEPTH: usize = 100;
 
+    /// Classifies why a glob expansion failed, so callers can react
+    /// structurally instead of string-matching the error message.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum GlobExpandErrorKind {
+        /// The expansion produced more paths than the caller's limit allowed.
+        LimitExceeded,
+        /// The pattern itself was invalid (e.g. unsupported syntax).
+        InvalidPattern,
+    }
+
     /// Error from canonical glob expansion.
     #[derive(Debug, Clone)]
     pub struct GlobExpandError {
         pub pattern: String,
         pub message: String,
+        pub kind: GlobExpandErrorKind,
     }
 
     impl fmt::Display for GlobExpandError {
@@ -351,13 +366,13 @@ mod walk {
         let normalized = normalize_path(pattern);
 
         // Non-glob pattern: return as-is
-        if !normalized.contains('*') && !normalized.contains('?') {
+        if !normalized.contains('*') {
             return Ok(vec![NormalizedPath::new(&normalized)]);
         }
 
         // Split into root prefix (literal) and wildcard suffix
         let parts: Vec<&str> = normalized.split('/').collect();
-        let first_wild = parts.iter().position(|p| p.contains('*') || p.contains('?'))
+        let first_wild = parts.iter().position(|p| p.contains('*'))
             .unwrap(); // safe: we checked for wildcards above
 
         let root = if first_wild == 0 {
@@ -379,17 +394,22 @@ mod walk {
         let compiled = CompiledPattern::new(&suffix_pattern).map_err(|e| GlobExpandError {
             pattern: pattern.to_string(),
             message: e.message,
+            kind: GlobExpandErrorKind::InvalidPattern,
         })?;
 
         let mut results = Vec::new();
         walk_dir(&canonical_root, "", &compiled, limit, &mut results, 0)
-            .map_err(|msg| GlobExpandError {
+            .map_err(|_| GlobExpandError {
                 pattern: pattern.to_string(),
-                message: msg,
+                message: format!("exceeded {} file limit", limit),
+                kind: GlobExpandErrorKind::LimitExceeded,
             })?;
 
         Ok(results)
     }
+
+    /// Marker error type returned when the walker exceeds the expansion limit.
+    struct WalkLimitExceeded;
 
     /// Recursively walk a directory, matching relative paths against the compiled pattern.
     fn walk_dir(
@@ -399,9 +419,17 @@ mod walk {
         limit: usize,
         results: &mut Vec<NormalizedPath>,
         depth: usize,
-    ) -> Result<(), String> {
+    ) -> Result<(), WalkLimitExceeded> {
         if depth > MAX_DEPTH {
-            return Ok(()); // silently stop — likely a symlink cycle
+            eprintln!(
+                "warning: glob walker reached max depth ({}) at '{}{}{}' — \
+                 skipping deeper entries (may indicate a symlink cycle or unusually deep tree)",
+                MAX_DEPTH,
+                root,
+                if relative.is_empty() { "" } else { "/" },
+                relative,
+            );
+            return Ok(());
         }
 
         let full_dir = if relative.is_empty() {
@@ -434,7 +462,7 @@ mod walk {
                 if pattern.matches(&child_relative) {
                     results.push(NormalizedPath::new(&format!("{}/{}", root, child_relative)));
                     if results.len() > limit {
-                        return Err(format!("exceeded {} file limit", limit));
+                        return Err(WalkLimitExceeded);
                     }
                 }
             }
@@ -449,7 +477,7 @@ mod walk {
 }
 
 #[cfg(feature = "native")]
-pub use walk::{expand_canonical, GlobExpandError};
+pub use walk::{expand_canonical, GlobExpandError, GlobExpandErrorKind};
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -563,6 +591,14 @@ mod tests {
     #[test]
     fn rejects_character_classes() {
         assert!(CompiledPattern::new("src/[abc]/*.rs").is_err());
+    }
+
+    #[test]
+    fn rejects_question_mark_wildcard() {
+        // `?` was previously silently accepted but never actually matched —
+        // it's now rejected at compile time with a clear error.
+        let err = CompiledPattern::new("file?.rs").unwrap_err();
+        assert!(err.message.contains("`?`"), "error should mention `?`: {}", err.message);
     }
 
     #[cfg(target_os = "windows")]

--- a/tractor-core/src/glob_match.rs
+++ b/tractor-core/src/glob_match.rs
@@ -384,11 +384,14 @@ mod walk {
 
         let suffix_pattern = parts[first_wild..].join("/");
 
-        // Canonicalize root for true filesystem casing
-        let canonical_root = match std::fs::canonicalize(&root) {
-            Ok(p) => normalize_path(&p.to_string_lossy()),
-            Err(_) => return Ok(vec![]), // root doesn't exist → empty
-        };
+        // Resolve the root: absolute + lexically normalized, with true
+        // filesystem casing on Windows. Does NOT resolve symlinks — paths
+        // built from `read_dir` further down keep the symlink name, so
+        // glob-expanded paths match CLI args that also use the link name.
+        if !std::path::Path::new(&root).exists() {
+            return Ok(vec![]); // root doesn't exist → empty
+        }
+        let canonical_root = NormalizedPath::absolute(&root).into_string();
 
         // Compile the wildcard suffix for matching
         let compiled = CompiledPattern::new(&suffix_pattern).map_err(|e| GlobExpandError {

--- a/tractor-core/src/glob_match.rs
+++ b/tractor-core/src/glob_match.rs
@@ -701,6 +701,39 @@ mod tests {
                 "expected InvalidPattern, got {:?}", err.kind);
         }
 
+        /// A symlink cycle (`a/loop → a`) must not hang the walker. The
+        /// MAX_DEPTH guard logs a warning and returns `Ok`, so expansion
+        /// completes and non-cyclic files inside the cycle are still found.
+        #[cfg(unix)]
+        #[test]
+        fn walk_terminates_on_symlink_cycle() {
+            use std::os::unix::fs::symlink;
+
+            let dir = std::env::temp_dir().join("tractor_test_cycle");
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+
+            let a = dir.join("a");
+            std::fs::create_dir(&a).unwrap();
+            std::fs::write(a.join("real.rs"), "").unwrap();
+            // a/loop → a creates the cycle.
+            symlink(&a, a.join("loop")).unwrap();
+
+            let pattern = format!("{}/**/*.rs", dir.to_string_lossy());
+            let result = expand_canonical(&pattern, 10_000)
+                .expect("walker must terminate without returning an error");
+
+            // MAX_DEPTH stops the recursion; the real file (at every depth
+            // up to the cutoff) shows up in the results.
+            assert!(
+                result.iter().any(|p| p.as_str().ends_with("/real.rs")),
+                "walker should still find real.rs before hitting MAX_DEPTH; got: {:?}",
+                result.iter().map(|p| p.as_str()).collect::<Vec<_>>()
+            );
+
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
         #[cfg(target_os = "windows")]
         #[test]
         fn expand_returns_canonical_casing() {

--- a/tractor-core/src/glob_match.rs
+++ b/tractor-core/src/glob_match.rs
@@ -391,7 +391,7 @@ mod walk {
         if !std::path::Path::new(&root).exists() {
             return Ok(vec![]); // root doesn't exist → empty
         }
-        let canonical_root = NormalizedPath::absolute(&root).into_string();
+        let canonical_root = NormalizedPath::absolute(&root);
 
         // Compile the wildcard suffix for matching
         let compiled = CompiledPattern::new(&suffix_pattern).map_err(|e| GlobExpandError {
@@ -401,7 +401,7 @@ mod walk {
         })?;
 
         let mut results = Vec::new();
-        walk_dir(&canonical_root, "", &compiled, limit, &mut results, 0)
+        walk_dir(&canonical_root, &canonical_root, "", &compiled, limit, &mut results, 0)
             .map_err(|_| GlobExpandError {
                 pattern: pattern.to_string(),
                 message: format!("exceeded {} file limit", limit),
@@ -414,9 +414,17 @@ mod walk {
     /// Marker error type returned when the walker exceeds the expansion limit.
     struct WalkLimitExceeded;
 
-    /// Recursively walk a directory, matching relative paths against the compiled pattern.
+    /// Recursively walk a directory, matching relative paths against the
+    /// compiled pattern.
+    ///
+    /// `root` is the normalized base of the walk (used for the warning message
+    /// only). `current` is the normalized absolute path of the directory being
+    /// scanned — each child is built by `current.join_segment(entry_name)`,
+    /// reusing the validated parent string without re-normalization.
+    /// `relative` is the path relative to `root` used for pattern matching.
     fn walk_dir(
-        root: &str,
+        root: &NormalizedPath,
+        current: &NormalizedPath,
         relative: &str,
         pattern: &CompiledPattern,
         limit: usize,
@@ -425,23 +433,15 @@ mod walk {
     ) -> Result<(), WalkLimitExceeded> {
         if depth > MAX_DEPTH {
             eprintln!(
-                "warning: glob walker reached max depth ({}) at '{}{}{}' — \
+                "warning: glob walker reached max depth ({}) at '{}' — \
                  skipping deeper entries (may indicate a symlink cycle or unusually deep tree)",
                 MAX_DEPTH,
-                root,
-                if relative.is_empty() { "" } else { "/" },
-                relative,
+                current,
             );
             return Ok(());
         }
 
-        let full_dir = if relative.is_empty() {
-            root.to_string()
-        } else {
-            format!("{}/{}", root, relative)
-        };
-
-        let entries = match std::fs::read_dir(&full_dir) {
+        let entries = match std::fs::read_dir(current.as_str()) {
             Ok(e) => e,
             Err(_) => return Ok(()), // permission denied, etc. — skip silently
         };
@@ -449,6 +449,11 @@ mod walk {
         for entry in entries.flatten() {
             let name = entry.file_name();
             let name_str = name.to_string_lossy();
+
+            // Extend the already-normalized parent with the raw entry name.
+            // `read_dir` yields single path components (no separators), so
+            // this preserves the NormalizedPath invariant by construction.
+            let child_path = current.join_segment(&name_str);
 
             let child_relative = if relative.is_empty() {
                 name_str.to_string()
@@ -463,7 +468,7 @@ mod walk {
 
             if file_type.is_file() || (file_type.is_symlink() && entry.path().is_file()) {
                 if pattern.matches(&child_relative) {
-                    results.push(NormalizedPath::new(&format!("{}/{}", root, child_relative)));
+                    results.push(child_path.clone());
                     if results.len() > limit {
                         return Err(WalkLimitExceeded);
                     }
@@ -471,7 +476,7 @@ mod walk {
             }
 
             if file_type.is_dir() || (file_type.is_symlink() && entry.path().is_dir()) {
-                walk_dir(root, &child_relative, pattern, limit, results, depth + 1)?;
+                walk_dir(root, &child_path, &child_relative, pattern, limit, results, depth + 1)?;
             }
         }
 

--- a/tractor-core/src/lib.rs
+++ b/tractor-core/src/lib.rs
@@ -59,7 +59,7 @@ pub use rule::{Rule, RuleSet};
 #[cfg(feature = "native")]
 pub use rule::{GlobMatcher, GlobError};
 #[cfg(feature = "native")]
-pub use files::{expand_globs, expand_globs_checked, filter_supported_files, GlobExpansion, GlobExpansionError};
+pub use files::{expand_globs, expand_globs_checked, GlobExpansion, GlobExpansionError};
 pub use xot_builder::{XotBuilder, XeeBuilder};
 pub use normalized_xpath::NormalizedXpath;
 pub use normalized_path::NormalizedPath;

--- a/tractor-core/src/lib.rs
+++ b/tractor-core/src/lib.rs
@@ -66,5 +66,5 @@ pub use normalized_path::NormalizedPath;
 pub use glob_pattern::GlobPattern;
 pub use glob_match::CompiledPattern;
 #[cfg(feature = "native")]
-pub use glob_match::{expand_canonical, GlobExpandError};
+pub use glob_match::{expand_canonical, pattern_literal_prefix, FilePrune, GlobExpandError};
 pub use tree_mode::TreeMode;

--- a/tractor-core/src/normalized_path.rs
+++ b/tractor-core/src/normalized_path.rs
@@ -61,11 +61,6 @@ impl NormalizedPath {
         &self.0
     }
 
-    /// Consume and return the inner String.
-    pub fn into_string(self) -> String {
-        self.0
-    }
-
     /// Make a relative path absolute by joining with `cwd`, normalizing
     /// lexically (collapsing `.`/`..`) and — on Windows — case-correcting
     /// each existing path component against the true filesystem casing.
@@ -594,6 +589,7 @@ mod tests {
         // path (may contain 8.3 on CI) and comparing to the long form
         // obtained via canonicalize (strip `\\?\` via NormalizedPath::new).
         let resolved = NormalizedPath::absolute(&tmp.to_string_lossy());
+        #[allow(clippy::disallowed_methods)] // test cross-checks against real canonical form
         let canonical = std::fs::canonicalize(&tmp).unwrap();
         let long_form = NormalizedPath::new(&canonical.to_string_lossy());
         assert_eq!(

--- a/tractor-core/src/normalized_path.rs
+++ b/tractor-core/src/normalized_path.rs
@@ -59,17 +59,18 @@ impl NormalizedPath {
     }
 }
 
-/// Case-correct each existing component of an absolute path against the
-/// true filesystem casing. No-op on non-Windows platforms.
+/// Normalize casing and 8.3 short-name aliases of an existing path
+/// against the true filesystem form. No-op on non-Windows platforms.
 ///
-/// On Windows, walks the path component by component, calling `read_dir`
-/// on each parent to find the entry whose name matches case-insensitively,
-/// then appends that entry's name (which has true filesystem casing).
-/// Does not resolve symlinks — unlike `std::fs::canonicalize`.
+/// On Windows we use `GetLongPathNameW`, which:
+/// - Resolves 8.3 short-name aliases (`RUNNER~1` → `runneradmin`) that
+///   CMD and legacy tools sometimes pass in.
+/// - Returns the path using the true filesystem casing.
+/// - Does NOT follow symlinks — unlike `std::fs::canonicalize`.
 ///
-/// Stops correcting at the first missing component (pushes the remaining
-/// components as-is). Paths where the parent can't be read (permissions,
-/// missing) are returned unchanged from that point.
+/// If the full path doesn't exist, we walk up to the nearest existing
+/// ancestor, resolve it, then re-append the missing components as-is.
+/// The drive letter is uppercased for consistency regardless.
 #[cfg(not(windows))]
 fn case_correct_existing(path: &Path) -> PathBuf {
     path.to_path_buf()
@@ -77,65 +78,97 @@ fn case_correct_existing(path: &Path) -> PathBuf {
 
 #[cfg(windows)]
 fn case_correct_existing(path: &Path) -> PathBuf {
-    let mut result = PathBuf::new();
-    let mut components = path.components();
+    // Find the longest existing ancestor to hand to GetLongPathName.
+    // `ancestors()` yields `path` itself first, then shorter prefixes;
+    // the drive root (e.g. `C:\`) always exists so this eventually
+    // finds something.
+    let anchor = path.ancestors().find(|p| p.exists());
 
-    // Copy the prefix (drive letter) and root directory verbatim.
-    // Case of a drive letter is not something `read_dir` can tell us;
-    // upstream `normalize_path` / the rest of the pipeline handles that.
-    while let Some(comp) = components.clone().next() {
-        match comp {
-            Component::Prefix(_) | Component::RootDir => {
-                result.push(comp.as_os_str());
-                components.next();
-            }
-            _ => break,
+    let resolved = if let Some(anchor) = anchor {
+        let long = get_long_path_name(anchor).unwrap_or_else(|| anchor.to_path_buf());
+        // Re-append any trailing components that didn't exist yet.
+        let anchor_comps = anchor.components().count();
+        let mut result = long;
+        for comp in path.components().skip(anchor_comps) {
+            result.push(comp.as_os_str());
         }
+        result
+    } else {
+        path.to_path_buf()
+    };
+
+    uppercase_drive_letter(resolved)
+}
+
+/// Uppercase the ASCII drive letter prefix of a Windows path, if any.
+/// `GetLongPathName` preserves whatever casing the caller passed in for
+/// the drive letter, so we normalize it here for consistent intersection.
+#[cfg(windows)]
+fn uppercase_drive_letter(path: PathBuf) -> PathBuf {
+    use std::path::Prefix;
+    let mut comps = path.components();
+    let first = match comps.next() {
+        Some(c) => c,
+        None => return path,
+    };
+    let prefix_str: std::ffi::OsString = match first {
+        Component::Prefix(p) => match p.kind() {
+            Prefix::Disk(letter) => {
+                format!("{}:", (letter as char).to_ascii_uppercase()).into()
+            }
+            Prefix::VerbatimDisk(letter) => {
+                format!(r"\\?\{}:", (letter as char).to_ascii_uppercase()).into()
+            }
+            _ => return path, // unsupported prefix shape — leave untouched
+        },
+        _ => return path, // no drive prefix — nothing to uppercase
+    };
+    let mut result = PathBuf::from(prefix_str);
+    for c in comps {
+        result.push(c.as_os_str());
+    }
+    result
+}
+
+/// Call the Windows `GetLongPathNameW` API to resolve 8.3 short names
+/// and get the true filesystem casing, without following symlinks.
+/// Returns `None` if the call fails (e.g. the path doesn't exist).
+#[cfg(windows)]
+fn get_long_path_name(path: &Path) -> Option<PathBuf> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GetLongPathNameW(
+            lpsz_short_path: *const u16,
+            lpsz_long_path: *mut u16,
+            cch_buffer: u32,
+        ) -> u32;
     }
 
-    // Case-correct remaining components via read_dir.
-    loop {
-        let comp = match components.next() {
-            Some(c) => c,
-            None => return result,
-        };
-        let name = comp.as_os_str();
-        let entries = match std::fs::read_dir(&result) {
-            Ok(e) => e,
-            Err(_) => {
-                // Parent can't be read — stop correcting, push rest as-is.
-                result.push(name);
-                for rest in components {
-                    result.push(rest.as_os_str());
-                }
-                return result;
-            }
-        };
+    let wide: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
 
-        let mut found: Option<std::ffi::OsString> = None;
-        for entry in entries.flatten() {
-            let entry_name = entry.file_name();
-            if entry_name.to_string_lossy()
-                .eq_ignore_ascii_case(&name.to_string_lossy())
-            {
-                found = Some(entry_name);
-                break;
-            }
-        }
-
-        match found {
-            Some(n) => result.push(n),
-            None => {
-                // Missing component — push as-is and stop correcting
-                // (we can't read_dir into something that doesn't exist).
-                result.push(name);
-                for rest in components {
-                    result.push(rest.as_os_str());
-                }
-                return result;
-            }
-        }
+    // First call with a null buffer returns the required size *including*
+    // the terminating null; 0 means the call failed (path missing, etc).
+    let needed = unsafe { GetLongPathNameW(wide.as_ptr(), std::ptr::null_mut(), 0) };
+    if needed == 0 {
+        return None;
     }
+
+    let mut buf = vec![0u16; needed as usize];
+    // Second call returns the length *excluding* the terminating null.
+    let written = unsafe { GetLongPathNameW(wide.as_ptr(), buf.as_mut_ptr(), needed) };
+    if written == 0 || written >= needed {
+        return None;
+    }
+
+    buf.truncate(written as usize);
+    Some(PathBuf::from(OsString::from_wide(&buf)))
 }
 
 fn normalize_lexically(path: &Path) -> PathBuf {
@@ -365,24 +398,73 @@ mod tests {
     }
 
     /// Fix #127 bug 1: on Windows, two paths differing only in case must
-    /// produce the same NormalizedPath after absolute(). Handled by the
-    /// Windows-only `case_correct_existing` helper, which walks each
-    /// component via `read_dir` to find the true filesystem casing
-    /// (without following symlinks, unlike `std::fs::canonicalize`).
+    /// produce the same NormalizedPath after absolute(). This also
+    /// covers 8.3 short-name aliases (e.g. `RUNNER~1` passed from CMD
+    /// or legacy tools) — both are handled by `GetLongPathNameW`.
     #[cfg(windows)]
     #[test]
     fn absolute_case_insensitive_on_windows() {
+        // Use the raw tempdir directly. On GitHub Actions runners this
+        // contains the 8.3 short-name alias `RUNNER~1`, which is exactly
+        // the CMD-prompt scenario we want to cover.
         let tmp = std::env::temp_dir().join("tractor_test_CaseCheck.txt");
         std::fs::write(&tmp, "").unwrap();
 
-        let lower = tmp.to_string_lossy().to_lowercase();
-        let upper = tmp.to_string_lossy().to_uppercase();
+        let path_str = tmp.to_string_lossy();
+        let lower = path_str.to_lowercase();
+        let upper = path_str.to_uppercase();
 
         let from_lower = NormalizedPath::absolute(&lower);
         let from_upper = NormalizedPath::absolute(&upper);
         assert_eq!(
             from_lower, from_upper,
             "absolute() must produce the same path regardless of input casing on Windows"
+        );
+
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    /// Windows: drive letters are always uppercased to give consistent
+    /// casing across inputs, even when the filesystem root `read_dir`
+    /// lookup can't help (the drive letter is not a `read_dir` entry).
+    #[cfg(windows)]
+    #[test]
+    fn absolute_uppercases_drive_letter_on_windows() {
+        let tmp = std::env::temp_dir().join("tractor_test_DriveCase.txt");
+        std::fs::write(&tmp, "").unwrap();
+
+        let path_str = tmp.to_string_lossy().into_owned();
+        // Force a lowercase drive letter on the input.
+        assert!(path_str.len() >= 2 && path_str.as_bytes()[1] == b':');
+        let mut lowered = path_str.clone();
+        lowered.replace_range(0..1, &path_str[0..1].to_ascii_lowercase());
+
+        let result = NormalizedPath::absolute(&lowered);
+        // First character of the result must be an uppercase drive letter.
+        let first = result.as_str().chars().next().unwrap();
+        assert!(first.is_ascii_uppercase(), "drive letter should be uppercased, got: {}", result);
+
+        std::fs::remove_file(&tmp).ok();
+    }
+
+    /// Windows: 8.3 short-name aliases (`RUNNER~1`, `PROGRA~1`, etc.)
+    /// must resolve to the long form so that short-name input from CMD
+    /// intersects with glob-expanded long-form paths.
+    #[cfg(windows)]
+    #[test]
+    fn absolute_resolves_83_short_names_on_windows() {
+        let tmp = std::env::temp_dir().join("tractor_test_ShortName.txt");
+        std::fs::write(&tmp, "").unwrap();
+
+        // Resolve to the long form by handing `absolute()` the raw tempdir
+        // path (may contain 8.3 on CI) and comparing to the long form
+        // obtained via canonicalize (strip `\\?\` via NormalizedPath::new).
+        let resolved = NormalizedPath::absolute(&tmp.to_string_lossy());
+        let canonical = std::fs::canonicalize(&tmp).unwrap();
+        let long_form = NormalizedPath::new(&canonical.to_string_lossy());
+        assert_eq!(
+            resolved, long_form,
+            "absolute() must resolve 8.3 short names to the long form"
         );
 
         std::fs::remove_file(&tmp).ok();

--- a/tractor-core/src/normalized_path.rs
+++ b/tractor-core/src/normalized_path.rs
@@ -23,6 +23,39 @@ impl NormalizedPath {
         Self(normalize_path_str(raw))
     }
 
+    /// Construct an empty `NormalizedPath`. Useful as an accumulator start
+    /// for [`Self::join_segment`].
+    pub fn empty() -> Self {
+        Self(String::new())
+    }
+
+    /// Append a single path component to this (already normalized) path.
+    ///
+    /// The parent string is reused verbatim — no re-scan, no re-normalization.
+    /// This is the hierarchical construction primitive: `read_dir` entry
+    /// names arrive as plain segments (no separator), and appending them to
+    /// an already-normalized parent yields a normalized child by construction.
+    ///
+    /// The segment MUST NOT contain `/` or `\` (those would smuggle in
+    /// unverified path structure). In debug builds this is asserted; in
+    /// release we still split on any stray separators and append each piece
+    /// as its own component, so we never produce an un-normalized value.
+    pub fn join_segment(&self, segment: &str) -> Self {
+        debug_assert!(
+            !segment.contains('/') && !segment.contains('\\'),
+            "join_segment expects a single path component, got {segment:?}"
+        );
+        let mut out = String::with_capacity(self.0.len() + 1 + segment.len());
+        out.push_str(&self.0);
+        for part in segment.split(|c| c == '/' || c == '\\').filter(|p| !p.is_empty()) {
+            if !out.is_empty() && !out.ends_with('/') {
+                out.push('/');
+            }
+            out.push_str(part);
+        }
+        Self(out)
+    }
+
     /// Return the normalized path as a string slice.
     pub fn as_str(&self) -> &str {
         &self.0
@@ -354,6 +387,27 @@ mod tests {
     #[test]
     fn normalizes_backslashes() {
         assert_eq!(NormalizedPath::new("src\\foo.rs"), "src/foo.rs");
+    }
+
+    #[test]
+    fn join_segment_appends_with_slash() {
+        let root = NormalizedPath::new("/tmp/project");
+        let child = root.join_segment("src");
+        assert_eq!(child, "/tmp/project/src");
+        let grand = child.join_segment("foo.rs");
+        assert_eq!(grand, "/tmp/project/src/foo.rs");
+    }
+
+    #[test]
+    fn join_segment_onto_empty_produces_plain_component() {
+        assert_eq!(NormalizedPath::empty().join_segment("foo"), "foo");
+    }
+
+    #[test]
+    fn join_segment_preserves_trailing_slash() {
+        // Root-only prefixes ("/", "C:/") already end in `/` — don't double it.
+        let root = NormalizedPath::new("/");
+        assert_eq!(root.join_segment("etc"), "/etc");
     }
 
     #[test]

--- a/tractor-core/src/normalized_path.rs
+++ b/tractor-core/src/normalized_path.rs
@@ -33,13 +33,17 @@ impl NormalizedPath {
         self.0
     }
 
-    /// Make a relative path absolute by joining with `cwd`.
-    /// If already absolute, just normalizes.
+    /// Make a relative path absolute by joining with `cwd`, normalizing
+    /// lexically (collapsing `.`/`..`) and — on Windows — case-correcting
+    /// each existing path component against the true filesystem casing.
     ///
-    /// Uses `std::fs::canonicalize` when the file exists to resolve symlinks
-    /// and — on Windows — get the true filesystem casing. This prevents
-    /// intersection failures caused by `current_dir()` returning a different
-    /// casing than `canonicalize()` used on config paths (fix #127).
+    /// This deliberately does **not** resolve symlinks, on any platform:
+    /// a symlink passed on the CLI stays at the symlink path, so it can
+    /// still intersect with glob-expanded paths that also use the link
+    /// name. This matches the glob walker's behavior (which builds paths
+    /// from `read_dir` entry names).
+    ///
+    /// Missing components are kept as-is without case correction.
     pub fn absolute(raw: &str) -> Self {
         let p = Path::new(raw);
         let full = if p.is_absolute() {
@@ -49,11 +53,88 @@ impl NormalizedPath {
         } else {
             return Self::new(raw);
         };
-        // Prefer canonicalize for consistent casing (Windows) and symlink resolution.
-        // Fall back to lexical normalization when the path doesn't exist yet.
-        let resolved = std::fs::canonicalize(&full)
-            .unwrap_or_else(|_| normalize_lexically(&full));
+        let lexical = normalize_lexically(&full);
+        let resolved = case_correct_existing(&lexical);
         Self::new(&resolved.to_string_lossy())
+    }
+}
+
+/// Case-correct each existing component of an absolute path against the
+/// true filesystem casing. No-op on non-Windows platforms.
+///
+/// On Windows, walks the path component by component, calling `read_dir`
+/// on each parent to find the entry whose name matches case-insensitively,
+/// then appends that entry's name (which has true filesystem casing).
+/// Does not resolve symlinks — unlike `std::fs::canonicalize`.
+///
+/// Stops correcting at the first missing component (pushes the remaining
+/// components as-is). Paths where the parent can't be read (permissions,
+/// missing) are returned unchanged from that point.
+#[cfg(not(windows))]
+fn case_correct_existing(path: &Path) -> PathBuf {
+    path.to_path_buf()
+}
+
+#[cfg(windows)]
+fn case_correct_existing(path: &Path) -> PathBuf {
+    let mut result = PathBuf::new();
+    let mut components = path.components();
+
+    // Copy the prefix (drive letter) and root directory verbatim.
+    // Case of a drive letter is not something `read_dir` can tell us;
+    // upstream `normalize_path` / the rest of the pipeline handles that.
+    while let Some(comp) = components.clone().next() {
+        match comp {
+            Component::Prefix(_) | Component::RootDir => {
+                result.push(comp.as_os_str());
+                components.next();
+            }
+            _ => break,
+        }
+    }
+
+    // Case-correct remaining components via read_dir.
+    loop {
+        let comp = match components.next() {
+            Some(c) => c,
+            None => return result,
+        };
+        let name = comp.as_os_str();
+        let entries = match std::fs::read_dir(&result) {
+            Ok(e) => e,
+            Err(_) => {
+                // Parent can't be read — stop correcting, push rest as-is.
+                result.push(name);
+                for rest in components {
+                    result.push(rest.as_os_str());
+                }
+                return result;
+            }
+        };
+
+        let mut found: Option<std::ffi::OsString> = None;
+        for entry in entries.flatten() {
+            let entry_name = entry.file_name();
+            if entry_name.to_string_lossy()
+                .eq_ignore_ascii_case(&name.to_string_lossy())
+            {
+                found = Some(entry_name);
+                break;
+            }
+        }
+
+        match found {
+            Some(n) => result.push(n),
+            None => {
+                // Missing component — push as-is and stop correcting
+                // (we can't read_dir into something that doesn't exist).
+                result.push(name);
+                for rest in components {
+                    result.push(rest.as_os_str());
+                }
+                return result;
+            }
+        }
     }
 }
 
@@ -202,48 +283,93 @@ mod tests {
         assert_eq!(NormalizedPath::absolute("nested/../src/foo.rs"), expected);
     }
 
-    /// Fix #127 bug 1: absolute() must canonicalize existing files so that
-    /// CLI paths match config-derived paths regardless of cwd casing.
+    /// absolute() must produce an absolute, normalized path for an existing
+    /// file. Symlinks are NOT resolved, so the result keeps the input path's
+    /// identity (this is what lets CLI paths intersect with glob-expanded
+    /// paths that both reference the same symlink).
     #[test]
-    fn absolute_canonicalizes_existing_file() {
-        // Create a temp file and resolve it via absolute() — the result
-        // must match std::fs::canonicalize (true casing on Windows).
-        let tmp = std::env::temp_dir().join("tractor_test_canon.txt");
+    fn absolute_on_existing_file_is_absolute() {
+        let tmp = std::env::temp_dir().join("tractor_test_abs.txt");
         std::fs::write(&tmp, "").unwrap();
 
-        let canonical = std::fs::canonicalize(&tmp).unwrap();
-        let expected = NormalizedPath::new(&canonical.to_string_lossy());
         let actual = NormalizedPath::absolute(&tmp.to_string_lossy());
-        assert_eq!(actual, expected, "absolute() should canonicalize existing files");
+        assert!(
+            std::path::Path::new(actual.as_str()).is_absolute(),
+            "absolute() must return an absolute path: {}",
+            actual
+        );
 
         std::fs::remove_file(&tmp).ok();
     }
 
-    /// Fix #127 bug 1: absolute() with a relative path to an existing file
-    /// must produce the same NormalizedPath as expanding a glob that matches
-    /// the same file (both should use canonical casing).
+    /// A relative path and its absolute counterpart must produce the same
+    /// NormalizedPath — this is what lets CLI-supplied relative paths
+    /// intersect with config-derived absolute paths (fix #127).
     #[test]
-    fn absolute_relative_matches_glob_expanded() {
-        // Use Cargo.toml (always present in the repo root) as a known file.
-        // The worktree cwd is the repo root, so "Cargo.toml" is resolvable.
+    fn absolute_relative_and_absolute_agree() {
         let cwd = std::env::current_dir().unwrap();
         let cargo_toml = cwd.join("Cargo.toml");
         if !cargo_toml.exists() {
             return; // skip if not in repo root
         }
 
-        let from_absolute = NormalizedPath::absolute("Cargo.toml");
-        let canonical = std::fs::canonicalize(&cargo_toml).unwrap();
-        let from_canonical = NormalizedPath::new(&canonical.to_string_lossy());
+        let from_relative = NormalizedPath::absolute("Cargo.toml");
+        let from_absolute = NormalizedPath::absolute(&cargo_toml.to_string_lossy());
         assert_eq!(
-            from_absolute, from_canonical,
-            "absolute('Cargo.toml') must match canonical form"
+            from_relative, from_absolute,
+            "absolute('Cargo.toml') and absolute('/abs/.../Cargo.toml') must agree"
         );
     }
 
+    /// Unix-only regression test for the Copilot #128 review: `absolute()`
+    /// must NOT resolve symlinks. A CLI arg of `link.txt` pointing at
+    /// `target.txt` must stay `link.txt`, so it can intersect with
+    /// glob-expanded paths that also use the link name.
+    #[cfg(unix)]
+    #[test]
+    fn absolute_does_not_resolve_unix_symlinks() {
+        use std::os::unix::fs::symlink;
+        let dir = std::env::temp_dir().join("tractor_test_symlink");
+        std::fs::create_dir_all(&dir).unwrap();
+        let target = dir.join("target.txt");
+        let link = dir.join("link.txt");
+        std::fs::write(&target, "").unwrap();
+        // Remove stale link from a previous run, if any.
+        let _ = std::fs::remove_file(&link);
+        symlink(&target, &link).unwrap();
+
+        let absolute = NormalizedPath::absolute(&link.to_string_lossy());
+        assert!(
+            absolute.as_str().ends_with("/link.txt"),
+            "symlink should be preserved, not resolved to target; got: {}",
+            absolute
+        );
+        assert!(
+            !absolute.as_str().ends_with("/target.txt"),
+            "symlink was resolved to target — this is the #128 review bug: {}",
+            absolute
+        );
+
+        // Also: absolute(link) should intersect with a HashSet built from
+        // the link path (what a glob walker would produce).
+        let mut set: HashSet<NormalizedPath> = HashSet::new();
+        set.insert(NormalizedPath::new(&link.to_string_lossy()));
+        assert!(
+            set.contains(&absolute),
+            "CLI-resolved symlink path must intersect with glob-walker path"
+        );
+
+        std::fs::remove_file(&link).ok();
+        std::fs::remove_file(&target).ok();
+        std::fs::remove_dir(&dir).ok();
+    }
+
     /// Fix #127 bug 1: on Windows, two paths differing only in case must
-    /// produce the same NormalizedPath after absolute().
-    #[cfg(target_os = "windows")]
+    /// produce the same NormalizedPath after absolute(). Handled by the
+    /// Windows-only `case_correct_existing` helper, which walks each
+    /// component via `read_dir` to find the true filesystem casing
+    /// (without following symlinks, unlike `std::fs::canonicalize`).
+    #[cfg(windows)]
     #[test]
     fn absolute_case_insensitive_on_windows() {
         let tmp = std::env::temp_dir().join("tractor_test_CaseCheck.txt");

--- a/tractor-core/src/normalized_path.rs
+++ b/tractor-core/src/normalized_path.rs
@@ -78,15 +78,32 @@ fn case_correct_existing(path: &Path) -> PathBuf {
 
 #[cfg(windows)]
 fn case_correct_existing(path: &Path) -> PathBuf {
-    // Find the longest existing ancestor to hand to GetLongPathName.
-    // `ancestors()` yields `path` itself first, then shorter prefixes;
-    // the drive root (e.g. `C:\`) always exists so this eventually
-    // finds something.
-    let anchor = path.ancestors().find(|p| p.exists());
+    // Step 1: resolve 8.3 short-name aliases via GetLongPathName.
+    //   This handles CMD-style paths like `C:\Users\RUNNER~1\...`.
+    //   GetLongPathName case-corrects path components only as a side
+    //   effect of 8.3 expansion (it has to enumerate the parent dir to
+    //   find which entry the `~1` alias points at), so the *leaf*
+    //   component — and any non-8.3 components — keeps the caller's
+    //   casing. That's what step 2 cleans up.
+    let after_long = resolve_long_path(path);
 
-    let resolved = if let Some(anchor) = anchor {
+    // Step 2: read_dir per-component case correction.
+    //   For each Normal component, look up the parent directory's
+    //   entries and use the entry's true filesystem casing.
+    let after_case = case_correct_via_readdir(&after_long);
+
+    // Step 3: uppercase the drive letter for consistency. GetLongPathName
+    //   and read_dir don't normalize drive-letter casing.
+    uppercase_drive_letter(after_case)
+}
+
+#[cfg(windows)]
+fn resolve_long_path(path: &Path) -> PathBuf {
+    // Find the longest existing ancestor and resolve it. Walk up to the
+    // drive root if needed (which always exists on Windows).
+    let anchor = path.ancestors().find(|p| p.exists());
+    if let Some(anchor) = anchor {
         let long = get_long_path_name(anchor).unwrap_or_else(|| anchor.to_path_buf());
-        // Re-append any trailing components that didn't exist yet.
         let anchor_comps = anchor.components().count();
         let mut result = long;
         for comp in path.components().skip(anchor_comps) {
@@ -95,9 +112,72 @@ fn case_correct_existing(path: &Path) -> PathBuf {
         result
     } else {
         path.to_path_buf()
-    };
+    }
+}
 
-    uppercase_drive_letter(resolved)
+#[cfg(windows)]
+fn case_correct_via_readdir(path: &Path) -> PathBuf {
+    let mut result = PathBuf::new();
+    let mut comps = path.components();
+
+    // Copy prefix (drive) and root verbatim — drive case is normalized
+    // separately by `uppercase_drive_letter`.
+    while let Some(c) = comps.clone().next() {
+        match c {
+            Component::Prefix(_) | Component::RootDir => {
+                result.push(c.as_os_str());
+                comps.next();
+            }
+            _ => break,
+        }
+    }
+
+    // For each remaining component, look up the parent's read_dir entries
+    // and use the entry's true filesystem casing. Stop at the first
+    // component we can't resolve (push the rest as-is).
+    loop {
+        let comp = match comps.next() {
+            Some(c) => c,
+            None => return result,
+        };
+        let name = comp.as_os_str();
+        let entries = match std::fs::read_dir(&result) {
+            Ok(e) => e,
+            Err(_) => {
+                result.push(name);
+                for rest in comps {
+                    result.push(rest.as_os_str());
+                }
+                return result;
+            }
+        };
+
+        let mut found: Option<std::ffi::OsString> = None;
+        for entry in entries.flatten() {
+            let entry_name = entry.file_name();
+            if entry_name.to_string_lossy()
+                .eq_ignore_ascii_case(&name.to_string_lossy())
+            {
+                found = Some(entry_name);
+                break;
+            }
+        }
+
+        match found {
+            Some(n) => result.push(n),
+            None => {
+                // Component doesn't exist (or isn't visible) — push
+                // remainder as-is and stop. Note: we should usually not
+                // hit this for components GetLongPathName already
+                // resolved, since they exist on disk by definition.
+                result.push(name);
+                for rest in comps {
+                    result.push(rest.as_os_str());
+                }
+                return result;
+            }
+        }
+    }
 }
 
 /// Uppercase the ASCII drive letter prefix of a Windows path, if any.

--- a/tractor-core/src/render/json.rs
+++ b/tractor-core/src/render/json.rs
@@ -486,7 +486,9 @@ mod tests {
         assert_eq!(parsed["nothing"], "null");
         // type="true"/"number"/"null" renders as bare values
         assert_eq!(parsed["active"], true);
-        assert_eq!(parsed["pi"], 3.14);
+        #[allow(clippy::approx_constant)] // test value, not meant as PI
+        let pi_value = 3.14;
+        assert_eq!(parsed["pi"], pi_value);
         assert!(parsed["empty"].is_null());
     }
 

--- a/tractor/src/executor.rs
+++ b/tractor/src/executor.rs
@@ -1736,6 +1736,7 @@ mod tests {
         // Create a temp JSON file that a rule's include pattern will match.
         let dir = tempfile::tempdir().unwrap();
         // Canonicalize to resolve 8.3 short names on Windows CI (e.g. RUNNER~1 → runneradmin)
+        #[allow(clippy::disallowed_methods)] // test-only filesystem setup
         let canon_dir = std::fs::canonicalize(dir.path()).unwrap();
         let src_dir = canon_dir.join("src");
         std::fs::create_dir_all(&src_dir).unwrap();
@@ -1777,6 +1778,7 @@ mod tests {
     #[test]
     fn check_multiple_rule_includes_discover_union() {
         let dir = tempfile::tempdir().unwrap();
+        #[allow(clippy::disallowed_methods)] // test-only filesystem setup
         let canon_dir = std::fs::canonicalize(dir.path()).unwrap();
         let src_dir = canon_dir.join("src");
         let test_dir = canon_dir.join("test");
@@ -1833,6 +1835,7 @@ mod tests {
         let json_path = dir.path().join("test.json");
         std::fs::write(&json_path, r#"{"bad": true}"#).unwrap();
 
+        #[allow(clippy::disallowed_methods)] // test-only filesystem setup
         let canonical = std::fs::canonicalize(&json_path).unwrap();
         let canonical_str = normalize_path(&canonical.to_string_lossy());
 
@@ -1881,6 +1884,7 @@ mod tests {
     #[test]
     fn check_overlapping_rule_includes_no_duplicate_matches() {
         let dir = tempfile::tempdir().unwrap();
+        #[allow(clippy::disallowed_methods)] // test-only filesystem setup
         let canon_dir = std::fs::canonicalize(dir.path()).unwrap();
         let sub_dir = canon_dir.join("src").join("sub");
         std::fs::create_dir_all(&sub_dir).unwrap();

--- a/tractor/src/file_resolver.rs
+++ b/tractor/src/file_resolver.rs
@@ -100,8 +100,7 @@ impl FileResolver {
 
         if options.verbose {
             let cwd_display = std::env::current_dir()
-                .and_then(|p| std::fs::canonicalize(&p).or(Ok(p)))
-                .map(|p| normalize_path(&p.display().to_string()))
+                .map(|p| NormalizedPath::absolute(&p.display().to_string()).to_string())
                 .unwrap_or_else(|_| ".".to_string());
             eprintln!("  files: working directory {}", cwd_display);
             eprintln!("  files: resolving relative to {}", base_dir_display);
@@ -125,8 +124,7 @@ impl FileResolver {
                         format_patterns(patterns), expansion.files.len());
                     log_files!(&expansion.files);
                 }
-                Some(expansion.files.into_iter()
-                    .map(|f| NormalizedPath::new(&f)).collect())
+                Some(expansion.files.into_iter().collect())
             }
             Some(_) => Some(HashSet::new()), // files: [] → explicit empty
             None => None,                     // key missing → unrestricted
@@ -140,7 +138,7 @@ impl FileResolver {
                     e.pattern, e.limit
                 ))?;
             let cli_set: HashSet<NormalizedPath> = expansion.files.into_iter()
-                .map(|f| NormalizedPath::absolute(&f)).collect();
+                .map(|f| NormalizedPath::absolute(f.as_str())).collect();
             if options.verbose {
                 eprintln!("  files: CLI args {} expanded to {} file(s)",
                     format_patterns(&options.cli_files), cli_set.len());
@@ -265,7 +263,6 @@ impl FileResolver {
                     // patterns matched it (#127 follow-up).
                     let mut seen = HashSet::new();
                     let files: Vec<NormalizedPath> = result.files.into_iter()
-                        .map(|f| NormalizedPath::new(&f))
                         .filter(|f| seen.insert(f.clone()))
                         .collect();
                     (files, result.empty_patterns)

--- a/tractor/src/file_resolver.rs
+++ b/tractor/src/file_resolver.rs
@@ -659,6 +659,46 @@ mod tests {
         assert!(report.all_matches().is_empty(), "should not emit diagnostic in non-config mode");
     }
 
+    /// Copilot review #4: invalid exclude patterns must surface as a fatal
+    /// diagnostic instead of being silently dropped (which would expand the
+    /// effective scope without warning).
+    #[test]
+    fn invalid_exclude_pattern_emits_fatal_diagnostic() {
+        use tractor_core::report::Severity;
+
+        let root: HashSet<NormalizedPath> =
+            [NormalizedPath::new("/tmp/foo.rs")].into();
+        let resolver = FileResolver {
+            root_files: Some(root),
+            cli_files: None,
+            global_diff_files: None,
+            verbose: false,
+            base_dir: Some(std::path::PathBuf::from(".")),
+            max_files: 1000,
+            global_diff_lines: None,
+        };
+
+        let mut builder = tractor_core::ReportBuilder::new();
+        // `[abc]` character classes are rejected by CompiledPattern.
+        let exclude = vec!["/tmp/[abc]/**".to_string()];
+        let request = FileRequest {
+            files: &[],
+            exclude: &exclude,
+            diff_files: None,
+            diff_lines: None,
+            command: "check",
+        };
+        let (files, _) = resolver.resolve(&request, &mut builder);
+        assert!(files.is_empty(), "invalid exclude must short-circuit resolution");
+
+        let report = builder.build();
+        let has_fatal = report.all_matches().iter().any(|m| {
+            m.severity == Some(Severity::Fatal)
+                && m.reason.as_ref().is_some_and(|r| r.contains("invalid exclude pattern"))
+        });
+        assert!(has_fatal, "expected fatal diagnostic about invalid exclude pattern, got: {:#?}", report.all_matches());
+    }
+
     // -----------------------------------------------------------------------
     // Bug 2 regression: case-insensitive exclude on Windows
     // -----------------------------------------------------------------------

--- a/tractor/src/file_resolver.rs
+++ b/tractor/src/file_resolver.rs
@@ -12,7 +12,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use tractor_core::{expand_globs_checked, detect_language, normalize_path, NormalizedPath, GlobPattern, CompiledPattern};
+use tractor_core::{expand_globs_checked, detect_language, normalize_path, pattern_literal_prefix, FilePrune, NormalizedPath, GlobPattern, CompiledPattern};
 use tractor_core::report::{ReportBuilder, ReportMatch, Severity, DiagnosticOrigin};
 
 use crate::executor::ExecuteOptions;
@@ -54,11 +54,31 @@ pub(crate) struct FileResolver {
     cli_files: Option<HashSet<NormalizedPath>>,
     /// Expanded global diff-files set, or None if not provided.
     global_diff_files: Option<HashSet<NormalizedPath>>,
+    /// Literal path prefixes of the root-level `files:` patterns. Used as
+    /// a prune group when expanding operation patterns so the walker
+    /// doesn't descend into subtrees that root already excludes.
+    root_prefixes: Vec<NormalizedPath>,
+    /// Literal path prefixes of the CLI file args. Plays the same role
+    /// as `root_prefixes` — sibling constraint during expansion.
+    cli_prefixes: Vec<NormalizedPath>,
     // Resolution parameters (copied from ExecuteOptions for self-containment)
     verbose: bool,
     base_dir: Option<PathBuf>,
     max_files: usize,
     global_diff_lines: Option<String>,
+}
+
+/// Collect absolute literal prefixes from a list of *already-absolutized*
+/// glob patterns. The result is the OR-group to pass to `FilePrune::with_group`.
+///
+/// Each prefix is case-canonicalized via `NormalizedPath::absolute` so it
+/// matches the walker's `read_dir`-derived casing on Windows.
+fn prefixes_of_patterns(patterns: &[String]) -> Vec<NormalizedPath> {
+    patterns.iter()
+        .map(|p| pattern_literal_prefix(p))
+        .filter(|p| !p.is_empty())
+        .map(|p| NormalizedPath::absolute(&p))
+        .collect()
 }
 
 impl FileResolver {
@@ -107,12 +127,34 @@ impl FileResolver {
             eprintln!("  files: max {} files", options.max_files);
         }
 
+        // --- Pre-compute sibling prefix groups ---
+        // Walker pruning (fix A): when expanding root patterns, the walker
+        // can skip subtrees that no CLI pattern's prefix is compatible with,
+        // and vice versa. We derive both prefix sets up-front so each
+        // expansion can be pruned by the other.
+        //
+        // Anchoring note: root patterns are rebased onto `base_dir` (the
+        // config's directory), while CLI patterns stay cwd-relative. The
+        // prefixes below must agree with how the actual expansion calls
+        // resolve "relative" — `prefixes_of_patterns` absolutises via
+        // `NormalizedPath::absolute`, which anchors relatives to cwd. That
+        // matches the CLI expansion (passes `options.cli_files` raw) and
+        // the root expansion (feeds pre-absolutised patterns).
+        let resolved_root_patterns: Option<Vec<String>> = options.config_root_files.as_ref()
+            .filter(|p| !p.is_empty())
+            .map(|p| resolve_globs_to_absolute(&options.base_dir, p));
+
+        let root_prefixes: Vec<NormalizedPath> = resolved_root_patterns.as_deref()
+            .map(prefixes_of_patterns).unwrap_or_default();
+        let cli_prefixes: Vec<NormalizedPath> = prefixes_of_patterns(&options.cli_files);
+
         // --- Root scope (fix #99) ---
         // None = key missing → unrestricted; Some([]) = explicit empty; Some([...]) = expand
-        let root_files = match &options.config_root_files {
-            Some(patterns) if !patterns.is_empty() => {
-                let root_globs = resolve_globs_to_absolute(&options.base_dir, patterns);
-                let expansion = expand_globs_checked(&root_globs, expansion_limit)
+        let root_files = match (&options.config_root_files, resolved_root_patterns) {
+            (Some(patterns), Some(root_globs)) if !patterns.is_empty() => {
+                // Prune root expansion by CLI prefixes — symmetric sibling constraint.
+                let prune = FilePrune::new().with_group(cli_prefixes.iter().cloned());
+                let expansion = expand_globs_checked(&root_globs, expansion_limit, Some(&prune))
                     .map_err(|e| {
                         format!(
                             "root pattern \"{}\" expanded to over {} paths — use a more specific pattern or increase --max-files",
@@ -126,13 +168,21 @@ impl FileResolver {
                 }
                 Some(expansion.files.into_iter().collect())
             }
-            Some(_) => Some(HashSet::new()), // files: [] → explicit empty
-            None => None,                     // key missing → unrestricted
+            (Some(_), _) => Some(HashSet::new()), // files: [] → explicit empty
+            (None, _) => None,                     // key missing → unrestricted
         };
 
         // --- CLI files (fix #98: normalize paths) ---
+        // CLI args are cwd-relative (they come from the user's shell) —
+        // pass them to `expand_globs_checked` unchanged and let
+        // `NormalizedPath::absolute` anchor them against cwd below. This
+        // preserves `./foo` semantics even when the config lives in a
+        // different directory.
         let cli_files = if !options.cli_files.is_empty() {
-            let expansion = expand_globs_checked(&options.cli_files, expansion_limit)
+            // Prune CLI expansion by root prefixes — the other half of the
+            // symmetric walker constraint.
+            let prune = FilePrune::new().with_group(root_prefixes.iter().cloned());
+            let expansion = expand_globs_checked(&options.cli_files, expansion_limit, Some(&prune))
                 .map_err(|e| format!(
                     "CLI pattern \"{}\" expanded to over {} paths — use a more specific pattern or increase --max-files",
                     e.pattern, e.limit
@@ -178,6 +228,8 @@ impl FileResolver {
             root_files,
             cli_files,
             global_diff_files,
+            root_prefixes,
+            cli_prefixes,
             verbose: options.verbose,
             base_dir: options.base_dir.clone(),
             max_files: options.max_files,
@@ -254,7 +306,16 @@ impl FileResolver {
             // (verbose log after expansion below)
             let globs = resolve_globs_to_absolute(&self.base_dir, request.files);
 
-            let (mut files, empty_patterns) = match expand_globs_checked(&globs, expansion_limit) {
+            // Prune the walker by sibling constraints: root patterns and
+            // CLI patterns are each AND-intersected with the operation
+            // result, so their literal prefixes bound where op patterns
+            // can possibly match. Each becomes an independent AND-group
+            // so the walker rejects dirs only outside *all* of them.
+            let prune = FilePrune::new()
+                .with_group(self.root_prefixes.iter().cloned())
+                .with_group(self.cli_prefixes.iter().cloned());
+
+            let (mut files, empty_patterns) = match expand_globs_checked(&globs, expansion_limit, Some(&prune)) {
                 Ok(result) => {
                     // Normalize and deduplicate expanded paths. Multiple patterns
                     // can expand to the same file (e.g. "src/**/*.cs" and
@@ -411,7 +472,17 @@ impl FileResolver {
         }
 
         // --- Check for empty result from glob expansion ---
-        if files.is_empty() && !request.files.is_empty() && !empty_patterns.is_empty() {
+        // When walker pruning is active (root/CLI sibling prefixes), an
+        // empty expansion result can mean "the prune cut away every match",
+        // not "the pattern truly matches nothing". An empty intersection
+        // with siblings has always been allowed to succeed silently, so we
+        // suppress the diagnostic in that case and only surface it when
+        // the walker did a full (unpruned) scan and still found nothing.
+        let prune_was_active = !self.root_prefixes.is_empty()
+            || !self.cli_prefixes.is_empty();
+        if files.is_empty() && !request.files.is_empty() && !empty_patterns.is_empty()
+            && !prune_was_active
+        {
             let patterns_str = empty_patterns.iter()
                 .map(|p| format!("\"{}\"", p))
                 .collect::<Vec<_>>()
@@ -601,6 +672,8 @@ mod tests {
             root_files: None,
             cli_files: None,
             global_diff_files: None,
+            root_prefixes: Vec::new(),
+            cli_prefixes: Vec::new(),
             verbose: false,
             base_dir: Some(std::path::PathBuf::from(".")),  // config mode
             max_files: 1000,
@@ -631,6 +704,8 @@ mod tests {
             root_files: None,
             cli_files: None,
             global_diff_files: None,
+            root_prefixes: Vec::new(),
+            cli_prefixes: Vec::new(),
             verbose: false,
             base_dir: None,  // non-config mode
             max_files: 1000,
@@ -665,6 +740,8 @@ mod tests {
             root_files: Some(root),
             cli_files: None,
             global_diff_files: None,
+            root_prefixes: Vec::new(),
+            cli_prefixes: Vec::new(),
             verbose: false,
             base_dir: Some(std::path::PathBuf::from(".")),
             max_files: 1000,

--- a/tractor/src/file_resolver.rs
+++ b/tractor/src/file_resolver.rs
@@ -12,7 +12,7 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use tractor_core::{expand_globs_checked, filter_supported_files, normalize_path, NormalizedPath, GlobPattern, CompiledPattern};
+use tractor_core::{expand_globs_checked, detect_language, normalize_path, NormalizedPath, GlobPattern, CompiledPattern};
 use tractor_core::report::{ReportBuilder, ReportMatch, Severity, DiagnosticOrigin};
 
 use crate::executor::ExecuteOptions;
@@ -53,7 +53,7 @@ pub(crate) struct FileResolver {
     /// Expanded CLI file args, or None if not provided.
     cli_files: Option<HashSet<NormalizedPath>>,
     /// Expanded global diff-files set, or None if not provided.
-    global_diff_files: Option<HashSet<PathBuf>>,
+    global_diff_files: Option<HashSet<NormalizedPath>>,
     // Resolution parameters (copied from ExecuteOptions for self-containment)
     verbose: bool,
     base_dir: Option<PathBuf>,
@@ -165,7 +165,7 @@ impl FileResolver {
                     if options.verbose {
                         eprintln!("  files: git diff \"{}\" found {} changed file(s)", spec, changed.len());
                     }
-                    Some(changed.into_iter().collect())
+                    Some(changed)
                 }
                 Err(e) => {
                     eprintln!("warning: --diff-files filter failed: {}", e);
@@ -371,27 +371,23 @@ impl FileResolver {
         }
 
         let before_lang = files.len();
-        let files: Vec<NormalizedPath> = filter_supported_files(
-            files.into_iter().map(|f| f.into_string()).collect()
-        ).into_iter().map(|f| NormalizedPath::new(&f)).collect();
+        // Filter by supported language directly on NormalizedPath — no
+        // String round-trip needed.
+        files.retain(|f| detect_language(f.as_str()) != "unknown");
         if self.verbose && files.len() != before_lang {
             eprintln!("  files: {} file(s) after language filter (was {})", files.len(), before_lang);
         }
 
         // --- Intersect with git diff-files ---
-        // Convert to strings for git module, then back to NormalizedPath
-        let string_files: Vec<String> = files.into_iter().map(|f| f.into_string()).collect();
-        let before_diff = string_files.len();
-        let string_files = if let Some(ref global_diff) = self.global_diff_files {
-            git::intersect_changed(string_files, global_diff)
-        } else {
-            string_files
-        };
+        // Both sides of the intersection are already `NormalizedPath`,
+        // produced via `NormalizedPath::absolute` — compare as-is.
+        let before_diff = files.len();
+        if let Some(ref global_diff) = self.global_diff_files {
+            files = git::intersect_changed(files, global_diff);
+        }
         let cwd = self.base_dir.as_deref()
             .unwrap_or_else(|| Path::new("."));
-        let string_files = apply_diff_files_filter(string_files, request.diff_files, cwd);
-        let mut files: Vec<NormalizedPath> = string_files.into_iter()
-            .map(|f| NormalizedPath::new(&f)).collect();
+        files = apply_diff_files_filter(files, request.diff_files, cwd);
         if self.verbose && files.len() != before_diff {
             eprintln!("  files: {} file(s) after diff filter (was {})", files.len(), before_diff);
         }
@@ -476,7 +472,7 @@ fn build_filters(
     filters
 }
 
-fn apply_diff_files_filter(files: Vec<String>, spec: Option<&str>, cwd: &Path) -> Vec<String> {
+fn apply_diff_files_filter(files: Vec<NormalizedPath>, spec: Option<&str>, cwd: &Path) -> Vec<NormalizedPath> {
     match spec {
         Some(spec) => {
             match git::git_changed_files(spec, cwd) {

--- a/tractor/src/file_resolver.rs
+++ b/tractor/src/file_resolver.rs
@@ -344,9 +344,23 @@ impl FileResolver {
         if !request.exclude.is_empty() {
             let before = files.len();
             let resolved = GlobPattern::resolve_all(request.exclude, &self.base_dir);
-            let exclude_patterns: Vec<CompiledPattern> = resolved.iter()
-                .filter_map(|p| CompiledPattern::new(p.as_str()).ok())
-                .collect();
+            let mut exclude_patterns: Vec<CompiledPattern> = Vec::with_capacity(resolved.len());
+            let mut invalid = false;
+            for pattern in &resolved {
+                match CompiledPattern::new(pattern.as_str()) {
+                    Ok(compiled) => exclude_patterns.push(compiled),
+                    Err(err) => {
+                        report.add(make_fatal_diagnostic(
+                            request.command,
+                            format!("invalid exclude pattern `{}`: {}", pattern, err),
+                        ));
+                        invalid = true;
+                    }
+                }
+            }
+            if invalid {
+                return Vec::new();
+            }
 
             files.retain(|f| {
                 !exclude_patterns.iter().any(|p| p.matches(f.as_str()))

--- a/tractor/src/file_resolver.rs
+++ b/tractor/src/file_resolver.rs
@@ -472,17 +472,14 @@ impl FileResolver {
         }
 
         // --- Check for empty result from glob expansion ---
-        // When walker pruning is active (root/CLI sibling prefixes), an
-        // empty expansion result can mean "the prune cut away every match",
-        // not "the pattern truly matches nothing". An empty intersection
-        // with siblings has always been allowed to succeed silently, so we
-        // suppress the diagnostic in that case and only surface it when
-        // the walker did a full (unpruned) scan and still found nothing.
-        let prune_was_active = !self.root_prefixes.is_empty()
-            || !self.cli_prefixes.is_empty();
-        if files.is_empty() && !request.files.is_empty() && !empty_patterns.is_empty()
-            && !prune_was_active
-        {
+        // An empty expansion is always a fatal diagnostic — whether the
+        // pattern genuinely matched nothing or the walker was pruned to
+        // nothing by sibling intersections (root ∩ CLI ∩ operation). In
+        // either case the user asked us to run checks on zero files,
+        // which is almost certainly a mistake (typo, misconfigured
+        // scope, stale rule) and deserves to be surfaced rather than
+        // swallowed as a silent success.
+        if files.is_empty() && !request.files.is_empty() && !empty_patterns.is_empty() {
             let patterns_str = empty_patterns.iter()
                 .map(|p| format!("\"{}\"", p))
                 .collect::<Vec<_>>()

--- a/tractor/src/modes/config.rs
+++ b/tractor/src/modes/config.rs
@@ -67,7 +67,13 @@ pub fn run_from_config(params: ConfigRunParams) -> Result<(), Box<dyn std::error
     } else {
         let base_dir = config_path.parent()
             .map(|p| if p.as_os_str().is_empty() { std::path::Path::new(".") } else { p })
-            .map(|p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf()));
+            .map(|p| {
+                // Absolutize without following symlinks — matches the glob
+                // walker and CLI path resolution, so `base_dir`-derived paths
+                // intersect by set equality with those pipelines.
+                let normalized = tractor_core::NormalizedPath::absolute(&p.to_string_lossy());
+                std::path::PathBuf::from(normalized.as_str())
+            });
 
         let options = ExecuteOptions {
             verbose: ctx.verbose,

--- a/tractor/src/pipeline/format/shared.rs
+++ b/tractor/src/pipeline/format/shared.rs
@@ -4,7 +4,7 @@ use tractor_core::report::ReportMatch;
 use super::options::{ViewField, ViewSet};
 
 pub fn to_absolute_path(path: &str) -> String {
-    tractor_core::NormalizedPath::absolute(path).into_string()
+    tractor_core::NormalizedPath::absolute(path).to_string()
 }
 
 /// Whether totals/metadata should be shown for this report.

--- a/tractor/src/pipeline/git.rs
+++ b/tractor/src/pipeline/git.rs
@@ -7,9 +7,9 @@
 //! matches whose line ranges overlap with changed hunks in a git diff.
 
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
-use tractor_core::Match;
+use tractor_core::{Match, NormalizedPath};
 use crate::filter::ResultFilter;
 
 /// Run `git diff --name-only` with the given spec and return the set of
@@ -21,10 +21,14 @@ use crate::filter::ResultFilter;
 ///
 /// Deleted files are excluded via `--diff-filter=ACMR` (Added, Copied,
 /// Modified, Renamed).
+///
+/// Paths are resolved via [`NormalizedPath::absolute`], which lexically
+/// joins and case-corrects but does **not** follow symlinks. This matches
+/// the glob walker's behavior so the two sets can intersect as-is.
 pub fn git_changed_files(
     spec: &str,
     cwd: &Path,
-) -> Result<HashSet<PathBuf>, Box<dyn std::error::Error>> {
+) -> Result<HashSet<NormalizedPath>, Box<dyn std::error::Error>> {
     let args: Vec<&str> = spec.split_whitespace().collect();
 
     let output = Command::new("git")
@@ -47,37 +51,26 @@ pub fn git_changed_files(
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let files: HashSet<PathBuf> = stdout
+    let files: HashSet<NormalizedPath> = stdout
         .lines()
         .filter(|l| !l.is_empty())
-        .map(|l| cwd.join(l))
+        .map(|l| NormalizedPath::absolute(&cwd.join(l).to_string_lossy()))
         .collect();
 
     Ok(files)
 }
 
 /// Filter a list of file paths to only those present in the `changed` set.
-/// Paths are canonicalized for reliable comparison.
+///
+/// Both sides are already `NormalizedPath`, produced by
+/// [`NormalizedPath::absolute`] at their respective entry points. That
+/// alignment is what makes this a simple hash-set lookup — no canonicalize,
+/// no symlink following.
 pub fn intersect_changed(
-    files: Vec<String>,
-    changed: &HashSet<PathBuf>,
-) -> Vec<String> {
-    // Pre-canonicalize the changed set for comparison.
-    let canonical_changed: HashSet<PathBuf> = changed
-        .iter()
-        .filter_map(|p| std::fs::canonicalize(p).ok())
-        .collect();
-
-    files
-        .into_iter()
-        .filter(|f| {
-            if let Ok(canonical) = std::fs::canonicalize(f) {
-                canonical_changed.contains(&canonical)
-            } else {
-                false
-            }
-        })
-        .collect()
+    files: Vec<NormalizedPath>,
+    changed: &HashSet<NormalizedPath>,
+) -> Vec<NormalizedPath> {
+    files.into_iter().filter(|f| changed.contains(f)).collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -95,8 +88,8 @@ pub struct LineRange {
 /// hunks from a git diff. Also implements file-level filtering: files
 /// not present in the diff are skipped entirely.
 pub struct DiffHunkFilter {
-    /// Map from canonical file path → changed line ranges.
-    hunks: HashMap<PathBuf, Vec<LineRange>>,
+    /// Map from normalized absolute file path → changed line ranges.
+    hunks: HashMap<NormalizedPath, Vec<LineRange>>,
 }
 
 impl DiffHunkFilter {
@@ -112,19 +105,17 @@ impl DiffHunkFilter {
 
     /// Create a filter from pre-parsed hunks (for testing).
     #[cfg(test)]
-    pub fn from_hunks(hunks: HashMap<PathBuf, Vec<LineRange>>) -> Self {
+    pub fn from_hunks(hunks: HashMap<NormalizedPath, Vec<LineRange>>) -> Self {
         DiffHunkFilter { hunks }
     }
 }
 
 impl ResultFilter for DiffHunkFilter {
     fn include(&self, m: &Match) -> bool {
-        let path = if let Ok(p) = std::fs::canonicalize(&m.file) {
-            p
-        } else {
-            PathBuf::from(&m.file)
-        };
-
+        // `Match::file` originates from the file resolver (already absolute
+        // + normalized), so wrapping it as `NormalizedPath` without going
+        // through `absolute()` again is safe and cheap.
+        let path = NormalizedPath::new(&m.file);
         match self.hunks.get(&path) {
             Some(ranges) => ranges.iter().any(|r| {
                 // Overlap: match.line <= range.end && match.end_line >= range.start
@@ -135,11 +126,7 @@ impl ResultFilter for DiffHunkFilter {
     }
 
     fn include_file(&self, file: &str) -> bool {
-        if let Ok(canonical) = std::fs::canonicalize(file) {
-            self.hunks.contains_key(&canonical)
-        } else {
-            false
-        }
+        self.hunks.contains_key(&NormalizedPath::new(file))
     }
 }
 
@@ -172,9 +159,9 @@ fn run_git_diff(spec: &str, cwd: &Path) -> Result<String, Box<dyn std::error::Er
 ///
 /// Only new-side ranges are extracted. Pure deletions (new_count == 0) are
 /// skipped since there are no new lines to match against.
-fn parse_diff_hunks(diff: &str, cwd: &Path) -> HashMap<PathBuf, Vec<LineRange>> {
-    let mut hunks: HashMap<PathBuf, Vec<LineRange>> = HashMap::new();
-    let mut current_file: Option<PathBuf> = None;
+fn parse_diff_hunks(diff: &str, cwd: &Path) -> HashMap<NormalizedPath, Vec<LineRange>> {
+    let mut hunks: HashMap<NormalizedPath, Vec<LineRange>> = HashMap::new();
+    let mut current_file: Option<NormalizedPath> = None;
 
     for line in diff.lines() {
         if let Some(rest) = line.strip_prefix("diff --git ") {
@@ -182,8 +169,7 @@ fn parse_diff_hunks(diff: &str, cwd: &Path) -> HashMap<PathBuf, Vec<LineRange>> 
             if let Some(b_idx) = rest.rfind(" b/") {
                 let rel_path = &rest[b_idx + 3..];
                 let abs_path = cwd.join(rel_path);
-                let canonical = std::fs::canonicalize(&abs_path).unwrap_or(abs_path);
-                current_file = Some(canonical);
+                current_file = Some(NormalizedPath::absolute(&abs_path.to_string_lossy()));
             }
         } else if line.starts_with("@@ ") {
             if let Some(ref file) = current_file {
@@ -230,6 +216,11 @@ fn parse_hunk_header(line: &str) -> Option<LineRange> {
 mod tests {
     use super::*;
 
+    /// Helper: wrap a filesystem path as a `NormalizedPath` via `absolute()`.
+    fn np(path: &std::path::Path) -> NormalizedPath {
+        NormalizedPath::absolute(&path.to_string_lossy())
+    }
+
     #[test]
     fn intersect_changed_filters_to_matching_files() {
         let dir = tempfile::tempdir().unwrap();
@@ -240,21 +231,17 @@ mod tests {
         std::fs::write(&b, "").unwrap();
         std::fs::write(&c, "").unwrap();
 
-        let files = vec![
-            a.to_str().unwrap().to_string(),
-            b.to_str().unwrap().to_string(),
-            c.to_str().unwrap().to_string(),
-        ];
+        let files = vec![np(&a), np(&b), np(&c)];
 
         // Only a.rs and c.rs are "changed"
         let mut changed = HashSet::new();
-        changed.insert(a.clone());
-        changed.insert(c.clone());
+        changed.insert(np(&a));
+        changed.insert(np(&c));
 
         let result = intersect_changed(files, &changed);
         assert_eq!(result.len(), 2);
-        assert!(result.contains(&a.to_str().unwrap().to_string()));
-        assert!(result.contains(&c.to_str().unwrap().to_string()));
+        assert!(result.contains(&np(&a)));
+        assert!(result.contains(&np(&c)));
     }
 
     #[test]
@@ -263,11 +250,40 @@ mod tests {
         let a = dir.path().join("a.rs");
         std::fs::write(&a, "").unwrap();
 
-        let files = vec![a.to_str().unwrap().to_string()];
+        let files = vec![np(&a)];
         let changed = HashSet::new();
 
         let result = intersect_changed(files, &changed);
         assert!(result.is_empty());
+    }
+
+    /// Regression: a symlink path must intersect with itself, not be
+    /// routed through `canonicalize` (which would resolve to the target).
+    /// Both the CLI/walker side and the diff side are `NormalizedPath`
+    /// obtained via `absolute()`, which deliberately does not follow
+    /// symlinks — so the intersection hits the link path directly.
+    #[cfg(unix)]
+    #[test]
+    fn intersect_changed_does_not_follow_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.rs");
+        let link = dir.path().join("link.rs");
+        std::fs::write(&target, "").unwrap();
+        symlink(&target, &link).unwrap();
+
+        let files = vec![np(&link)];
+        let mut changed = HashSet::new();
+        changed.insert(np(&link));
+
+        let result = intersect_changed(files, &changed);
+        assert_eq!(result.len(), 1);
+        assert!(
+            result[0].as_str().ends_with("/link.rs"),
+            "intersection must stay on the symlink path, not resolve to the target; got: {}",
+            result[0]
+        );
     }
 
     #[test]
@@ -280,16 +296,12 @@ mod tests {
         std::fs::write(&b, "").unwrap();
         std::fs::write(&c, "").unwrap();
 
-        let files = vec![
-            c.to_str().unwrap().to_string(),
-            a.to_str().unwrap().to_string(),
-            b.to_str().unwrap().to_string(),
-        ];
+        let files = vec![np(&c), np(&a), np(&b)];
 
         let mut changed = HashSet::new();
-        changed.insert(a.clone());
-        changed.insert(b.clone());
-        changed.insert(c.clone());
+        changed.insert(np(&a));
+        changed.insert(np(&b));
+        changed.insert(np(&c));
 
         let result = intersect_changed(files.clone(), &changed);
         assert_eq!(result, files);
@@ -340,8 +352,8 @@ mod tests {
         run(&["-c", "commit.gpgsign=false", "commit", "-m", "modify a.rs, add b.rs"]);
 
         let changed = git_changed_files("HEAD~1 HEAD", cwd).unwrap();
-        let a_path = cwd.join("a.rs");
-        let b_path = cwd.join("b.rs");
+        let a_path = np(&cwd.join("a.rs"));
+        let b_path = np(&cwd.join("b.rs"));
 
         assert!(changed.contains(&a_path), "a.rs should be in changed set");
         assert!(changed.contains(&b_path), "b.rs should be in changed set");
@@ -374,13 +386,13 @@ mod tests {
         run(&["-c", "commit.gpgsign=false", "commit", "-m", "modify lines 3 and 7"]);
 
         let filter = DiffHunkFilter::from_spec("HEAD~1 HEAD", cwd).unwrap();
-        let test_canon = std::fs::canonicalize(cwd.join("test.rs")).unwrap();
+        let test_norm = np(&cwd.join("test.rs"));
 
         // File should be included
         assert!(filter.include_file(cwd.join("test.rs").to_str().unwrap()));
 
         // Match on line 3 should be included
-        let m = Match::new(test_canon.to_str().unwrap().to_string(), "x".into());
+        let m = Match::new(test_norm.as_str().to_string(), "x".into());
         let m3 = Match { line: 3, end_line: 3, ..m.clone() };
         assert!(filter.include(&m3), "line 3 should be in a changed hunk");
 
@@ -458,15 +470,15 @@ mod tests {
 
         let hunks = parse_diff_hunks(&diff, dir.path());
 
-        let a_canon = std::fs::canonicalize(&a).unwrap();
-        let b_canon = std::fs::canonicalize(&b).unwrap();
+        let a_norm = np(&a);
+        let b_norm = np(&b);
 
-        let a_hunks = hunks.get(&a_canon).unwrap();
+        let a_hunks = hunks.get(&a_norm).unwrap();
         assert_eq!(a_hunks.len(), 2);
         assert_eq!(a_hunks[0], LineRange { start: 1, end: 3 });
         assert_eq!(a_hunks[1], LineRange { start: 11, end: 12 });
 
-        let b_hunks = hunks.get(&b_canon).unwrap();
+        let b_hunks = hunks.get(&b_norm).unwrap();
         assert_eq!(b_hunks.len(), 1);
         assert_eq!(b_hunks[0], LineRange { start: 5, end: 5 });
     }
@@ -480,14 +492,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let a = dir.path().join("a.rs");
         std::fs::write(&a, "line1\nline2\nline3\nline4\nline5\n").unwrap();
-        let a_canon = std::fs::canonicalize(&a).unwrap();
+        let a_norm = np(&a);
 
         let mut hunks = HashMap::new();
-        hunks.insert(a_canon, vec![LineRange { start: 2, end: 4 }]);
+        hunks.insert(a_norm.clone(), vec![LineRange { start: 2, end: 4 }]);
         let filter = DiffHunkFilter::from_hunks(hunks);
 
-        // Match fully within hunk
-        let m = Match::new(a.to_str().unwrap().to_string(), "x".into());
+        // Match fully within hunk. `Match::file` must already be normalized —
+        // that's the invariant the file resolver provides in production.
+        let m = Match::new(a_norm.as_str().to_string(), "x".into());
         let m = Match { line: 3, end_line: 3, ..m };
         assert!(filter.include(&m));
 
@@ -511,14 +524,14 @@ mod tests {
         let b = dir.path().join("b.rs");
         std::fs::write(&a, "").unwrap();
         std::fs::write(&b, "").unwrap();
-        let a_canon = std::fs::canonicalize(&a).unwrap();
+        let a_norm = np(&a);
 
         let mut hunks = HashMap::new();
-        hunks.insert(a_canon, vec![LineRange { start: 1, end: 10 }]);
+        hunks.insert(a_norm.clone(), vec![LineRange { start: 1, end: 10 }]);
         let filter = DiffHunkFilter::from_hunks(hunks);
 
-        assert!(filter.include_file(a.to_str().unwrap()));
-        assert!(!filter.include_file(b.to_str().unwrap()));
+        assert!(filter.include_file(a_norm.as_str()));
+        assert!(!filter.include_file(np(&b).as_str()));
     }
 
     #[test]

--- a/tractor/src/pipeline/git.rs
+++ b/tractor/src/pipeline/git.rs
@@ -389,7 +389,7 @@ mod tests {
         let test_norm = np(&cwd.join("test.rs"));
 
         // File should be included
-        assert!(filter.include_file(cwd.join("test.rs").to_str().unwrap()));
+        assert!(filter.include_file(test_norm.as_str()));
 
         // Match on line 3 should be included
         let m = Match::new(test_norm.as_str().to_string(), "x".into());

--- a/tractor/src/pipeline/input.rs
+++ b/tractor/src/pipeline/input.rs
@@ -13,7 +13,7 @@ pub fn resolve_input(
     content: Option<String>,
 ) -> Result<InputMode, Box<dyn std::error::Error>> {
     let expansion_limit = shared.max_files * 10;
-    let result = expand_globs_checked(&files, expansion_limit)
+    let result = expand_globs_checked(&files, expansion_limit, None)
         .map_err(|e| format!("{} — use a more specific pattern or increase --max-files", e))?;
     // Output boundary: downstream `InputMode::Files` carries `Vec<String>`,
     // so we convert here and treat stdin-fed paths as raw strings.

--- a/tractor/src/pipeline/input.rs
+++ b/tractor/src/pipeline/input.rs
@@ -1,5 +1,5 @@
 use std::io::{self, BufRead, Read};
-use tractor_core::{expand_globs_checked, filter_supported_files};
+use tractor_core::{expand_globs_checked, detect_language};
 use crate::cli::SharedArgs;
 
 pub enum InputMode {
@@ -15,7 +15,9 @@ pub fn resolve_input(
     let expansion_limit = shared.max_files * 10;
     let result = expand_globs_checked(&files, expansion_limit)
         .map_err(|e| format!("{} — use a more specific pattern or increase --max-files", e))?;
-    let mut files: Vec<String> = result.files;
+    // Output boundary: downstream `InputMode::Files` carries `Vec<String>`,
+    // so we convert here and treat stdin-fed paths as raw strings.
+    let mut files: Vec<String> = result.files.into_iter().map(|p| p.as_str().to_string()).collect();
 
     let input = if let Some(ref content_str) = content {
         if shared.lang.is_none() {
@@ -44,7 +46,7 @@ pub fn resolve_input(
                 }
             }
         }
-        files = filter_supported_files(files);
+        files.retain(|f| detect_language(f) != "unknown");
         InputMode::Files(files)
     };
 

--- a/tractor/tests/cli.rs
+++ b/tractor/tests/cli.rs
@@ -791,14 +791,23 @@ fn run_scope_intersection_falls_back_to_root_when_operation_has_no_files() {
 }
 
 #[test]
-fn run_scope_intersection_can_be_empty() {
-    cli_case!({
-        tractor run "scope-intersection/intersect-disjoint.yaml";
-        expect => combined "";
-    })
-    .in_fixture("run")
-    .fixture_prefix("")
-    .run();
+fn run_scope_intersection_fatal_when_empty() {
+    // Running checks on zero files is almost always a mistake (typo,
+    // stale scope, misconfigured rule) — surface it as a fatal error
+    // rather than silently succeeding. This holds whether the emptiness
+    // came from a pattern genuinely matching nothing or from sibling
+    // intersections (root ∩ operation) reducing the set to zero.
+    let result = command(["run", "scope-intersection/intersect-disjoint.yaml"])
+        .in_fixture("run")
+        .fixture_prefix("")
+        .assert_exit(1)
+        .capture();
+    let combined = format!("{}{}", result.stdout, result.stderr);
+    assert!(
+        combined.contains("file patterns matched 0 files"),
+        "expected fatal about empty expansion, got: {}",
+        combined
+    );
 }
 
 #[test]

--- a/tractor/tests/support/mod.rs
+++ b/tractor/tests/support/mod.rs
@@ -751,6 +751,7 @@ fn candidate_path_strings(path: &Path) -> Vec<String> {
     let raw = path.to_string_lossy().to_string();
     let mut candidates = vec![raw.clone()];
 
+    #[allow(clippy::disallowed_methods)] // test helper: generate fallback path variants
     if let Ok(canonical) = fs::canonicalize(path) {
         let canonical = canonical.to_string_lossy().to_string();
         if canonical != raw {


### PR DESCRIPTION
Started as a Copilot-review follow-up to #128 and grew into a broader
cleanup of the file-resolution pipeline. Everything here targets the
same surface area — how glob patterns, CLI paths, and config-relative
paths become the set of files tractor actually reads.

**Copilot review follow-ups** (original scope)
- Reject `?` in glob patterns at compile time — it was advertised but
  never actually matched, so `file?.rs` was silently a no-op.
- Introduce `GlobExpandErrorKind::{LimitExceeded, InvalidPattern}` so
  callers stop string-matching the error message.
- Surface a fatal diagnostic for invalid exclude patterns instead of
  silently dropping them (with the new walker rejecting `[...]`/`?`,
  this turned config typos into invisible no-ops).
- Emit a warning when the walker hits `MAX_DEPTH` so symlink cycles
  and pathologically deep trees are visible.

**`NormalizedPath` typed paths**
- Stop resolving symlinks in `NormalizedPath::absolute` — CLI paths
  now stay on the user's link, matching the walker's `read_dir`-built
  paths so set-equality intersections work.
- Windows: resolve 8.3 short names and case-correct against
  `read_dir` for canonical filesystem casing.
- Thread `NormalizedPath` through the diff pipeline so hunks and
  filter results compare by set equality, not by string coincidence.
- Ban `std::fs::canonicalize` via `clippy::disallowed_methods` and
  delete `NormalizedPath::into_string` to prevent regressions.

**Walker pruning by sibling literal prefixes** (primary new feature)
When root / CLI / operation pattern sets intersect downstream, the
walker now skips subtrees that couldn't contribute to the result.
Each pattern contributes its wildcard-free path prefix; a `FilePrune`
predicate (AND-of-OR groups) gates directory descent. Two use cases:
- Scoping to a directory — `backend/**/*.cs` on the CLI + `**/*.cs`
  in a rule walks only `backend/`.
- Scoping to a single file — a concrete CLI path short-circuits
  every rule expansion to that one file.

**Windows test hardening**
- `diff_hunk_filter` test now queries with the same `NormalizedPath`
  keying as the production code path.
- `expand_invalid_pattern_kind` anchors at `./` so the walker reaches
  the pattern-compile failure path on Windows (where `/tmp` doesn't
  exist and would short-circuit first).
- Added symlink-cycle termination test for the walker.

Option B (pruning further *expanded* sets against *unfinished* walks)
is left as future work — the prefix-based approach covers the two
primary use cases with much less state.

All tests pass. Pre-existing `useless_format` clippy warnings are not
addressed here.

https://claude.ai/code/session_01AVFvSBm4eiaZyDVAT5VZP3