### PR TITLE
Drop identifier→type heuristic; default identifiers to <name>

### DIFF
--- a/tests/integration/languages/go/sample.go.xml
+++ b/tests/integration/languages/go/sample.go.xml
@@ -27,16 +27,12 @@
               <params>
                 (
                 <param>
-                  <name>
-                    <type>a</type>
-                  </name>
+                  <name>a</name>
                   <type>int</type>
                 </param>
                 ,
                 <param>
-                  <name>
-                    <type>b</type>
-                  </name>
+                  <name>b</name>
                   <type>int</type>
                 </param>
                 )
@@ -54,11 +50,11 @@
                       +
                     </op>
                     <left>
-                      <type>a</type>
+                      <name>a</name>
                     </left>
                     +
                     <right>
-                      <type>b</type>
+                      <name>b</name>
                     </right>
                   </binary>
                 </expression_list>
@@ -78,14 +74,14 @@
               <short_var_declaration>
                 <left>
                   <expression_list>
-                    <type>result</type>
+                    <name>result</name>
                   </expression_list>
                 </left>
                 :=
                 <right>
                   <expression_list>
                     <call>
-                      <type>add</type>
+                      <name>add</name>
                       <arguments>
                         <argument_list>
                           (
@@ -101,7 +97,7 @@
               </short_var_declaration>
               <call>
                 <member>
-                  <type>fmt</type>
+                  <name>fmt</name>
                   .
                   <field>Printf</field>
                 </member>
@@ -115,7 +111,7 @@
                       &quot;
                     </string>
                     ,
-                    <type>result</type>
+                    <name>result</name>
                     )
                   </argument_list>
                 </arguments>

--- a/tests/integration/languages/java/sample.java.xml
+++ b/tests/integration/languages/java/sample.java.xml
@@ -15,9 +15,7 @@
                 <private/>
                 <integral_type>int</integral_type>
                 <variable_declarator>
-                  <name>
-                    <type>value</type>
-                  </name>
+                  <name>value</name>
                 </variable_declarator>
                 ;
               </field>
@@ -29,9 +27,7 @@
                     (
                     <param>
                       <integral_type>int</integral_type>
-                      <name>
-                        <type>value</type>
-                      </name>
+                      <name>value</name>
                     </param>
                     )
                   </params>
@@ -45,12 +41,12 @@
                         <member>
                           <this>this</this>
                           .
-                          <type>value</type>
+                          <name>value</name>
                         </member>
                       </left>
                       =
                       <right>
-                        <type>value</type>
+                        <name>value</name>
                       </right>
                     </assign>
                     ;
@@ -68,16 +64,12 @@
                     (
                     <param>
                       <integral_type>int</integral_type>
-                      <name>
-                        <type>a</type>
-                      </name>
+                      <name>a</name>
                     </param>
                     ,
                     <param>
                       <integral_type>int</integral_type>
-                      <name>
-                        <type>b</type>
-                      </name>
+                      <name>b</name>
                     </param>
                     )
                   </params>
@@ -92,11 +84,11 @@
                         +
                       </op>
                       <left>
-                        <type>a</type>
+                        <name>a</name>
                       </left>
                       +
                       <right>
-                        <type>b</type>
+                        <name>b</name>
                       </right>
                     </binary>
                     ;
@@ -113,9 +105,7 @@
                     (
                     <param>
                       <type>String</type>
-                      <name>
-                        <type>message</type>
-                      </name>
+                      <name>message</name>
                     </param>
                     )
                   </params>
@@ -124,18 +114,16 @@
                   {
                   <call>
                     <member>
-                      <type>System</type>
+                      <name>System</name>
                       .
-                      <type>out</type>
+                      <name>out</name>
                     </member>
                     .
-                    <name>
-                      <type>println</type>
-                    </name>
+                    <name>println</name>
                     <arguments>
                       <args>
                         (
-                        <type>message</type>
+                        <name>message</name>
                         )
                       </args>
                     </arguments>
@@ -170,9 +158,7 @@
                         <type>String</type>
                         <dimensions>[]</dimensions>
                       </array>
-                      <name>
-                        <type>args</type>
-                      </name>
+                      <name>args</name>
                     </param>
                     )
                   </params>
@@ -182,15 +168,11 @@
                   <local_variable_declaration>
                     <integral_type>int</integral_type>
                     <variable_declarator>
-                      <name>
-                        <type>result</type>
-                      </name>
+                      <name>result</name>
                       =
                       <value>
                         <call>
-                          <name>
-                            <type>add</type>
-                          </name>
+                          <name>add</name>
                           <arguments>
                             <args>
                               (
@@ -207,14 +189,12 @@
                   </local_variable_declaration>
                   <call>
                     <member>
-                      <type>System</type>
+                      <name>System</name>
                       .
-                      <type>out</type>
+                      <name>out</name>
                     </member>
                     .
-                    <name>
-                      <type>println</type>
-                    </name>
+                    <name>println</name>
                     <arguments>
                       <args>
                         (
@@ -232,7 +212,7 @@
                           </left>
                           +
                           <right>
-                            <type>result</type>
+                            <name>result</name>
                           </right>
                         </binary>
                         )
@@ -272,15 +252,11 @@
               <enum_body>
                 {
                 <enum_constant>
-                  <name>
-                    <type>ACTIVE</type>
-                  </name>
+                  <name>ACTIVE</name>
                 </enum_constant>
                 ,
                 <enum_constant>
-                  <name>
-                    <type>INACTIVE</type>
-                  </name>
+                  <name>INACTIVE</name>
                 </enum_constant>
                 }
               </enum_body>

--- a/tests/integration/languages/javascript/sample.js.xml
+++ b/tests/integration/languages/javascript/sample.js.xml
@@ -11,9 +11,9 @@
             <parameters>
               <params>
                 (
-                <type>a</type>
+                <name>a</name>
                 ,
-                <type>b</type>
+                <name>b</name>
                 )
               </params>
             </parameters>
@@ -28,11 +28,11 @@
                       +
                     </op>
                     <left>
-                      <type>a</type>
+                      <name>a</name>
                     </left>
                     +
                     <right>
-                      <type>b</type>
+                      <name>b</name>
                     </right>
                   </binary>
                   ;
@@ -53,9 +53,7 @@
                 <variable>
                   <const/>
                   const
-                  <name>
-                    <type>result</type>
-                  </name>
+                  <name>result</name>
                   =
                   <value>
                     <call>
@@ -98,7 +96,7 @@
                         <string_fragment>Result: </string_fragment>
                         <template_substitution>
                           ${
-                          <type>result</type>
+                          <name>result</name>
                           }
                         </template_substitution>
                         `

--- a/tests/integration/languages/python/multiline-string-crlf.py.xml
+++ b/tests/integration/languages/python/multiline-string-crlf.py.xml
@@ -6,7 +6,7 @@
         <module>
           <assign>
             <left>
-              <type>msg</type>
+              <name>msg</name>
             </left>
             =
             <right>

--- a/tests/integration/languages/python/multiline-string-lf.py.xml
+++ b/tests/integration/languages/python/multiline-string-lf.py.xml
@@ -6,7 +6,7 @@
         <module>
           <assign>
             <left>
-              <type>msg</type>
+              <name>msg</name>
             </left>
             =
             <right>

--- a/tests/integration/languages/python/sample.py.xml
+++ b/tests/integration/languages/python/sample.py.xml
@@ -15,9 +15,9 @@
             <params>
               <params>
                 (
-                <type>a</type>
+                <name>a</name>
                 ,
-                <type>b</type>
+                <name>b</name>
                 )
               </params>
             </params>
@@ -36,11 +36,11 @@
                     +
                   </op>
                   <left>
-                    <type>a</type>
+                    <name>a</name>
                   </left>
                   +
                   <right>
-                    <type>b</type>
+                    <name>b</name>
                   </right>
                 </binary>
               </return>
@@ -53,7 +53,7 @@
             <params>
               <params>
                 (
-                <type>url</type>
+                <name>url</name>
                 )
               </params>
             </params>
@@ -66,7 +66,7 @@
               </string>
               <return>
                 return
-                <type>url</type>
+                <name>url</name>
               </return>
             </body>
           </function>
@@ -80,12 +80,12 @@
             <body>
               <assign>
                 <left>
-                  <type>result</type>
+                  <name>result</name>
                 </left>
                 =
                 <right>
                   <call>
-                    <type>add</type>
+                    <name>add</name>
                     <arguments>
                       <argument_list>
                         (
@@ -99,7 +99,7 @@
                 </right>
               </assign>
               <call>
-                <type>print</type>
+                <name>print</name>
                 <arguments>
                   <argument_list>
                     (
@@ -108,7 +108,7 @@
                       <string_content>Result: </string_content>
                       <interpolation>
                         {
-                        <type>result</type>
+                        <name>result</name>
                         }
                       </interpolation>
                       <string_end>&quot;</string_end>
@@ -127,7 +127,7 @@
                   <equals/>
                   ==
                 </op>
-                <type>__name__</type>
+                <name>__name__</name>
                 ==
                 <string>
                   <string_start>&quot;</string_start>
@@ -139,7 +139,7 @@
             :
             <consequence>
               <call>
-                <type>main</type>
+                <name>main</name>
                 <arguments>
                   <argument_list>()</argument_list>
                 </arguments>

--- a/tests/integration/languages/rust/sample.rs.xml
+++ b/tests/integration/languages/rust/sample.rs.xml
@@ -13,13 +13,13 @@
               <params>
                 (
                 <param>
-                  <type>a</type>
+                  <name>a</name>
                   :
                   <type>i32</type>
                 </param>
                 ,
                 <param>
-                  <type>b</type>
+                  <name>b</name>
                   :
                   <type>i32</type>
                 </param>
@@ -36,11 +36,11 @@
                   +
                 </op>
                 <left>
-                  <type>a</type>
+                  <name>a</name>
                 </left>
                 +
                 <right>
-                  <type>b</type>
+                  <name>b</name>
                 </right>
               </binary>
               }
@@ -57,11 +57,11 @@
               {
               <let>
                 let
-                <type>result</type>
+                <name>result</name>
                 =
                 <value>
                   <call>
-                    <type>add</type>
+                    <name>add</name>
                     <arguments>
                       <arguments>
                         (
@@ -76,7 +76,7 @@
                 ;
               </let>
               <macro>
-                <type>println</type>
+                <name>println</name>
                 !
                 <token_tree>
                   (
@@ -86,7 +86,7 @@
                     &quot;
                   </string>
                   ,
-                  <type>result</type>
+                  <name>result</name>
                   )
                 </token_tree>
               </macro>
@@ -120,17 +120,13 @@
                 {
                 <field_declaration>
                   <pub/>
-                  <name>
-                    <field_identifier>x</field_identifier>
-                  </name>
+                  <name>x</name>
                   :
                   <type>i32</type>
                 </field_declaration>
                 ,
                 <field_declaration>
-                  <name>
-                    <field_identifier>y</field_identifier>
-                  </name>
+                  <name>y</name>
                   :
                   <type>i32</type>
                 </field_declaration>
@@ -147,21 +143,15 @@
               <enum_variant_list>
                 {
                 <enum_variant>
-                  <name>
-                    <type>Red</type>
-                  </name>
+                  <name>Red</name>
                 </enum_variant>
                 ,
                 <enum_variant>
-                  <name>
-                    <type>Green</type>
-                  </name>
+                  <name>Green</name>
                 </enum_variant>
                 ,
                 <enum_variant>
-                  <name>
-                    <type>Blue</type>
-                  </name>
+                  <name>Blue</name>
                 </enum_variant>
                 ,
         }
@@ -176,9 +166,7 @@
               {
               <function_signature_item>
                 fn
-                <name>
-                  <type>draw</type>
-                </name>
+                <name>draw</name>
                 <params>
                   <params>
                     (

--- a/tests/integration/languages/tsx/sample.tsx.xml
+++ b/tests/integration/languages/tsx/sample.tsx.xml
@@ -8,14 +8,12 @@
           <import>
             import
             <import_clause>
-              <type>React</type>
+              <name>React</name>
               ,
               <named_imports>
                 {
                 <import_specifier>
-                  <name>
-                    <type>useState</type>
-                  </name>
+                  <name>useState</name>
                 </import_specifier>
                 }
               </named_imports>
@@ -36,9 +34,7 @@
             <body>
               {
               <property_signature>
-                <name>
-                  <type>name</type>
-                </name>
+                <name>name</name>
                 <typeof>
                   :
                   <predefined_type>string</predefined_type>
@@ -46,9 +42,7 @@
               </property_signature>
               ;
               <property_signature>
-                <name>
-                  <type>age</type>
-                </name>
+                <name>age</name>
                 ?
                 <typeof>
                   :
@@ -91,9 +85,9 @@
                   <name>
                     <array_pattern>
                       [
-                      <type>count</type>
+                      <name>count</name>
                       ,
-                      <type>setCount</type>
+                      <name>setCount</name>
                       ]
                     </array_pattern>
                   </name>
@@ -122,11 +116,9 @@
                     <jsx_element>
                       <jsx_opening_element>
                         &lt;
-                        <name>
-                          <type>div</type>
-                        </name>
+                        <name>div</name>
                         <jsx_attribute>
-                          <type>className</type>
+                          <name>className</name>
                           =
                           <string>
                             &quot;
@@ -139,23 +131,19 @@
                       <jsx_element>
                         <jsx_opening_element>
                           &lt;
-                          <name>
-                            <type>h1</type>
-                          </name>
+                          <name>h1</name>
                           &gt;
                         </jsx_opening_element>
                         <jsx_text>Hello, </jsx_text>
                         <jsx_expression>
                           {
-                          <type>name</type>
+                          <name>name</name>
                           }
                         </jsx_expression>
                         <jsx_text>!</jsx_text>
                         <jsx_closing_element>
                           &lt;/
-                          <name>
-                            <type>h1</type>
-                          </name>
+                          <name>h1</name>
                           &gt;
                         </jsx_closing_element>
                       </jsx_element>
@@ -169,29 +157,25 @@
                             &amp;&amp;
                           </op>
                           <left>
-                            <type>age</type>
+                            <name>age</name>
                           </left>
                           &amp;&amp;
                           <right>
                             <jsx_element>
                               <jsx_opening_element>
                                 &lt;
-                                <name>
-                                  <type>span</type>
-                                </name>
+                                <name>span</name>
                                 &gt;
                               </jsx_opening_element>
                               <jsx_text>Age: </jsx_text>
                               <jsx_expression>
                                 {
-                                <type>age</type>
+                                <name>age</name>
                                 }
                               </jsx_expression>
                               <jsx_closing_element>
                                 &lt;/
-                                <name>
-                                  <type>span</type>
-                                </name>
+                                <name>span</name>
                                 &gt;
                               </jsx_closing_element>
                             </jsx_element>
@@ -202,11 +186,9 @@
                       <jsx_element>
                         <jsx_opening_element>
                           &lt;
-                          <name>
-                            <type>button</type>
-                          </name>
+                          <name>button</name>
                           <jsx_attribute>
-                            <type>onClick</type>
+                            <name>onClick</name>
                             =
                             <jsx_expression>
                               {
@@ -230,7 +212,7 @@
                                             +
                                           </op>
                                           <left>
-                                            <type>count</type>
+                                            <name>count</name>
                                           </left>
                                           +
                                           <right>
@@ -252,24 +234,20 @@
                         Clicked </jsx_text>
                         <jsx_expression>
                           {
-                          <type>count</type>
+                          <name>count</name>
                           }
                         </jsx_expression>
                         <jsx_text> times
                     </jsx_text>
                         <jsx_closing_element>
                           &lt;/
-                          <name>
-                            <type>button</type>
-                          </name>
+                          <name>button</name>
                           &gt;
                         </jsx_closing_element>
                       </jsx_element>
                       <jsx_closing_element>
                         &lt;/
-                        <name>
-                          <type>div</type>
-                        </name>
+                        <name>div</name>
                         &gt;
                       </jsx_closing_element>
                     </jsx_element>
@@ -284,7 +262,7 @@
           <export>
             export default
             <value>
-              <type>Greeting</type>
+              <name>Greeting</name>
             </value>
             ;
           </export>

--- a/tests/integration/languages/typescript/sample.ts.xml
+++ b/tests/integration/languages/typescript/sample.ts.xml
@@ -13,7 +13,7 @@
                 (
                 <param>
                   <required/>
-                  <type>a</type>
+                  <name>a</name>
                   <typeof>
                     :
                     <predefined_type>number</predefined_type>
@@ -22,7 +22,7 @@
                 ,
                 <param>
                   <required/>
-                  <type>b</type>
+                  <name>b</name>
                   <typeof>
                     :
                     <predefined_type>number</predefined_type>
@@ -46,11 +46,11 @@
                       +
                     </op>
                     <left>
-                      <type>a</type>
+                      <name>a</name>
                     </left>
                     +
                     <right>
-                      <type>b</type>
+                      <name>b</name>
                     </right>
                   </binary>
                   ;
@@ -75,9 +75,7 @@
                 <variable>
                   <const/>
                   const
-                  <name>
-                    <type>result</type>
-                  </name>
+                  <name>result</name>
                   =
                   <value>
                     <call>
@@ -120,7 +118,7 @@
                         <string_fragment>Result: </string_fragment>
                         <template_substitution>
                           ${
-                          <type>result</type>
+                          <name>result</name>
                           }
                         </template_substitution>
                         `
@@ -152,9 +150,7 @@
             <body>
               {
               <property_signature>
-                <name>
-                  <type>name</type>
-                </name>
+                <name>name</name>
                 <typeof>
                   :
                   <predefined_type>string</predefined_type>
@@ -162,9 +158,7 @@
               </property_signature>
               ;
               <property_signature>
-                <name>
-                  <type>age</type>
-                </name>
+                <name>age</name>
                 <typeof>
                   :
                   <predefined_type>number</predefined_type>
@@ -176,22 +170,14 @@
           </interface>
           <enum>
             enum
-            <name>
-              <type>Color</type>
-            </name>
+            <name>Color</name>
             <body>
               {
-              <name>
-                <type>Red</type>
-              </name>
+              <name>Red</name>
               ,
-              <name>
-                <type>Green</type>
-              </name>
+              <name>Green</name>
               ,
-              <name>
-                <type>Blue</type>
-              </name>
+              <name>Blue</name>
               }
             </body>
           </enum>
@@ -203,7 +189,7 @@
                 (
                 <param>
                   <required/>
-                  <type>name</type>
+                  <name>name</name>
                   <typeof>
                     :
                     <predefined_type>string</predefined_type>
@@ -212,7 +198,7 @@
                 ,
                 <param>
                   <optional/>
-                  <type>title</type>
+                  <name>title</name>
                   ?
                   <typeof>
                     :
@@ -233,7 +219,7 @@
                   return
                   <ternary>
                     <condition>
-                      <type>title</type>
+                      <name>title</name>
                     </condition>
                     ?
                     <consequence>
@@ -241,13 +227,13 @@
                         `
                         <template_substitution>
                           ${
-                          <type>title</type>
+                          <name>title</name>
                           }
                         </template_substitution>
                         <string_fragment> </string_fragment>
                         <template_substitution>
                           ${
-                          <type>name</type>
+                          <name>name</name>
                           }
                         </template_substitution>
                         `
@@ -255,7 +241,7 @@
                     </consequence>
                     :
                     <alternative>
-                      <type>name</type>
+                      <name>name</name>
                     </alternative>
                   </ternary>
                   ;
@@ -272,7 +258,7 @@
                 (
                 <param>
                   <required/>
-                  <type>host</type>
+                  <name>host</name>
                   <typeof>
                     :
                     <predefined_type>string</predefined_type>
@@ -281,7 +267,7 @@
                 ,
                 <param>
                   <required/>
-                  <type>port</type>
+                  <name>port</name>
                   <typeof>
                     :
                     <predefined_type>number</predefined_type>
@@ -290,7 +276,7 @@
                 ,
                 <param>
                   <optional/>
-                  <type>timeout</type>
+                  <name>timeout</name>
                   ?
                   <typeof>
                     :
@@ -324,11 +310,11 @@
                   <arguments>
                     <arguments>
                       (
-                      <type>host</type>
+                      <name>host</name>
                       ,
-                      <type>port</type>
+                      <name>port</name>
                       ,
-                      <type>timeout</type>
+                      <name>timeout</name>
                       )
                     </arguments>
                   </arguments>

--- a/todo/12-field-role-elements-all-languages.md
+++ b/todo/12-field-role-elements-all-languages.md
@@ -1,23 +1,24 @@
 # Field-as-role-element for all languages
 
-JS/TS now promotes tree-sitter field names (`function`, `object`, `property`) to
-wrapper elements in call/member expressions, replacing the global `identifier` →
-`type` rename with a `<ref/>` marker for simple references.
+Replaced the per-language `classify_identifier` heuristic (default
+`identifier → type`) with the simpler rule: tree-sitter already distinguishes
+type positions via `type_identifier`, `primitive_type`, `predefined_type`, etc.,
+so bare `identifier` → `name` with no context inspection.
 
-Apply the same pattern to other languages:
+Done:
+- [x] Rust (`rust_lang.rs`)
+- [x] Python (`python.rs`)
+- [x] Java (`java.rs`)
+- [x] Go (`go.rs`)
+- [x] TypeScript/JavaScript (`typescript.rs`) — kept call/member field promotion
+      for `<function>`/`<object>`/`<property>` wrappers with `<ref/>` markers
 
-- [ ] C# (`csharp.rs`) — `classify_identifier` returns `"type"`, `"name"`, or `"ref"`
-- [ ] Java (`java.rs`) — same pattern
-- [ ] Python (`python.rs`) — same pattern
-- [ ] Go (`go.rs`) — same pattern
-- [ ] Rust (`rust_lang.rs`) — same pattern
-- [ ] T-SQL (`tsql.rs`) — uses `transform_identifier` with different categories
+Not migrated:
+- C# (`csharp.rs`) — uses `name`/`type`/`ref` trio with namespace-aware logic;
+  not broken, but diverges from the spec's `<name>`-for-references convention.
+- T-SQL (`tsql.rs`) — uses its own `transform_identifier` with categories
+  specific to SQL; out of scope for the identifier-to-type fix.
 
-Each language should:
-1. Identify which field names to promote (language-specific — may differ from JS/TS)
-2. Call `promote_field_to_wrapper` on appropriate parent nodes
-3. Add `inline_identifier_with_ref` handler for the new wrapper elements
-4. Stop renaming identifiers to `<type>` in non-type contexts
-5. Update integration tests and snapshots
-
-The shared helper `promote_field_to_wrapper` in `xot_transform::helpers` is ready.
+JS/TS keeps `promote_field_to_wrapper` for call/member expressions so call
+targets and member chains render as `<function><ref/>x</function>` etc. Other
+languages do not currently promote fields beyond the builder's defaults.

--- a/tractor/src/languages/go.rs
+++ b/tractor/src/languages/go.rs
@@ -15,32 +15,11 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
         "expression_statement" => Ok(TransformAction::Skip),
         "block" => Ok(TransformAction::Flatten),
 
-        // Name wrappers - inline identifier text directly
+        // Name wrappers created by the builder for field="name".
+        // Inline the single identifier/type_identifier child as text:
+        //   <name><identifier>foo</identifier></name> -> <name>foo</name>
         "name" => {
-            if let Some(parent) = get_parent(xot, node) {
-                let parent_kind = get_element_name(xot, parent).unwrap_or_default();
-                if matches!(parent_kind.as_str(),
-                    "function_declaration" | "method_declaration" | "type_spec"
-                    | "function" | "method" | "typespec"
-                ) {
-                    let children: Vec<_> = xot.children(node).collect();
-                    for child in children {
-                        if let Some(child_name) = get_element_name(xot, child) {
-                            if child_name == "identifier" || child_name == "type_identifier" {
-                                if let Some(text) = get_text_content(xot, child) {
-                                    let all_children: Vec<_> = xot.children(node).collect();
-                                    for c in all_children {
-                                        xot.detach(c)?;
-                                    }
-                                    let text_node = xot.new_text(&text);
-                                    xot.append(node, text_node)?;
-                                    return Ok(TransformAction::Done);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            inline_single_identifier(xot, node)?;
             Ok(TransformAction::Continue)
         }
 
@@ -62,9 +41,11 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
             Ok(TransformAction::Continue)
         }
 
+        // Identifiers are always names (definitions or references).
+        // Tree-sitter uses `type_identifier` for type positions, so bare
+        // identifiers never need a heuristic — they are never types.
         "identifier" => {
-            let classification = classify_identifier(xot, node);
-            rename(xot, node, classification);
+            rename(xot, node, "name");
             Ok(TransformAction::Continue)
         }
         "type_identifier" => {
@@ -180,20 +161,32 @@ fn extract_operator(xot: &mut Xot, node: XotNode) -> Result<(), xot::Error> {
     Ok(())
 }
 
-fn classify_identifier(xot: &Xot, node: XotNode) -> &'static str {
-    let parent = match get_parent(xot, node) {
-        Some(p) => p,
-        None => return "name",
-    };
-    let parent_kind = get_element_name(xot, parent).unwrap_or_default();
-
-    match parent_kind.as_str() {
-        "function_declaration" | "method_declaration" => "name",
-        "type_spec" => "name",
-        "parameter_declaration" => "name",
-        "var_spec" | "const_spec" => "name",
-        _ => "type",
+/// If `node` contains a single identifier child, replace the node's children
+/// with that identifier's text. Used to flatten builder-created wrappers like
+/// `<name><identifier>foo</identifier></name>` to `<name>foo</name>`.
+fn inline_single_identifier(xot: &mut Xot, node: XotNode) -> Result<(), xot::Error> {
+    let children: Vec<_> = xot.children(node).collect();
+    for child in children {
+        let child_name = match get_element_name(xot, child) {
+            Some(n) => n,
+            None => continue,
+        };
+        if !matches!(child_name.as_str(), "identifier" | "type_identifier") {
+            continue;
+        }
+        let text = match get_text_content(xot, child) {
+            Some(t) => t,
+            None => continue,
+        };
+        let all_children: Vec<_> = xot.children(node).collect();
+        for c in all_children {
+            xot.detach(c)?;
+        }
+        let text_node = xot.new_text(&text);
+        xot.append(node, text_node)?;
+        return Ok(());
     }
+    Ok(())
 }
 
 /// Map a transformed element name to a syntax category for highlighting

--- a/tractor/src/languages/java.rs
+++ b/tractor/src/languages/java.rs
@@ -26,34 +26,12 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
         "class_body" | "interface_body" | "block" => Ok(TransformAction::Flatten),
 
         // ---------------------------------------------------------------------
-        // Name wrappers - inline identifier text directly
+        // Name wrappers created by the builder for field="name".
+        // Inline the single identifier child as text:
+        //   <name><identifier>foo</identifier></name> -> <name>foo</name>
         // ---------------------------------------------------------------------
         "name" => {
-            if let Some(parent) = get_parent(xot, node) {
-                let parent_kind = get_element_name(xot, parent).unwrap_or_default();
-                if matches!(parent_kind.as_str(),
-                    "class_declaration" | "interface_declaration" | "enum_declaration"
-                    | "method_declaration" | "constructor_declaration"
-                    | "class" | "interface" | "enum" | "method" | "ctor"
-                ) {
-                    let children: Vec<_> = xot.children(node).collect();
-                    for child in children {
-                        if let Some(child_name) = get_element_name(xot, child) {
-                            if child_name == "identifier" {
-                                if let Some(text) = get_text_content(xot, child) {
-                                    let all_children: Vec<_> = xot.children(node).collect();
-                                    for c in all_children {
-                                        xot.detach(c)?;
-                                    }
-                                    let text_node = xot.new_text(&text);
-                                    xot.append(node, text_node)?;
-                                    return Ok(TransformAction::Done);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            inline_single_identifier(xot, node)?;
             Ok(TransformAction::Continue)
         }
 
@@ -98,11 +76,12 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
         }
 
         // ---------------------------------------------------------------------
-        // Identifiers - classify as name or type based on context
+        // Identifiers are always names (definitions or references).
+        // Tree-sitter uses `type_identifier` for type positions, so bare
+        // identifiers never need a heuristic — they are never types.
         // ---------------------------------------------------------------------
         "identifier" => {
-            let classification = classify_identifier(xot, node);
-            rename(xot, node, classification);
+            rename(xot, node, "name");
             Ok(TransformAction::Continue)
         }
         "type_identifier" => {
@@ -222,38 +201,28 @@ fn extract_operator(xot: &mut Xot, node: XotNode) -> Result<(), xot::Error> {
     Ok(())
 }
 
-/// Classify an identifier as "name" or "type" based on context
-fn classify_identifier(xot: &Xot, node: XotNode) -> &'static str {
-    let parent = match get_parent(xot, node) {
-        Some(p) => p,
-        None => return "type",  // Default for Java
-    };
-    let parent_kind = get_element_name(xot, parent).unwrap_or_default();
-
-    // Check if followed by parameter list (method/ctor name)
-    let siblings = get_following_siblings(xot, node);
-    let has_param_sibling = siblings.iter().any(|&s| {
-        get_element_name(xot, s)
-            .map(|n| matches!(n.as_str(), "formal_parameters" | "parameters"))
-            .unwrap_or(false)
-    });
-
-    match parent_kind.as_str() {
-        // Method/constructor names followed by params
-        "method_declaration" | "constructor_declaration" if has_param_sibling => "name",
-
-        // Type declarations - the identifier IS the name
-        "class_declaration" | "interface_declaration" | "enum_declaration" => "name",
-
-        // Variable declarator - the identifier is the name
-        "variable_declarator" => "name",
-
-        // Parameter - the identifier is the parameter name
-        "formal_parameter" => "name",
-
-        // Default to type
-        _ => "type",
+/// If `node` contains a single identifier child, replace the node's children
+/// with that identifier's text. Used to flatten builder-created wrappers like
+/// `<name><identifier>foo</identifier></name>` to `<name>foo</name>`.
+fn inline_single_identifier(xot: &mut Xot, node: XotNode) -> Result<(), xot::Error> {
+    let children: Vec<_> = xot.children(node).collect();
+    for child in children {
+        if get_element_name(xot, child).as_deref() != Some("identifier") {
+            continue;
+        }
+        let text = match get_text_content(xot, child) {
+            Some(t) => t,
+            None => continue,
+        };
+        let all_children: Vec<_> = xot.children(node).collect();
+        for c in all_children {
+            xot.detach(c)?;
+        }
+        let text_node = xot.new_text(&text);
+        xot.append(node, text_node)?;
+        return Ok(());
     }
+    Ok(())
 }
 
 /// Map a transformed element name to a syntax category for highlighting

--- a/tractor/src/languages/python.rs
+++ b/tractor/src/languages/python.rs
@@ -15,32 +15,18 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
         "expression_statement" => Ok(TransformAction::Skip),
         "block" => Ok(TransformAction::Flatten),
 
-        // Name wrappers - inline identifier text directly
+        // Name wrappers created by the builder for field="name".
+        // Inline the single identifier child as text:
+        //   <name><identifier>foo</identifier></name> -> <name>foo</name>
         "name" => {
-            if let Some(parent) = get_parent(xot, node) {
-                let parent_kind = get_element_name(xot, parent).unwrap_or_default();
-                if matches!(parent_kind.as_str(),
-                    "function_definition" | "class_definition"
-                    | "function" | "class"
-                ) {
-                    let children: Vec<_> = xot.children(node).collect();
-                    for child in children {
-                        if let Some(child_name) = get_element_name(xot, child) {
-                            if child_name == "identifier" {
-                                if let Some(text) = get_text_content(xot, child) {
-                                    let all_children: Vec<_> = xot.children(node).collect();
-                                    for c in all_children {
-                                        xot.detach(c)?;
-                                    }
-                                    let text_node = xot.new_text(&text);
-                                    xot.append(node, text_node)?;
-                                    return Ok(TransformAction::Done);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            inline_single_identifier(xot, node)?;
+            Ok(TransformAction::Continue)
+        }
+
+        // Type wrappers from Python's tree-sitter grammar contain a single
+        // identifier — inline it so the result is `<type>int</type>`.
+        "type" => {
+            inline_single_identifier(xot, node)?;
             Ok(TransformAction::Continue)
         }
 
@@ -64,10 +50,11 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
             Ok(TransformAction::Continue)
         }
 
-        // Identifiers
+        // Identifiers are always names (definitions or references).
+        // Tree-sitter uses a separate `type` node for type annotations, so
+        // bare identifiers never need a heuristic — they are never types.
         "identifier" => {
-            let classification = classify_identifier(xot, node);
-            rename(xot, node, classification);
+            rename(xot, node, "name");
             Ok(TransformAction::Continue)
         }
 
@@ -140,19 +127,28 @@ fn extract_operator(xot: &mut Xot, node: XotNode) -> Result<(), xot::Error> {
     Ok(())
 }
 
-fn classify_identifier(xot: &Xot, node: XotNode) -> &'static str {
-    let parent = match get_parent(xot, node) {
-        Some(p) => p,
-        None => return "name",
-    };
-    let parent_kind = get_element_name(xot, parent).unwrap_or_default();
-
-    match parent_kind.as_str() {
-        "function_definition" | "class_definition" => "name",
-        "parameter" | "default_parameter" | "typed_parameter" => "name",
-        "assignment" => "name",
-        _ => "type",
+/// If `node` contains a single identifier child, replace the node's children
+/// with that identifier's text. Used to flatten builder-created wrappers like
+/// `<name><identifier>foo</identifier></name>` to `<name>foo</name>`.
+fn inline_single_identifier(xot: &mut Xot, node: XotNode) -> Result<(), xot::Error> {
+    let children: Vec<_> = xot.children(node).collect();
+    for child in children {
+        if get_element_name(xot, child).as_deref() != Some("identifier") {
+            continue;
+        }
+        let text = match get_text_content(xot, child) {
+            Some(t) => t,
+            None => continue,
+        };
+        let all_children: Vec<_> = xot.children(node).collect();
+        for c in all_children {
+            xot.detach(c)?;
+        }
+        let text_node = xot.new_text(&text);
+        xot.append(node, text_node)?;
+        return Ok(());
     }
+    Ok(())
 }
 
 /// Map a transformed element name to a syntax category for highlighting

--- a/tractor/src/languages/rust_lang.rs
+++ b/tractor/src/languages/rust_lang.rs
@@ -15,33 +15,11 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
         "expression_statement" => Ok(TransformAction::Skip),
         "block" | "declaration_list" => Ok(TransformAction::Flatten),
 
-        // Name wrappers - inline identifier text directly
-        // <name><identifier>foo</identifier></name> -> <name>foo</name>
+        // Name wrappers created by the builder for field="name".
+        // Inline the single identifier/type_identifier/field_identifier child as text:
+        //   <name><identifier>foo</identifier></name> -> <name>foo</name>
         "name" => {
-            if let Some(parent) = get_parent(xot, node) {
-                let parent_kind = get_element_name(xot, parent).unwrap_or_default();
-                if matches!(parent_kind.as_str(),
-                    "function_item" | "struct_item" | "enum_item" | "trait_item" | "mod_item" | "type_item"
-                    | "function" | "struct" | "enum" | "trait" | "mod" | "typedef"
-                ) {
-                    let children: Vec<_> = xot.children(node).collect();
-                    for child in children {
-                        if let Some(child_name) = get_element_name(xot, child) {
-                            if child_name == "identifier" || child_name == "type_identifier" {
-                                if let Some(text) = get_text_content(xot, child) {
-                                    let all_children: Vec<_> = xot.children(node).collect();
-                                    for c in all_children {
-                                        xot.detach(c)?;
-                                    }
-                                    let text_node = xot.new_text(&text);
-                                    xot.append(node, text_node)?;
-                                    return Ok(TransformAction::Done);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            inline_single_identifier(xot, node)?;
             Ok(TransformAction::Continue)
         }
 
@@ -100,9 +78,12 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
             Ok(TransformAction::Continue)
         }
 
-        "identifier" => {
-            let classification = classify_identifier(xot, node);
-            rename(xot, node, classification);
+        // Identifiers are always names (definitions or references).
+        // Tree-sitter uses distinct node kinds for type positions
+        // (type_identifier, primitive_type, etc.), so bare identifiers
+        // never need a heuristic — they are never types.
+        "identifier" | "field_identifier" | "shorthand_field_identifier" => {
+            rename(xot, node, "name");
             Ok(TransformAction::Continue)
         }
         "type_identifier" | "primitive_type" => {
@@ -190,28 +171,34 @@ fn extract_modifiers(xot: &mut Xot, node: XotNode) -> Result<(), xot::Error> {
     Ok(())
 }
 
-fn classify_identifier(xot: &Xot, node: XotNode) -> &'static str {
-    let parent = match get_parent(xot, node) {
-        Some(p) => p,
-        None => return "name",
-    };
-    let parent_kind = get_element_name(xot, parent).unwrap_or_default();
-
-    // Check if followed by parameter list
-    let siblings = get_following_siblings(xot, node);
-    let has_param_sibling = siblings.iter().any(|&s| {
-        get_element_name(xot, s)
-            .map(|n| matches!(n.as_str(), "parameters"))
-            .unwrap_or(false)
-    });
-
-    match parent_kind.as_str() {
-        "function_item" if has_param_sibling => "name",
-        "struct_item" | "enum_item" | "trait_item" | "mod_item" | "type_item" => "name",
-        "let_declaration" => "name",
-        "parameter" => "name",
-        _ => "type",
+/// If `node` contains a single identifier-kind child, replace the node's
+/// children with that identifier's text. Used to flatten builder-created
+/// wrappers like `<name><identifier>foo</identifier></name>` to `<name>foo</name>`.
+fn inline_single_identifier(xot: &mut Xot, node: XotNode) -> Result<(), xot::Error> {
+    let children: Vec<_> = xot.children(node).collect();
+    for child in children {
+        let child_name = match get_element_name(xot, child) {
+            Some(n) => n,
+            None => continue,
+        };
+        if !matches!(child_name.as_str(),
+            "identifier" | "type_identifier" | "field_identifier" | "shorthand_field_identifier")
+        {
+            continue;
+        }
+        let text = match get_text_content(xot, child) {
+            Some(t) => t,
+            None => continue,
+        };
+        let all_children: Vec<_> = xot.children(node).collect();
+        for c in all_children {
+            xot.detach(c)?;
+        }
+        let text_node = xot.new_text(&text);
+        xot.append(node, text_node)?;
+        return Ok(());
     }
+    Ok(())
 }
 
 /// Map a transformed element name to a syntax category for highlighting

--- a/tractor/src/languages/typescript.rs
+++ b/tractor/src/languages/typescript.rs
@@ -30,33 +30,12 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
         "class_body" | "interface_body" | "enum_body" => Ok(TransformAction::Flatten),
 
         // ---------------------------------------------------------------------
-        // Name wrappers - inline identifier text directly
+        // Name wrappers created by the builder for field="name".
+        // Inline the single identifier/property_identifier child as text:
+        //   <name><identifier>foo</identifier></name> -> <name>foo</name>
         // ---------------------------------------------------------------------
         "name" => {
-            if let Some(parent) = get_parent(xot, node) {
-                let parent_kind = get_element_name(xot, parent).unwrap_or_default();
-                if matches!(parent_kind.as_str(),
-                    "function_declaration" | "class_declaration" | "method_definition"
-                    | "function" | "class" | "method"
-                ) {
-                    let children: Vec<_> = xot.children(node).collect();
-                    for child in children {
-                        if let Some(child_name) = get_element_name(xot, child) {
-                            if child_name == "identifier" || child_name == "property_identifier" {
-                                if let Some(text) = get_text_content(xot, child) {
-                                    let all_children: Vec<_> = xot.children(node).collect();
-                                    for c in all_children {
-                                        xot.detach(c)?;
-                                    }
-                                    let text_node = xot.new_text(&text);
-                                    xot.append(node, text_node)?;
-                                    return Ok(TransformAction::Done);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            inline_single_identifier(xot, node)?;
             Ok(TransformAction::Continue)
         }
 
@@ -102,11 +81,12 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
         }
 
         // ---------------------------------------------------------------------
-        // Identifiers - classify as name or type based on context
+        // Identifiers are always names (definitions or references).
+        // Tree-sitter uses `type_identifier` for type positions, so bare
+        // identifiers never need a heuristic — they are never types.
         // ---------------------------------------------------------------------
         "identifier" | "property_identifier" => {
-            let classification = classify_identifier(xot, node);
-            rename(xot, node, classification);
+            rename(xot, node, "name");
             Ok(TransformAction::Continue)
         }
         "type_identifier" => {
@@ -290,43 +270,32 @@ fn inline_identifier_with_ref(xot: &mut Xot, wrapper: XotNode) -> Result<(), xot
     Ok(())
 }
 
-/// Classify an identifier as "name" or "type" based on context
-fn classify_identifier(xot: &Xot, node: XotNode) -> &'static str {
-    let parent = match get_parent(xot, node) {
-        Some(p) => p,
-        None => return "name",  // Default
-    };
-
-    let parent_kind = get_element_name(xot, parent).unwrap_or_default();
-
-    // Check if followed by parameter list (function/method name)
-    let siblings = get_following_siblings(xot, node);
-    let has_param_sibling = siblings.iter().any(|&s| {
-        get_element_name(xot, s)
-            .map(|n| matches!(n.as_str(), "formal_parameters" | "parameters"))
-            .unwrap_or(false)
-    });
-
-    match parent_kind.as_str() {
-        // Method/function names followed by params
-        "method_definition" | "function_declaration" | "arrow_function" if has_param_sibling => "name",
-
-        // Type declarations - the identifier IS the name
-        "class_declaration" | "interface_declaration" | "type_alias_declaration"
-        | "enum_declaration" => "name",
-
-        // Variable declarator - the identifier is the name
-        "variable_declarator" => "name",
-
-        // Parameter - the identifier is the parameter name
-        "required_parameter" | "optional_parameter" => "name",
-
-        // Property assignment - the key is a name
-        "pair" => "name",
-
-        // Default to type
-        _ => "type",
+/// If `node` contains a single identifier child, replace the node's children
+/// with that identifier's text. Used to flatten builder-created wrappers like
+/// `<name><identifier>foo</identifier></name>` to `<name>foo</name>`.
+fn inline_single_identifier(xot: &mut Xot, node: XotNode) -> Result<(), xot::Error> {
+    let children: Vec<_> = xot.children(node).collect();
+    for child in children {
+        let child_name = match get_element_name(xot, child) {
+            Some(n) => n,
+            None => continue,
+        };
+        if !matches!(child_name.as_str(), "identifier" | "property_identifier") {
+            continue;
+        }
+        let text = match get_text_content(xot, child) {
+            Some(t) => t,
+            None => continue,
+        };
+        let all_children: Vec<_> = xot.children(node).collect();
+        for c in all_children {
+            xot.detach(c)?;
+        }
+        let text_node = xot.new_text(&text);
+        xot.append(node, text_node)?;
+        return Ok(());
     }
+    Ok(())
 }
 
 /// Map a transformed element name to a syntax category for highlighting


### PR DESCRIPTION
Tree-sitter already distinguishes type positions via distinct node kinds
(type_identifier, primitive_type, predefined_type, Python's <type>).
Bare <identifier> never needs context inspection to decide — it's always
a name (definition or reference).

Applied the same pattern across Rust, Python, Java, Go, TypeScript/JS:
- Remove classify_identifier heuristics (default was "type", miscategorizing
  variable references, let-bindings, parameter names, call targets).
- Rename <identifier> → <name> unconditionally.
- Simplify <name> wrappers to always inline a single identifier child,
  dropping the parent-kind allowlist that masked the bug elsewhere.

Snapshot churn: <type>a</type> → <name>a</name> wherever the identifier
was not a type, and <name><type>X</type></name> collapses to <name>X</name>.

C# (uses name/type/ref trio with namespace-aware logic) and T-SQL are
out of scope for this pass; todo/12 updated to reflect status.