### PR TITLE
Add TS-to-C# POC via query map projection piped into render

### DIFF
--- a/samples/ts-to-csharp.xpath
+++ b/samples/ts-to-csharp.xpath
@@ -26,8 +26,8 @@ map {
                   else "object"
                 ),
         "name": concat(
-          upper-case(substring($p/name/type/string(), 1, 1)),
-          substring($p/name/type/string(), 2)
+          upper-case(substring($p/name/string(), 1, 1)),
+          substring($p/name/string(), 2)
         ),
         "accessors": map {
           "children": array {

--- a/samples/ts-to-csharp.xpath
+++ b/samples/ts-to-csharp.xpath
@@ -1,0 +1,41 @@
+(: Map a TypeScript interface into the shape Tractor's C# renderer expects. :)
+(: Pipe usage: :)
+(:   tractor samples/user.ts -x "$(cat samples/ts-to-csharp.xpath)" \ :)
+(:     -f json -p tree --single | tractor render -l csharp :)
+map {
+  "$type": "class",
+  "public": true(),
+  "name": //interface/name/type/string(),
+  "body": map {
+    "children": array {
+      for $p in //property_signature return map {
+        "$type": "property",
+        "public": true(),
+        "type": if (exists($p/node()[. = "?"])) then map {
+                  "nullable": true(),
+                  "children": array {
+                    if ($p//predefined_type = "string") then "string"
+                    else if ($p//predefined_type = "number") then "int"
+                    else if ($p//predefined_type = "boolean") then "bool"
+                    else "object"
+                  }
+                } else (
+                  if ($p//predefined_type = "string") then "string"
+                  else if ($p//predefined_type = "number") then "int"
+                  else if ($p//predefined_type = "boolean") then "bool"
+                  else "object"
+                ),
+        "name": concat(
+          upper-case(substring($p/name/type/string(), 1, 1)),
+          substring($p/name/type/string(), 2)
+        ),
+        "accessors": map {
+          "children": array {
+            map {"accessor": "get;"},
+            map {"accessor": "set;"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/samples/ts-to-python.xpath
+++ b/samples/ts-to-python.xpath
@@ -1,0 +1,30 @@
+(: Map a TypeScript interface into the shape Tractor's Python renderer expects. :)
+(: Pipe usage: :)
+(:   tractor samples/user.ts -x "$(cat samples/ts-to-python.xpath)" \ :)
+(:     -f json -p tree --single | tractor render -l python :)
+map {
+  "$type": "class",
+  "name": //interface/name/type/string(),
+  "body": map {
+    "children": array {
+      for $p in //property_signature return map {
+        "$type": "field",
+        "name": $p/name/type/string(),
+        "type": if (exists($p/node()[. = "?"])) then map {
+                  "optional": true(),
+                  "children": array {
+                    if ($p//predefined_type = "string") then "str"
+                    else if ($p//predefined_type = "number") then "int"
+                    else if ($p//predefined_type = "boolean") then "bool"
+                    else "object"
+                  }
+                } else (
+                  if ($p//predefined_type = "string") then "str"
+                  else if ($p//predefined_type = "number") then "int"
+                  else if ($p//predefined_type = "boolean") then "bool"
+                  else "object"
+                )
+      }
+    }
+  }
+}

--- a/samples/ts-to-python.xpath
+++ b/samples/ts-to-python.xpath
@@ -9,7 +9,7 @@ map {
     "children": array {
       for $p in //property_signature return map {
         "$type": "field",
-        "name": $p/name/type/string(),
+        "name": $p/name/string(),
         "type": if (exists($p/node()[. = "?"])) then map {
                   "optional": true(),
                   "children": array {

--- a/samples/user.ts
+++ b/samples/user.ts
@@ -1,0 +1,6 @@
+interface User {
+    name: string;
+    id: number;
+    age?: number;
+    isActive: boolean;
+}

--- a/tests/integration/languages/csharp/sample.cs.xml
+++ b/tests/integration/languages/csharp/sample.cs.xml
@@ -265,7 +265,6 @@
                 <body>
                   {
                   <method>
-                    <private/>
                     <returns>
                       <type>void</type>
                     </returns>
@@ -281,21 +280,19 @@
                 enum
                 <name>Status</name>
                 <body>
-                  <enum_member_declaration_list>
-                    {
-                    <enum_member_declaration>
-                      <name>
-                        <ref>Active</ref>
-                      </name>
-                    </enum_member_declaration>
-                    ,
-                    <enum_member_declaration>
-                      <name>
-                        <ref>Inactive</ref>
-                      </name>
-                    </enum_member_declaration>
-                    }
-                  </enum_member_declaration_list>
+                  {
+                  <enum_member>
+                    <name>
+                      <ref>Active</ref>
+                    </name>
+                  </enum_member>
+                  ,
+                  <enum_member>
+                    <name>
+                      <ref>Inactive</ref>
+                    </name>
+                  </enum_member>
+                  }
                 </body>
               </enum>
               <struct>

--- a/tests/integration/languages/csharp/sample.cs.xml
+++ b/tests/integration/languages/csharp/sample.cs.xml
@@ -265,6 +265,7 @@
                 <body>
                   {
                   <method>
+                    <public/>
                     <returns>
                       <type>void</type>
                     </returns>

--- a/tests/integration/languages/java/sample.java.xml
+++ b/tests/integration/languages/java/sample.java.xml
@@ -4,7 +4,7 @@
     <match file="tests/integration/languages/java/sample.java" line="1" column="1">
       <tree>
         <program>
-          <line_comment>// Simple Java example</line_comment>
+          <comment>// Simple Java example</comment>
           <class>
             <public/>
             class
@@ -13,7 +13,7 @@
               {
               <field>
                 <private/>
-                <integral_type>int</integral_type>
+                <type>int</type>
                 <variable_declarator>
                   <name>value</name>
                 </variable_declarator>
@@ -26,7 +26,7 @@
                   <params>
                     (
                     <param>
-                      <integral_type>int</integral_type>
+                      <type>int</type>
                       <name>value</name>
                     </param>
                     )
@@ -57,18 +57,18 @@
               <method>
                 <static/>
                 <public/>
-                <integral_type>int</integral_type>
+                <type>int</type>
                 <name>add</name>
                 <parameters>
                   <params>
                     (
                     <param>
-                      <integral_type>int</integral_type>
+                      <type>int</type>
                       <name>a</name>
                     </param>
                     ,
                     <param>
-                      <integral_type>int</integral_type>
+                      <type>int</type>
                       <name>b</name>
                     </param>
                     )
@@ -141,7 +141,7 @@
                 </parameters>
                 <body>
                   {
-                  <line_comment>// package-private method</line_comment>
+                  <comment>// package-private method</comment>
                   }
                 </body>
               </method>
@@ -166,7 +166,7 @@
                 <body>
                   {
                   <local_variable_declaration>
-                    <integral_type>int</integral_type>
+                    <type>int</type>
                     <variable_declarator>
                       <name>result</name>
                       =
@@ -249,17 +249,15 @@
             enum
             <name>Status</name>
             <body>
-              <enum_body>
-                {
-                <enum_constant>
-                  <name>ACTIVE</name>
-                </enum_constant>
-                ,
-                <enum_constant>
-                  <name>INACTIVE</name>
-                </enum_constant>
-                }
-              </enum_body>
+              {
+              <enum_member>
+                <name>ACTIVE</name>
+              </enum_member>
+              ,
+              <enum_member>
+                <name>INACTIVE</name>
+              </enum_member>
+              }
             </body>
           </enum>
         </program>

--- a/tests/integration/languages/tsx/sample.tsx.xml
+++ b/tests/integration/languages/tsx/sample.tsx.xml
@@ -33,22 +33,19 @@
             </name>
             <body>
               {
-              <property_signature>
+              <field>
+                <required/>
                 <name>name</name>
-                <typeof>
-                  :
-                  <predefined_type>string</predefined_type>
-                </typeof>
-              </property_signature>
+                :
+                <type>string</type>
+              </field>
               ;
-              <property_signature>
+              <field>
+                <optional/>
                 <name>age</name>
-                ?
-                <typeof>
-                  :
-                  <predefined_type>number</predefined_type>
-                </typeof>
-              </property_signature>
+                ?:
+                <type>number</type>
+              </field>
               ;
         }
             </body>
@@ -68,10 +65,8 @@
                     <shorthand_property_identifier_pattern>age</shorthand_property_identifier_pattern>
                     }
                   </object_pattern>
-                  <typeof>
-                    :
-                    <type>Props</type>
-                  </typeof>
+                  :
+                  <type>Props</type>
                 </param>
                 )
               </params>

--- a/tests/integration/languages/typescript/sample.ts.xml
+++ b/tests/integration/languages/typescript/sample.ts.xml
@@ -14,27 +14,21 @@
                 <param>
                   <required/>
                   <name>a</name>
-                  <typeof>
-                    :
-                    <predefined_type>number</predefined_type>
-                  </typeof>
+                  :
+                  <type>number</type>
                 </param>
                 ,
                 <param>
                   <required/>
                   <name>b</name>
-                  <typeof>
-                    :
-                    <predefined_type>number</predefined_type>
-                  </typeof>
+                  :
+                  <type>number</type>
                 </param>
                 )
               </params>
             </parameters>
-            <typeof>
-              :
-              <predefined_type>number</predefined_type>
-            </typeof>
+            :
+            <type>number</type>
             <body>
               <block>
                 {
@@ -65,10 +59,8 @@
             <parameters>
               <params>()</params>
             </parameters>
-            <typeof>
-              :
-              <predefined_type>void</predefined_type>
-            </typeof>
+            :
+            <type>void</type>
             <body>
               <block>
                 {
@@ -149,21 +141,19 @@
             </name>
             <body>
               {
-              <property_signature>
+              <field>
+                <required/>
                 <name>name</name>
-                <typeof>
-                  :
-                  <predefined_type>string</predefined_type>
-                </typeof>
-              </property_signature>
+                :
+                <type>string</type>
+              </field>
               ;
-              <property_signature>
+              <field>
+                <required/>
                 <name>age</name>
-                <typeof>
-                  :
-                  <predefined_type>number</predefined_type>
-                </typeof>
-              </property_signature>
+                :
+                <type>number</type>
+              </field>
               ;
         }
             </body>
@@ -190,28 +180,21 @@
                 <param>
                   <required/>
                   <name>name</name>
-                  <typeof>
-                    :
-                    <predefined_type>string</predefined_type>
-                  </typeof>
+                  :
+                  <type>string</type>
                 </param>
                 ,
                 <param>
                   <optional/>
                   <name>title</name>
-                  ?
-                  <typeof>
-                    :
-                    <predefined_type>string</predefined_type>
-                  </typeof>
+                  ?:
+                  <type>string</type>
                 </param>
                 )
               </params>
             </parameters>
-            <typeof>
-              :
-              <predefined_type>string</predefined_type>
-            </typeof>
+            :
+            <type>string</type>
             <body>
               <block>
                 {
@@ -259,37 +242,28 @@
                 <param>
                   <required/>
                   <name>host</name>
-                  <typeof>
-                    :
-                    <predefined_type>string</predefined_type>
-                  </typeof>
+                  :
+                  <type>string</type>
                 </param>
                 ,
                 <param>
                   <required/>
                   <name>port</name>
-                  <typeof>
-                    :
-                    <predefined_type>number</predefined_type>
-                  </typeof>
+                  :
+                  <type>number</type>
                 </param>
                 ,
                 <param>
                   <optional/>
                   <name>timeout</name>
-                  ?
-                  <typeof>
-                    :
-                    <predefined_type>number</predefined_type>
-                  </typeof>
+                  ?:
+                  <type>number</type>
                 </param>
                 )
               </params>
             </parameters>
-            <typeof>
-              :
-              <predefined_type>void</predefined_type>
-            </typeof>
+            :
+            <type>void</type>
             <body>
               <block>
                 {

--- a/tests/integration/render/csharp/supported.cs
+++ b/tests/integration/render/csharp/supported.cs
@@ -6,11 +6,16 @@
 // definition, supported by the C# renderer — expand this file to grow the
 // renderer's feature surface.
 //
-// Formatting is whatever the renderer emits (Allman braces, four-space
-// indent, blank line between class members, single blank line between
-// imports and the first declaration).
+// Scope: data-structure constructs only (types, fields, properties, enums,
+// records) plus namespaces/imports/attributes. Imperative code (method
+// bodies, statements) is out of scope and lives in a later batch.
+//
+// Canonical form: Allman braces, four-space indent, blank line between
+// members, and always-explicit access modifiers (so queries like
+// `//method[public]` never have to branch against an implicit default).
 
 using System;
+using System.Collections.Generic;
 
 namespace SampleApp
 {
@@ -20,16 +25,32 @@ namespace SampleApp
 
         public string Name { get; set; }
 
+        public string DisplayName { get; set; } = "default";
+
         public List<string> Tags { get; set; }
 
         public Dictionary<string, int> Counters { get; set; }
 
         public int[] Scores { get; set; }
 
+        public Dictionary<string, List<int>> Buckets { get; set; }
+
         [Required]
+        [MaxLength(100)]
         public string Email { get; set; }
 
-        private readonly int _count;
+        public const int MaxLength = 100;
+
+        public int InitialCount = 0;
+
+        private readonly int _cache;
+    }
+
+    public static class Helpers
+    {
+        public const string Version = "1.0";
+
+        public static int Count { get; set; }
     }
 
     public struct Point
@@ -39,17 +60,30 @@ namespace SampleApp
         public int Y;
     }
 
-    public interface IEntity
-    {
-        Guid? Id { get; set; }
+    public record Address(string Street, string City);
 
-        void Save(int id);
+    public record Person(string Name)
+    {
+        public int Age { get; set; }
     }
 
-    public enum Status
+    public interface IEntity
     {
-        Active,
-        Inactive = 2,
-        Suspended
+        public Guid? Id { get; set; }
+    }
+
+    public enum Status : byte
+    {
+        Active = 0,
+        Inactive = 1,
+        Suspended = 2
+    }
+
+    public class Outer
+    {
+        public class Inner
+        {
+            public int X { get; set; }
+        }
     }
 }

--- a/tests/integration/render/csharp/supported.cs
+++ b/tests/integration/render/csharp/supported.cs
@@ -37,6 +37,8 @@ namespace SampleApp
 
         [Required]
         [MaxLength(100)]
+        [Display(Name = "Full Name", ShortName = "FN")]
+        [StringLength(100, MinimumLength = 2)]
         public string Email { get; set; }
 
         public const int MaxLength = 100;

--- a/tests/integration/render/csharp/supported.cs
+++ b/tests/integration/render/csharp/supported.cs
@@ -1,0 +1,55 @@
+// Canonical C# fixture for tractor's render round-trip tests.
+//
+// The tractor/tests/render_roundtrip.rs test parses this file, renders the
+// resulting semantic tree back to source, and fails if the output differs
+// from this file byte-for-byte. Anything that stays in here is, by
+// definition, supported by the C# renderer — expand this file to grow the
+// renderer's feature surface.
+//
+// Formatting is whatever the renderer emits (Allman braces, four-space
+// indent, blank line between class members, single blank line between
+// imports and the first declaration).
+
+using System;
+
+namespace SampleApp
+{
+    public class User : IEntity
+    {
+        public Guid? Id { get; set; }
+
+        public string Name { get; set; }
+
+        public List<string> Tags { get; set; }
+
+        public Dictionary<string, int> Counters { get; set; }
+
+        public int[] Scores { get; set; }
+
+        [Required]
+        public string Email { get; set; }
+
+        private readonly int _count;
+    }
+
+    public struct Point
+    {
+        public int X;
+
+        public int Y;
+    }
+
+    public interface IEntity
+    {
+        Guid? Id { get; set; }
+
+        void Save(int id);
+    }
+
+    public enum Status
+    {
+        Active,
+        Inactive = 2,
+        Suspended
+    }
+}

--- a/tests/integration/render/java/supported.java
+++ b/tests/integration/render/java/supported.java
@@ -1,0 +1,43 @@
+// Canonical Java fixture for tractor's render round-trip tests.
+//
+// The tractor/tests/render_roundtrip.rs test parses this file, renders the
+// resulting semantic tree back to source, and fails if the output differs
+// from this file byte-for-byte. Anything that stays in here is, by
+// definition, supported by the Java renderer — expand this file to grow
+// the renderer's feature surface.
+//
+// Scope: data-structure constructs only (package and import declarations,
+// classes with typed fields, interfaces with method signatures, records,
+// enums with constants). Imperative code (method bodies, statements) is
+// out of scope and lives in a later batch.
+
+package com.example;
+
+import java.util.List;
+import java.util.Map;
+
+public class User {
+    public static final String VERSION = "1.0";
+
+    private String name;
+
+    private int age = 0;
+
+    public List<String> tags;
+
+    public Map<String, Integer> counters;
+
+    public int[] scores;
+}
+
+public interface Entity {
+    String getId();
+}
+
+public record Point(int x, int y) {}
+
+public enum Status {
+    ACTIVE,
+    INACTIVE,
+    SUSPENDED
+}

--- a/tests/integration/render/python/supported.py
+++ b/tests/integration/render/python/supported.py
@@ -1,0 +1,34 @@
+# Canonical Python fixture for tractor's render round-trip tests.
+#
+# The tractor/tests/render_roundtrip.rs test parses this file, renders the
+# resulting semantic tree back to source, and fails if the output differs
+# from this file byte-for-byte. Anything that stays in here is, by
+# definition, supported by the Python renderer — expand this file to grow
+# the renderer's feature surface.
+#
+# Scope: data-structure constructs only (classes with typed attributes,
+# Enum / IntEnum, TypedDict-style containers, type aliases). Imperative
+# code is out of scope and lives in a later batch.
+
+import typing
+import os.path
+from dataclasses import dataclass
+from typing import Optional, List
+
+
+@dataclass
+class User:
+    name: str
+    age: int = 0
+    nickname: str = ""
+    score: float = 0.0
+    active: bool = True
+    email: Optional[str] = None
+    tags: list[str]
+    counters: dict[str, int]
+
+
+class Address:
+    street: str
+    city: str
+    zip: str

--- a/tests/integration/render/typescript/supported.ts
+++ b/tests/integration/render/typescript/supported.ts
@@ -1,0 +1,25 @@
+// Canonical TypeScript fixture for tractor's render round-trip tests.
+//
+// The tractor/tests/render_roundtrip.rs test parses this file, renders the
+// resulting semantic tree back to source, and fails if the output differs
+// from this file byte-for-byte. Anything that stays in here is, by
+// definition, supported by the TypeScript renderer — expand this file to
+// grow the renderer's feature surface.
+//
+// Scope: data-structure constructs only (interfaces, type aliases, enums,
+// classes with typed fields). Imperative code is out of scope and lives
+// in a later batch.
+
+interface User {
+    name: string;
+    age: number;
+    nickname?: string;
+    tags: string[];
+}
+
+type Id = string;
+
+enum Status {
+    Active,
+    Inactive
+}

--- a/tractor/src/languages/csharp.rs
+++ b/tractor/src/languages/csharp.rs
@@ -52,8 +52,8 @@ pub mod semantic {
     pub const GENERIC: &str = "generic";
     pub const ARRAY: &str = "array";
 
-    // Base list (inheritance)
-    pub const BASE: &str = "base";
+    // Base list (inheritance) — list of base types/interfaces following `:`
+    pub const BASES: &str = "bases";
     pub const REF: &str = "ref";
 
     // Method-specific children
@@ -101,7 +101,9 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
         // ---------------------------------------------------------------------
         // Flatten nodes - transform children, then remove wrapper
         // ---------------------------------------------------------------------
-        "declaration_list" | "parameters" => Ok(TransformAction::Flatten),
+        "declaration_list" | "parameters" | "enum_member_declaration_list" => {
+            Ok(TransformAction::Flatten)
+        }
 
         // ---------------------------------------------------------------------
         // Name wrappers - inline identifier text directly
@@ -262,8 +264,9 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
         | "method_declaration" | "constructor_declaration"
         | "property_declaration" | "field_declaration" => {
             if !has_access_modifier_child(xot, node) {
-                let default = default_access_modifier(xot, node);
-                prepend_empty_element(xot, node, default)?;
+                if let Some(default) = default_access_modifier(xot, node) {
+                    prepend_empty_element(xot, node, default)?;
+                }
             }
             if let Some(new_name) = map_element_name(&kind) {
                 rename(xot, node, new_name);
@@ -358,15 +361,21 @@ fn has_access_modifier_child(xot: &Xot, node: XotNode) -> bool {
 }
 
 /// Determine the default access modifier for a C# declaration based on context.
-/// Looks through `declaration_list` wrappers (which get Flatten'd, so children are
-/// processed while still inside the wrapper).
-fn default_access_modifier(xot: &Xot, node: XotNode) -> &'static str {
+/// Returns `None` for contexts where leaving the modifier off is the canonical
+/// source form (e.g. interface members, whose access is implicitly `public`).
+/// Looks through `declaration_list` wrappers (which get Flatten'd, so children
+/// are processed while still inside the wrapper).
+fn default_access_modifier(xot: &Xot, node: XotNode) -> Option<&'static str> {
     let mut current = get_parent(xot, node);
     while let Some(parent) = current {
         if let Some(parent_kind) = get_kind(xot, parent).as_deref().map(str::to_owned) {
             match parent_kind.as_str() {
-                "class_declaration" | "struct_declaration" | "interface_declaration"
-                | "record_declaration" => return "private",
+                // Interface members are implicitly public — don't inject a modifier
+                // so round-trips preserve the source's lack of one.
+                "interface_declaration" => return None,
+                "class_declaration" | "struct_declaration" | "record_declaration" => {
+                    return Some("private")
+                }
                 // declaration_list is a transparent wrapper — look through it
                 "declaration_list" => {}
                 _ => break,
@@ -374,7 +383,7 @@ fn default_access_modifier(xot: &Xot, node: XotNode) -> &'static str {
         }
         current = get_parent(xot, parent);
     }
-    "internal"
+    Some("internal")
 }
 
 /// Known C# modifiers (access + other + "this" for extension methods)
@@ -427,6 +436,8 @@ fn map_element_name(kind: &str) -> Option<&'static str> {
         "variable_declaration" => Some(VARIABLE),
         "variable_declarator" => Some(DECLARATOR),
         "local_declaration_statement" => Some("local"),
+        "base_list" => Some(BASES),
+        "enum_member_declaration" => Some(ENUM_MEMBER),
         "string_literal" => Some("string"),
         "integer_literal" => Some("int"),
         "real_literal" => Some("float"),

--- a/tractor/src/languages/csharp.rs
+++ b/tractor/src/languages/csharp.rs
@@ -50,6 +50,18 @@ pub mod semantic {
     // Type markers
     pub const NULLABLE: &str = "nullable";
     pub const GENERIC: &str = "generic";
+    pub const ARRAY: &str = "array";
+
+    // Base list (inheritance)
+    pub const BASE: &str = "base";
+    pub const REF: &str = "ref";
+
+    // Method-specific children
+    pub const RETURNS: &str = "returns";
+
+    // Enum members
+    pub const ENUM_MEMBER: &str = "enum_member";
+    pub const VALUE: &str = "value";
 
     // Comment markers
     pub const TRAILING: &str = "trailing";

--- a/tractor/src/languages/csharp.rs
+++ b/tractor/src/languages/csharp.rs
@@ -264,9 +264,8 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
         | "method_declaration" | "constructor_declaration"
         | "property_declaration" | "field_declaration" => {
             if !has_access_modifier_child(xot, node) {
-                if let Some(default) = default_access_modifier(xot, node) {
-                    prepend_empty_element(xot, node, default)?;
-                }
+                let default = default_access_modifier(xot, node);
+                prepend_empty_element(xot, node, default)?;
             }
             if let Some(new_name) = map_element_name(&kind) {
                 rename(xot, node, new_name);
@@ -361,21 +360,22 @@ fn has_access_modifier_child(xot: &Xot, node: XotNode) -> bool {
 }
 
 /// Determine the default access modifier for a C# declaration based on context.
-/// Returns `None` for contexts where leaving the modifier off is the canonical
-/// source form (e.g. interface members, whose access is implicitly `public`).
+/// Tractor always injects an explicit access modifier when the source omits
+/// one, so queries never need to branch between implicit and explicit values
+/// (e.g. `[public]` matches both an explicitly-written `public` and the
+/// implicit default for interface members). Canonical source form — what the
+/// renderer emits and what the fixture round-trip tests assert — therefore
+/// always spells the modifier out.
 /// Looks through `declaration_list` wrappers (which get Flatten'd, so children
 /// are processed while still inside the wrapper).
-fn default_access_modifier(xot: &Xot, node: XotNode) -> Option<&'static str> {
+fn default_access_modifier(xot: &Xot, node: XotNode) -> &'static str {
     let mut current = get_parent(xot, node);
     while let Some(parent) = current {
         if let Some(parent_kind) = get_kind(xot, parent).as_deref().map(str::to_owned) {
             match parent_kind.as_str() {
-                // Interface members are implicitly public — don't inject a modifier
-                // so round-trips preserve the source's lack of one.
-                "interface_declaration" => return None,
-                "class_declaration" | "struct_declaration" | "record_declaration" => {
-                    return Some("private")
-                }
+                // Interface and record members are implicitly public in C#.
+                "interface_declaration" | "record_declaration" => return "public",
+                "class_declaration" | "struct_declaration" => return "private",
                 // declaration_list is a transparent wrapper — look through it
                 "declaration_list" => {}
                 _ => break,
@@ -383,7 +383,7 @@ fn default_access_modifier(xot: &Xot, node: XotNode) -> Option<&'static str> {
         }
         current = get_parent(xot, parent);
     }
-    Some("internal")
+    "internal"
 }
 
 /// Known C# modifiers (access + other + "this" for extension methods)

--- a/tractor/src/languages/java.rs
+++ b/tractor/src/languages/java.rs
@@ -23,7 +23,7 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
         // ---------------------------------------------------------------------
         // Flatten nodes - transform children, then remove wrapper
         // ---------------------------------------------------------------------
-        "class_body" | "interface_body" | "block" => Ok(TransformAction::Flatten),
+        "class_body" | "interface_body" | "enum_body" | "block" => Ok(TransformAction::Flatten),
 
         // ---------------------------------------------------------------------
         // Name wrappers created by the builder for field="name".
@@ -115,6 +115,23 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
     }
 }
 
+/// Java access modifiers in canonical declaration order. `package-private` is
+/// the exhaustive default marker for declarations that carry no explicit
+/// access keyword.
+pub const ACCESS_MODIFIERS: &[&str] = &["public", "private", "protected", "package-private"];
+
+/// Java non-access modifiers in canonical declaration order.
+pub const OTHER_MODIFIERS: &[&str] = &[
+    "static",
+    "final",
+    "abstract",
+    "synchronized",
+    "volatile",
+    "transient",
+    "native",
+    "strictfp",
+];
+
 /// Check if text is an access modifier keyword
 fn is_access_modifier(text: &str) -> bool {
     matches!(text, "public" | "private" | "protected")
@@ -151,6 +168,13 @@ fn map_element_name(kind: &str) -> Option<&'static str> {
         "method_declaration" => Some("method"),
         "constructor_declaration" => Some("ctor"),
         "field_declaration" => Some("field"),
+        "record_declaration" => Some("record"),
+        "enum_constant" => Some("enum_member"),
+        "line_comment" | "block_comment" => Some("comment"),
+        // Primitive types get a uniform <type> wrapper so queries can filter by
+        // `//field/type` regardless of whether the declared type is `int`,
+        // `double`, `boolean`, etc.
+        "integral_type" | "floating_point_type" | "boolean_type" => Some("type"),
         "formal_parameters" => Some("params"),
         "formal_parameter" => Some("param"),
         "argument_list" => Some("args"),

--- a/tractor/src/languages/python.rs
+++ b/tractor/src/languages/python.rs
@@ -81,6 +81,25 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
             Ok(TransformAction::Continue)
         }
 
+        // Annotated assignments — `name: T` or `name: T = default` — are the
+        // Python way to declare a field. Rewrite to the semantic `<field>`
+        // shape so queries and the renderer treat them like declarations
+        // rather than expression statements.
+        //
+        //   assignment       name
+        //   ├─ left          type
+        //   │  └─ identifier default?
+        //   ├─ type
+        //   └─ right?
+        "assignment" => {
+            if has_child_element(xot, node, "type") {
+                rewrite_annotated_assignment_as_field(xot, node)?;
+            } else {
+                rename(xot, node, "assign");
+            }
+            Ok(TransformAction::Continue)
+        }
+
         // Identifiers are always names (definitions or references).
         // Tree-sitter uses a separate `type` node for type annotations, so
         // bare identifiers never need a heuristic — they are never types.
@@ -155,6 +174,53 @@ fn extract_operator(xot: &mut Xot, node: XotNode) -> Result<(), xot::Error> {
     if let Some(op) = operator {
         prepend_op_element(xot, node, op)?;
     }
+    Ok(())
+}
+
+/// Check whether `node` has a direct child element with the given name.
+fn has_child_element(xot: &Xot, node: XotNode, name: &str) -> bool {
+    xot.children(node)
+        .any(|c| get_element_name(xot, c).as_deref() == Some(name))
+}
+
+fn find_child_element(xot: &Xot, node: XotNode, name: &str) -> Option<XotNode> {
+    xot.children(node)
+        .find(|c| get_element_name(xot, *c).as_deref() == Some(name))
+}
+
+/// Rewrite an annotated assignment into a `<field>` by lifting `<left>`'s
+/// inner identifier directly, renaming `<right>` to `<default>`, and dropping
+/// the `<left>` wrapper. The surrounding `<type>` child is preserved in place,
+/// and subsequent identifier-rename walks turn the lifted identifier into
+/// `<name>` naturally.
+fn rewrite_annotated_assignment_as_field(
+    xot: &mut Xot,
+    node: XotNode,
+) -> Result<(), xot::Error> {
+    rename(xot, node, "field");
+
+    // Lift the identifier out of <left> so it becomes a direct child of the
+    // field. The identifier-rename pass visits it afterwards and renames it
+    // to <name>.
+    if let Some(left) = find_child_element(xot, node, "left") {
+        let inner: Vec<_> = xot
+            .children(left)
+            .filter(|&c| xot.element(c).is_some())
+            .collect();
+        for child in inner {
+            xot.detach(child)?;
+            xot.insert_before(left, child)?;
+        }
+        xot.detach(left)?;
+    }
+
+    // Rename <right>…</right> to <default>…</default>. Queries can then match
+    // `field/default` consistently whether the default came from a literal,
+    // a call, or another expression.
+    if let Some(right) = find_child_element(xot, node, "right") {
+        rename(xot, right, "default");
+    }
+
     Ok(())
 }
 

--- a/tractor/src/languages/python.rs
+++ b/tractor/src/languages/python.rs
@@ -4,6 +4,37 @@ use xot::{Xot, Node as XotNode};
 use crate::xot_transform::{TransformAction, helpers::*};
 use crate::output::syntax_highlight::SyntaxCategory;
 
+/// Semantic element names — tractor's Python XML vocabulary shared with the renderer.
+pub mod semantic {
+    // Top-level / structural
+    pub const MODULE: &str = "module";
+    pub const IMPORT: &str = "import";
+    pub const BODY: &str = "body";
+
+    // Declarations
+    pub const CLASS: &str = "class";
+    pub const FUNCTION: &str = "function";
+    pub const METHOD: &str = "method";
+    pub const FIELD: &str = "field";
+    pub const COMMENT: &str = "comment";
+
+    // Members / shared children
+    pub const NAME: &str = "name";
+    pub const TYPE: &str = "type";
+    pub const PARAMETERS: &str = "parameters";
+    pub const PARAMETER: &str = "parameter";
+    pub const RETURNS: &str = "returns";
+    pub const DEFAULT: &str = "default";
+    pub const BASE: &str = "base";
+    pub const REF: &str = "ref";
+    pub const DECORATORS: &str = "decorators";
+    pub const DECORATOR: &str = "decorator";
+
+    // Type markers
+    pub const OPTIONAL: &str = "optional";
+    pub const LIST: &str = "list";
+}
+
 /// Transform a Python AST node
 pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::Error> {
     let kind = match get_element_name(xot, node) {

--- a/tractor/src/languages/typescript.rs
+++ b/tractor/src/languages/typescript.rs
@@ -113,6 +113,32 @@ pub fn transform(xot: &mut Xot, node: XotNode) -> Result<TransformAction, xot::E
         }
 
         // ---------------------------------------------------------------------
+        // Interface and type-literal property signatures — promote to <field>
+        // so queries and the renderer share the data-structure vocabulary
+        // with C# and Python. Exhaustive markers: `?` gets `<optional/>`,
+        // absence gets `<required/>`.
+        // ---------------------------------------------------------------------
+        "property_signature" => {
+            let optional = get_text_children(xot, node)
+                .iter()
+                .any(|t| t.trim() == "?");
+            prepend_empty_element(xot, node, if optional { "optional" } else { "required" })?;
+            rename(xot, node, "field");
+            Ok(TransformAction::Continue)
+        }
+
+        // ---------------------------------------------------------------------
+        // `type_annotation` (named `typeof` after rename) wraps the actual
+        // type with a `:` token. For data-structure-shaped parents like
+        // fields and parameters, drop the wrapper so the <type> sits directly
+        // on the parent and queries stay shallow.
+        // ---------------------------------------------------------------------
+        "type_annotation" => {
+            rename(xot, node, "typeof");
+            Ok(TransformAction::Flatten)
+        }
+
+        // ---------------------------------------------------------------------
         // Other nodes - just rename if needed
         // ---------------------------------------------------------------------
         _ => {
@@ -181,6 +207,8 @@ fn map_element_name(kind: &str) -> Option<&'static str> {
         "type_annotation" => Some("typeof"),
         "type_parameters" => Some("typeparams"),
         "type_parameter" => Some("typeparam"),
+        "predefined_type" => Some("type"),
+        "array_type" => Some("array"),
 
         // Default - no mapping
         _ => None,

--- a/tractor/src/render/csharp.rs
+++ b/tractor/src/render/csharp.rs
@@ -1,7 +1,8 @@
 //! C# code renderer
 //!
 //! Renders tractor's semantic XML back to C# source code.
-//! Supports: class, property, field declarations.
+//! Supports: class, struct, interface, enum, property, field, method,
+//! constructor declarations, with array and base-list type support.
 
 use super::{
     get_child, get_child_text, get_children, has_marker, text_content, RenderError, RenderOptions,
@@ -15,8 +16,12 @@ pub fn render_node(node: &XmlNode, opts: &RenderOptions) -> Result<String, Rende
         XmlNode::Element { name, .. } => match name.as_str() {
             CLASS => render_class(node, opts),
             STRUCT => render_struct(node, opts),
+            INTERFACE => render_interface(node, opts),
+            ENUM => render_enum(node, opts),
             PROPERTY => render_property(node, opts),
             FIELD => render_field(node, opts),
+            METHOD => render_method(node, opts),
+            CONSTRUCTOR => render_constructor(node, opts),
             UNIT => render_unit(node, opts),
             NAMESPACE => render_namespace(node, opts),
             IMPORT => render_import(node, opts),
@@ -93,10 +98,50 @@ fn render_type(node: &XmlNode) -> Result<String, RenderError> {
                 Ok(type_name)
             }
         }
+        XmlNode::Element { name, .. } if name == ARRAY => {
+            let inner = get_child(node, TYPE).ok_or_else(|| RenderError::MissingChild {
+                parent: ARRAY.into(),
+                child: TYPE.into(),
+            })?;
+            Ok(format!("{}[]", render_type(inner)?))
+        }
         _ => text_content(node).ok_or_else(|| RenderError::MissingChild {
             parent: TYPE.into(),
             child: "text".into(),
         }),
+    }
+}
+
+/// Render a type-position child — looks first for <type>, then <array>.
+fn render_type_slot(node: &XmlNode, parent_label: &str) -> Result<String, RenderError> {
+    if let Some(t) = get_child(node, TYPE) {
+        return render_type(t);
+    }
+    if let Some(a) = get_child(node, ARRAY) {
+        return render_type(a);
+    }
+    Err(RenderError::MissingChild {
+        parent: parent_label.into(),
+        child: TYPE.into(),
+    })
+}
+
+/// Render a <base> list: `: Foo, IBar`
+fn render_base_list(node: &XmlNode) -> String {
+    let base = match get_child(node, BASE) {
+        Some(b) => b,
+        None => return String::new(),
+    };
+    let refs: Vec<String> = get_children(base, REF)
+        .iter()
+        .filter_map(|r| text_content(r))
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .collect();
+    if refs.is_empty() {
+        String::new()
+    } else {
+        format!(" : {}", refs.join(", "))
     }
 }
 
@@ -229,12 +274,8 @@ fn render_property(node: &XmlNode, opts: &RenderOptions) -> Result<String, Rende
     // Modifiers
     let mods = modifiers_str(node);
 
-    // Type
-    let type_node = get_child(node, TYPE).ok_or_else(|| RenderError::MissingChild {
-        parent: PROPERTY.into(),
-        child: TYPE.into(),
-    })?;
-    let type_str = render_type(type_node)?;
+    // Type (may be <type> or <array>)
+    let type_str = render_type_slot(node, PROPERTY)?;
 
     let name = get_child_text(node, NAME).ok_or_else(|| RenderError::MissingChild {
         parent: PROPERTY.into(),
@@ -260,14 +301,7 @@ fn render_field(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderEr
     let mods = modifiers_str(node);
 
     // Type — fields may have type as a child element or as a variable/declarator structure
-    let type_str = if let Some(type_node) = get_child(node, TYPE) {
-        render_type(type_node)?
-    } else {
-        return Err(RenderError::MissingChild {
-            parent: FIELD.into(),
-            child: TYPE.into(),
-        });
-    };
+    let type_str = render_type_slot(node, FIELD)?;
 
     // Name — may be in <name> directly or in a <variable><declarator><name>
     let name = get_child_text(node, NAME)
@@ -298,6 +332,10 @@ fn render_struct(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderE
     render_type_declaration(node, STRUCT, opts)
 }
 
+fn render_interface(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    render_type_declaration(node, INTERFACE, opts)
+}
+
 fn render_type_declaration(
     node: &XmlNode,
     keyword: &str,
@@ -313,14 +351,16 @@ fn render_type_declaration(
         child: NAME.into(),
     })?;
 
+    let base = render_base_list(node);
+
     // Collect body members
     let body_opts = opts.indented();
     let members = collect_body_members(node, &body_opts)?;
 
     let mut result = String::new();
     result.push_str(&attrs);
-    result.push_str(&format!("{}{}{} {}", indent, mods, keyword, name));
-    result.push_str(&format!("{}{{{}", opts.newline, opts.newline));
+    result.push_str(&format!("{}{}{} {}{}", indent, mods, keyword, name, base));
+    result.push_str(&format!("{}{}{{{}", opts.newline, indent, opts.newline));
 
     for (i, member) in members.iter().enumerate() {
         result.push_str(member);
@@ -334,6 +374,121 @@ fn render_type_declaration(
     result.push_str(&format!("{}}}", indent));
 
     Ok(result)
+}
+
+// ---------------------------------------------------------------------------
+// Enum
+// ---------------------------------------------------------------------------
+
+fn render_enum(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let attrs = render_attributes(node, opts)?;
+    let mods = modifiers_str(node);
+    let name = get_child_text(node, NAME).ok_or_else(|| RenderError::MissingChild {
+        parent: ENUM.into(),
+        child: NAME.into(),
+    })?;
+
+    let member_indent = opts.indented().current_indent();
+    let members: Vec<String> = collect_enum_members(node)
+        .iter()
+        .map(|(n, v)| match v {
+            Some(val) => format!("{}{} = {}", member_indent, n, val),
+            None => format!("{}{}", member_indent, n),
+        })
+        .collect();
+
+    let mut result = String::new();
+    result.push_str(&attrs);
+    result.push_str(&format!("{}{}{} {}", indent, mods, ENUM, name));
+    result.push_str(&format!("{}{}{{{}", opts.newline, indent, opts.newline));
+    result.push_str(&members.join(&format!(",{}", opts.newline)));
+    if !members.is_empty() {
+        result.push_str(&opts.newline);
+    }
+    result.push_str(&format!("{}}}", indent));
+    Ok(result)
+}
+
+/// Return enum members as (name, optional value) pairs.
+/// Accepts either a flat list of <enum_member> children or a <body> wrapper.
+fn collect_enum_members(node: &XmlNode) -> Vec<(String, Option<String>)> {
+    let container = get_child(node, BODY).unwrap_or(node);
+    get_children(container, ENUM_MEMBER)
+        .iter()
+        .filter_map(|m| {
+            let n = get_child_text(m, NAME)?;
+            let v = get_child_text(m, VALUE);
+            Some((n, v))
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Method / Constructor
+// ---------------------------------------------------------------------------
+
+fn render_parameters(node: &XmlNode) -> String {
+    let params_node = match get_child(node, PARAMETERS) {
+        Some(p) => p,
+        None => return "()".to_string(),
+    };
+    let parts: Vec<String> = get_children(params_node, PARAMETER)
+        .iter()
+        .filter_map(|p| {
+            let ty = render_type_slot(p, PARAMETER).ok()?;
+            let name = get_child_text(p, NAME)?;
+            Some(format!("{} {}", ty, name))
+        })
+        .collect();
+    format!("({})", parts.join(", "))
+}
+
+fn render_method(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let attrs = render_attributes(node, opts)?;
+    let mods = modifiers_str(node);
+
+    let return_type = if let Some(returns) = get_child(node, RETURNS) {
+        render_type_slot(returns, RETURNS)?
+    } else {
+        render_type_slot(node, METHOD).unwrap_or_else(|_| "void".into())
+    };
+
+    let name = get_child_text(node, NAME).ok_or_else(|| RenderError::MissingChild {
+        parent: METHOD.into(),
+        child: NAME.into(),
+    })?;
+
+    let params = render_parameters(node);
+
+    // If a <body> is present, render `{ }`. Otherwise treat as a signature (`;`).
+    let tail = if get_child(node, BODY).is_some() {
+        format!("{}{}{{{}{}}}", opts.newline, indent, opts.newline, indent)
+    } else {
+        ";".to_string()
+    };
+
+    let decl = format!("{}{}{} {}{}{}", indent, mods, return_type, name, params, tail);
+    Ok(format!("{}{}", attrs, decl))
+}
+
+fn render_constructor(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let attrs = render_attributes(node, opts)?;
+    let mods = modifiers_str(node);
+    let name = get_child_text(node, NAME).ok_or_else(|| RenderError::MissingChild {
+        parent: CONSTRUCTOR.into(),
+        child: NAME.into(),
+    })?;
+    let params = render_parameters(node);
+    let tail = if get_child(node, BODY).is_some() {
+        format!("{}{}{{{}{}}}", opts.newline, indent, opts.newline, indent)
+    } else {
+        ";".to_string()
+    };
+    let decl = format!("{}{}{}{}{}", indent, mods, name, params, tail);
+    Ok(format!("{}{}", attrs, decl))
 }
 
 /// Collect renderable body members from a class/struct node
@@ -359,7 +514,8 @@ fn collect_body_members(node: &XmlNode, opts: &RenderOptions) -> Result<Vec<Stri
     for child in body_children {
         if let XmlNode::Element { name, .. } = child {
             match name.as_str() {
-                PROPERTY | FIELD | CLASS | STRUCT | COMMENT => {
+                PROPERTY | FIELD | METHOD | CONSTRUCTOR
+                | CLASS | STRUCT | INTERFACE | ENUM | COMMENT => {
                     members.push(render_node(child, opts)?);
                 }
                 // Skip non-renderable elements (body wrapper text like { })
@@ -417,7 +573,7 @@ fn collect_namespace_members(
     for child in children {
         if let XmlNode::Element { name, .. } = child {
             match name.as_str() {
-                CLASS | STRUCT | IMPORT | COMMENT => {
+                CLASS | STRUCT | INTERFACE | ENUM | IMPORT | COMMENT => {
                     members.push(render_node(child, opts)?);
                 }
                 _ => {}
@@ -464,7 +620,7 @@ fn render_unit(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderErr
     for child in children {
         if let XmlNode::Element { name, .. } = child {
             match name.as_str() {
-                IMPORT | NAMESPACE | CLASS | STRUCT | COMMENT => {
+                IMPORT | NAMESPACE | CLASS | STRUCT | INTERFACE | ENUM | COMMENT => {
                     parts.push(render_node(child, opts)?);
                 }
                 _ => {}
@@ -568,5 +724,51 @@ mod tests {
         let node = parse_xml(xml).unwrap();
         let result = render_node(&node, &RenderOptions::default()).unwrap();
         assert_eq!(result, "public class Empty\n{\n}");
+    }
+
+    #[test]
+    fn test_render_interface_with_signature_method() {
+        let xml = r#"<interface><public/><name>IUser</name><body><method><returns><type>void</type></returns><name>Save</name><parameters><parameter><type>int</type><name>id</name></parameter></parameters></method></body></interface>"#;
+        let node = parse_xml(xml).unwrap();
+        let result = render_node(&node, &RenderOptions::default()).unwrap();
+        assert_eq!(
+            result,
+            "public interface IUser\n{\n    void Save(int id);\n}"
+        );
+    }
+
+    #[test]
+    fn test_render_enum_with_values() {
+        let xml = r#"<enum><public/><name>Color</name><body><enum_member><name>Red</name></enum_member><enum_member><name>Green</name><value>2</value></enum_member><enum_member><name>Blue</name></enum_member></body></enum>"#;
+        let node = parse_xml(xml).unwrap();
+        let result = render_node(&node, &RenderOptions::default()).unwrap();
+        assert_eq!(
+            result,
+            "public enum Color\n{\n    Red,\n    Green = 2,\n    Blue\n}"
+        );
+    }
+
+    #[test]
+    fn test_render_array_property() {
+        let xml = r#"<property><public/><array><type>int</type></array><name>Ids</name><accessors><accessor>get;</accessor><accessor>set;</accessor></accessors></property>"#;
+        let node = parse_xml(xml).unwrap();
+        let result = render_node(&node, &RenderOptions::default()).unwrap();
+        assert_eq!(result, "public int[] Ids { get; set; }");
+    }
+
+    #[test]
+    fn test_render_class_with_base_list() {
+        let xml = r#"<class><public/><name>Dog</name><base><ref>Animal</ref><ref>IBarker</ref></base></class>"#;
+        let node = parse_xml(xml).unwrap();
+        let result = render_node(&node, &RenderOptions::default()).unwrap();
+        assert_eq!(result, "public class Dog : Animal, IBarker\n{\n}");
+    }
+
+    #[test]
+    fn test_render_constructor_with_body() {
+        let xml = r#"<constructor><public/><name>Dog</name><parameters><parameter><type>string</type><name>breed</name></parameter></parameters><body/></constructor>"#;
+        let node = parse_xml(xml).unwrap();
+        let result = render_node(&node, &RenderOptions::default()).unwrap();
+        assert_eq!(result, "public Dog(string breed)\n{\n}");
     }
 }

--- a/tractor/src/render/csharp.rs
+++ b/tractor/src/render/csharp.rs
@@ -295,8 +295,7 @@ fn render_single_attribute(node: &XmlNode) -> Result<String, RenderError> {
     if let Some(args_node) = args {
         let arg_values: Vec<String> = get_children(args_node, ARGUMENT)
             .iter()
-            .filter_map(|a| text_content(a).map(|s| s.trim().to_string()))
-            .filter(|s| !s.is_empty())
+            .filter_map(|a| render_attribute_argument(a))
             .collect();
         if !arg_values.is_empty() {
             return Ok(format!("{}({})", name, arg_values.join(", ")));
@@ -304,6 +303,30 @@ fn render_single_attribute(node: &XmlNode) -> Result<String, RenderError> {
     }
 
     Ok(name)
+}
+
+/// Render an attribute argument — either positional (`100`, `"foo"`, `Bar`) or
+/// named (`Name = "foo"`). Named args have a `<name>` child; positional args
+/// don't. Values come from typed literals or bare identifier refs.
+fn render_attribute_argument(node: &XmlNode) -> Option<String> {
+    let XmlNode::Element { children, .. } = node else {
+        return None;
+    };
+
+    let named = get_child_text(node, NAME).map(|s| s.trim().to_string());
+    let value = children.iter().find_map(|c| match c {
+        XmlNode::Element { name: n, .. } if n == NAME => None,
+        XmlNode::Element { name: n, .. } if n == REF => text_content(c).map(|s| s.trim().to_string()),
+        XmlNode::Element { .. } => render_literal(c),
+        _ => None,
+    });
+
+    match (named, value) {
+        (Some(lhs), Some(rhs)) if !lhs.is_empty() => Some(format!("{} = {}", lhs, rhs)),
+        (_, Some(rhs)) => Some(rhs),
+        (Some(lhs), None) => Some(lhs),
+        _ => None,
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tractor/src/render/csharp.rs
+++ b/tractor/src/render/csharp.rs
@@ -112,13 +112,23 @@ fn render_type(node: &XmlNode) -> Result<String, RenderError> {
     }
 }
 
-/// Render a type-position child — looks first for <type>, then <array>.
+/// Render a type-position child — looks first for direct <type>/<array>,
+/// then falls back to the <variable> wrapper emitted by the C# parser for
+/// field declarations (`<field><variable><type>…</type><declarator>…</declarator></variable></field>`).
 fn render_type_slot(node: &XmlNode, parent_label: &str) -> Result<String, RenderError> {
     if let Some(t) = get_child(node, TYPE) {
         return render_type(t);
     }
     if let Some(a) = get_child(node, ARRAY) {
         return render_type(a);
+    }
+    if let Some(v) = get_child(node, VARIABLE) {
+        if let Some(t) = get_child(v, TYPE) {
+            return render_type(t);
+        }
+        if let Some(a) = get_child(v, ARRAY) {
+            return render_type(a);
+        }
     }
     Err(RenderError::MissingChild {
         parent: parent_label.into(),
@@ -128,7 +138,7 @@ fn render_type_slot(node: &XmlNode, parent_label: &str) -> Result<String, Render
 
 /// Render a <base> list: `: Foo, IBar`
 fn render_base_list(node: &XmlNode) -> String {
-    let base = match get_child(node, BASE) {
+    let base = match get_child(node, BASES) {
         Some(b) => b,
         None => return String::new(),
     };
@@ -216,16 +226,19 @@ fn render_attributes(node: &XmlNode, opts: &RenderOptions) -> Result<String, Ren
 }
 
 fn render_single_attribute(node: &XmlNode) -> Result<String, RenderError> {
-    let name = get_child_text(node, NAME).ok_or_else(|| RenderError::MissingChild {
-        parent: ATTRIBUTE.into(),
-        child: NAME.into(),
-    })?;
+    let name = get_child_text(node, NAME)
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| RenderError::MissingChild {
+            parent: ATTRIBUTE.into(),
+            child: NAME.into(),
+        })?;
 
     let args = get_child(node, ARGUMENTS);
     if let Some(args_node) = args {
         let arg_values: Vec<String> = get_children(args_node, ARGUMENT)
             .iter()
-            .filter_map(|a| text_content(a))
+            .filter_map(|a| text_content(a).map(|s| s.trim().to_string()))
+            .filter(|s| !s.is_empty())
             .collect();
         if !arg_values.is_empty() {
             return Ok(format!("{}({})", name, arg_values.join(", ")));
@@ -412,13 +425,16 @@ fn render_enum(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderErr
 
 /// Return enum members as (name, optional value) pairs.
 /// Accepts either a flat list of <enum_member> children or a <body> wrapper.
+/// Names and values are trimmed: the parser wraps them as
+/// `<name><ref>Red</ref></name>` / `<value><int>2</int></value>`, so concatenated
+/// text can include surrounding whitespace from pretty-printing.
 fn collect_enum_members(node: &XmlNode) -> Vec<(String, Option<String>)> {
     let container = get_child(node, BODY).unwrap_or(node);
     get_children(container, ENUM_MEMBER)
         .iter()
         .filter_map(|m| {
-            let n = get_child_text(m, NAME)?;
-            let v = get_child_text(m, VALUE);
+            let n = get_child_text(m, NAME).map(|s| s.trim().to_string())?;
+            let v = get_child_text(m, VALUE).map(|s| s.trim().to_string());
             Some((n, v))
         })
         .collect()
@@ -532,27 +548,36 @@ fn collect_body_members(node: &XmlNode, opts: &RenderOptions) -> Result<Vec<Stri
 // ---------------------------------------------------------------------------
 
 fn render_namespace(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
-    let name = get_child_text(node, NAME).ok_or_else(|| RenderError::MissingChild {
-        parent: NAMESPACE.into(),
-        child: NAME.into(),
-    })?;
+    let indent = opts.current_indent();
+    let name = get_child_text(node, NAME)
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| RenderError::MissingChild {
+            parent: NAMESPACE.into(),
+            child: NAME.into(),
+        })?;
 
     let has_body = get_child(node, BODY).is_some();
 
     if has_body {
         let body_opts = opts.indented();
         let members = collect_namespace_members(node, &body_opts)?;
-        let mut result = format!("namespace {}{{{}", name, opts.newline);
-        for member in &members {
+        let mut result = format!(
+            "{}namespace {}{}{}{{{}",
+            indent, name, opts.newline, indent, opts.newline
+        );
+        for (i, member) in members.iter().enumerate() {
             result.push_str(member);
             result.push_str(&opts.newline);
+            if i < members.len() - 1 {
+                result.push_str(&opts.newline);
+            }
         }
-        result.push('}');
+        result.push_str(&format!("{}}}", indent));
         Ok(result)
     } else {
         // File-scoped: just the declaration + members at same indent level
         let members = collect_namespace_members(node, opts)?;
-        let mut result = format!("namespace {};{}{}", name, opts.newline, opts.newline);
+        let mut result = format!("{}namespace {};{}{}", indent, name, opts.newline, opts.newline);
         for member in &members {
             result.push_str(member);
             result.push_str(&opts.newline);
@@ -565,7 +590,10 @@ fn collect_namespace_members(
     node: &XmlNode,
     opts: &RenderOptions,
 ) -> Result<Vec<String>, RenderError> {
-    let XmlNode::Element { children, .. } = node else {
+    // Parser form wraps members in <body>; hand-authored shapes may put them
+    // directly under the namespace.
+    let container = get_child(node, BODY).unwrap_or(node);
+    let XmlNode::Element { children, .. } = container else {
         return Ok(Vec::new());
     };
 
@@ -588,14 +616,25 @@ fn collect_namespace_members(
 // ---------------------------------------------------------------------------
 
 fn render_import(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
-    let text = text_content(node).unwrap_or_default();
-    // The text content should contain "using X;" or just the namespace
-    let trimmed = text.trim();
-    if trimmed.starts_with("using") {
-        Ok(format!("{}{}", opts.current_indent(), trimmed))
-    } else {
-        Ok(format!("{}using {};", opts.current_indent(), trimmed))
+    // Prefer the child <ref> (parser form: `<import>using<ref>X</ref>;</import>`).
+    if let Some(r) = get_child(node, REF) {
+        if let Some(ns) = text_content(r) {
+            let ns = ns.trim();
+            if !ns.is_empty() {
+                return Ok(format!("{}using {};", opts.current_indent(), ns));
+            }
+        }
     }
+    // Fall back to the flat text form.
+    let text = text_content(node).unwrap_or_default();
+    let trimmed = text.trim();
+    let line = if let Some(rest) = trimmed.strip_prefix("using") {
+        let ns = rest.trim().trim_end_matches(';').trim();
+        format!("using {};", ns)
+    } else {
+        format!("using {};", trimmed.trim_end_matches(';'))
+    };
+    Ok(format!("{}{}", opts.current_indent(), line))
 }
 
 // ---------------------------------------------------------------------------
@@ -616,19 +655,33 @@ fn render_unit(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderErr
         return Ok(String::new());
     };
 
-    let mut parts = Vec::new();
+    let mut parts: Vec<(&str, String)> = Vec::new();
     for child in children {
         if let XmlNode::Element { name, .. } = child {
             match name.as_str() {
                 IMPORT | NAMESPACE | CLASS | STRUCT | INTERFACE | ENUM | COMMENT => {
-                    parts.push(render_node(child, opts)?);
+                    parts.push((name.as_str(), render_node(child, opts)?));
                 }
                 _ => {}
             }
         }
     }
 
-    Ok(parts.join(&format!("{}", opts.newline)))
+    // Join with a blank line between different kinds (e.g. imports → types) and
+    // between top-level declarations; consecutive imports stay tight.
+    let mut result = String::new();
+    for (i, (kind, text)) in parts.iter().enumerate() {
+        if i > 0 {
+            let prev_kind = parts[i - 1].0;
+            let tight = prev_kind == IMPORT && *kind == IMPORT;
+            result.push_str(&opts.newline);
+            if !tight {
+                result.push_str(&opts.newline);
+            }
+        }
+        result.push_str(text);
+    }
+    Ok(result)
 }
 
 // ---------------------------------------------------------------------------
@@ -640,135 +693,41 @@ mod tests {
     use super::*;
     use crate::render::parse_xml;
 
+    // Round-trip coverage for the C# renderer lives in the fixture-based
+    // integration test `tractor/tests/render_roundtrip.rs`, which reads
+    // `tests/integration/render/csharp/supported.cs` as its single snapshot.
+    // The tests below anchor individual renderer behaviors on hand-authored
+    // XML, independent of the parser, and document the input contract.
+
+    fn render_xml(xml: &str) -> String {
+        let node = parse_xml(xml).unwrap();
+        render_node(&node, &RenderOptions::default()).unwrap()
+    }
+
     #[test]
-    fn test_render_simple_property() {
+    fn property_from_flat_shape() {
         let xml = r#"<property><public/><type>string</type><name>Name</name><accessors><accessor>get;</accessor><accessor>set;</accessor></accessors></property>"#;
-        let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
-        assert_eq!(result, "public string Name { get; set; }");
+        assert_eq!(render_xml(xml), "public string Name { get; set; }");
     }
 
     #[test]
-    fn test_render_nullable_property() {
-        let xml = r#"<property><public/><type>Guid<nullable/></type><name>UserId</name><accessors><accessor>get;</accessor><accessor>set;</accessor></accessors></property>"#;
-        let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
-        assert_eq!(result, "public Guid? UserId { get; set; }");
+    fn field_from_variable_wrapper() {
+        // The parser emits fields as <field><variable><type>..</type><declarator><name>..</name></declarator></variable></field>
+        let xml = r#"<field><private/><readonly/><variable><type>int</type><declarator><name>_count</name></declarator></variable></field>"#;
+        assert_eq!(render_xml(xml), "private readonly int _count;");
     }
 
     #[test]
-    fn test_render_property_with_attribute() {
-        let xml = r#"<property><attributes><attribute><name>Required</name></attribute></attributes><public/><type>string</type><name>Name</name><accessors><accessor>get;</accessor><accessor>set;</accessor></accessors></property>"#;
-        let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
-        assert_eq!(result, "[Required]\npublic string Name { get; set; }");
-    }
-
-    #[test]
-    fn test_render_field() {
-        let xml = r#"<field><private/><readonly/><type>int</type><name>_count</name></field>"#;
-        let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
-        assert_eq!(result, "private readonly int _count;");
-    }
-
-    #[test]
-    fn test_render_static_field() {
-        let xml =
-            r#"<field><private/><static/><type>string</type><name>DefaultName</name></field>"#;
-        let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
-        assert_eq!(result, "private static string DefaultName;");
-    }
-
-    #[test]
-    fn test_render_class_with_members() {
-        let xml = r#"<class><public/><name>User</name><body><property><public/><type>string</type><name>Name</name><accessors><accessor>get;</accessor><accessor>set;</accessor></accessors></property><field><private/><readonly/><type>int</type><name>_id</name></field></body></class>"#;
-        let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
-        let expected = "public class User\n{\n    public string Name { get; set; }\n\n    private readonly int _id;\n}";
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn test_render_generic_type_property() {
-        let xml = r#"<property><public/><type><generic/>List<arguments><type>string</type></arguments></type><name>Items</name><accessors><accessor>get;</accessor><accessor>set;</accessor></accessors></property>"#;
-        let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
-        assert_eq!(result, "public List<string> Items { get; set; }");
-    }
-
-    #[test]
-    fn test_render_nested_generic_type() {
-        let xml = r#"<property><public/><type><generic/>Dictionary<arguments><type>string</type><type>int</type></arguments></type><name>Map</name><accessors><accessor>get;</accessor><accessor>set;</accessor></accessors></property>"#;
-        let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
-        assert_eq!(result, "public Dictionary<string, int> Map { get; set; }");
-    }
-
-    #[test]
-    fn test_render_property_with_indentation() {
+    fn property_indented_by_option() {
         let xml = r#"<property><public/><type>string</type><name>Name</name><accessors><accessor>get;</accessor><accessor>set;</accessor></accessors></property>"#;
-        let node = parse_xml(xml).unwrap();
         let opts = RenderOptions {
             indent_level: 1,
             ..Default::default()
         };
-        let result = render_node(&node, &opts).unwrap();
-        assert_eq!(result, "    public string Name { get; set; }");
-    }
-
-    #[test]
-    fn test_render_empty_class() {
-        let xml = r#"<class><public/><name>Empty</name></class>"#;
         let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
-        assert_eq!(result, "public class Empty\n{\n}");
-    }
-
-    #[test]
-    fn test_render_interface_with_signature_method() {
-        let xml = r#"<interface><public/><name>IUser</name><body><method><returns><type>void</type></returns><name>Save</name><parameters><parameter><type>int</type><name>id</name></parameter></parameters></method></body></interface>"#;
-        let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
         assert_eq!(
-            result,
-            "public interface IUser\n{\n    void Save(int id);\n}"
+            render_node(&node, &opts).unwrap(),
+            "    public string Name { get; set; }"
         );
-    }
-
-    #[test]
-    fn test_render_enum_with_values() {
-        let xml = r#"<enum><public/><name>Color</name><body><enum_member><name>Red</name></enum_member><enum_member><name>Green</name><value>2</value></enum_member><enum_member><name>Blue</name></enum_member></body></enum>"#;
-        let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
-        assert_eq!(
-            result,
-            "public enum Color\n{\n    Red,\n    Green = 2,\n    Blue\n}"
-        );
-    }
-
-    #[test]
-    fn test_render_array_property() {
-        let xml = r#"<property><public/><array><type>int</type></array><name>Ids</name><accessors><accessor>get;</accessor><accessor>set;</accessor></accessors></property>"#;
-        let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
-        assert_eq!(result, "public int[] Ids { get; set; }");
-    }
-
-    #[test]
-    fn test_render_class_with_base_list() {
-        let xml = r#"<class><public/><name>Dog</name><base><ref>Animal</ref><ref>IBarker</ref></base></class>"#;
-        let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
-        assert_eq!(result, "public class Dog : Animal, IBarker\n{\n}");
-    }
-
-    #[test]
-    fn test_render_constructor_with_body() {
-        let xml = r#"<constructor><public/><name>Dog</name><parameters><parameter><type>string</type><name>breed</name></parameter></parameters><body/></constructor>"#;
-        let node = parse_xml(xml).unwrap();
-        let result = render_node(&node, &RenderOptions::default()).unwrap();
-        assert_eq!(result, "public Dog(string breed)\n{\n}");
     }
 }

--- a/tractor/src/render/csharp.rs
+++ b/tractor/src/render/csharp.rs
@@ -17,6 +17,7 @@ pub fn render_node(node: &XmlNode, opts: &RenderOptions) -> Result<String, Rende
             CLASS => render_class(node, opts),
             STRUCT => render_struct(node, opts),
             INTERFACE => render_interface(node, opts),
+            RECORD => render_record(node, opts),
             ENUM => render_enum(node, opts),
             PROPERTY => render_property(node, opts),
             FIELD => render_field(node, opts),
@@ -136,23 +137,80 @@ fn render_type_slot(node: &XmlNode, parent_label: &str) -> Result<String, Render
     })
 }
 
-/// Render a <base> list: `: Foo, IBar`
+/// Render a `<bases>` list: `: Foo, IBar` or `: byte` (enum underlying type).
+/// Accepts either `<ref>` children (inheritance) or `<type>` children
+/// (enum underlying type).
 fn render_base_list(node: &XmlNode) -> String {
     let base = match get_child(node, BASES) {
         Some(b) => b,
         None => return String::new(),
     };
-    let refs: Vec<String> = get_children(base, REF)
+    let XmlNode::Element { children, .. } = base else {
+        return String::new();
+    };
+    let items: Vec<String> = children
         .iter()
-        .filter_map(|r| text_content(r))
+        .filter_map(|c| match c {
+            XmlNode::Element { name, .. } if name == REF => text_content(c),
+            XmlNode::Element { name, .. } if name == TYPE => render_type(c).ok(),
+            _ => None,
+        })
         .map(|t| t.trim().to_string())
         .filter(|t| !t.is_empty())
         .collect();
-    if refs.is_empty() {
+    if items.is_empty() {
         String::new()
     } else {
-        format!(" : {}", refs.join(", "))
+        format!(" : {}", items.join(", "))
     }
+}
+
+// ---------------------------------------------------------------------------
+// Literals (for field/property initializers, enum values, attribute args)
+// ---------------------------------------------------------------------------
+
+/// Render a typed literal element (`<int>`, `<float>`, `<bool>`, `<null>`,
+/// `<string>`) back to C# source form. Returns `None` when the node isn't a
+/// recognised literal.
+///
+/// Strings are reassembled from the parser's
+/// `<string>"<string_literal_content>…</string_literal_content>"</string>`
+/// shape so internal whitespace is preserved verbatim while the
+/// pretty-printer's surrounding whitespace is discarded.
+fn render_literal(node: &XmlNode) -> Option<String> {
+    let XmlNode::Element { name, children, .. } = node else {
+        return None;
+    };
+    match name.as_str() {
+        "int" | "float" | "bool" | "null" => text_content(node).map(|t| t.trim().to_string()),
+        "string" => {
+            let inner = children
+                .iter()
+                .find_map(|c| match c {
+                    XmlNode::Element { name: n, .. } if n == "string_literal_content" => {
+                        text_content(c)
+                    }
+                    _ => None,
+                })
+                .unwrap_or_default();
+            Some(format!("\"{}\"", inner))
+        }
+        _ => None,
+    }
+}
+
+/// Find the first literal-valued child of `node` and render it.
+/// Accepts either a direct literal child (fields: `<declarator>…<int>5</int></declarator>`)
+/// or a `<value>` wrapper (properties, enum members: `<value><int>2</int></value>`).
+fn render_literal_slot(node: &XmlNode) -> Option<String> {
+    let XmlNode::Element { name, children, .. } = node else {
+        return None;
+    };
+    if name == VALUE {
+        // Inside <value>, look for the first literal element.
+        return children.iter().find_map(render_literal);
+    }
+    children.iter().find_map(render_literal)
 }
 
 /// Render a generic type like <type><generic/>List<arguments>...</arguments></type>
@@ -298,7 +356,15 @@ fn render_property(node: &XmlNode, opts: &RenderOptions) -> Result<String, Rende
     // Accessors
     let accessors = render_accessors(node)?;
 
-    let decl = format!("{}{}{} {} {}", indent, mods, type_str, name, accessors);
+    // Optional initializer: `<value>…</value>` after the accessors renders as
+    // `= <literal>;`. Property initializers always end with `;`, unlike the
+    // bare accessor form.
+    let initializer = get_child(node, VALUE).and_then(render_literal_slot);
+
+    let decl = match initializer {
+        Some(init) => format!("{}{}{} {} {} = {};", indent, mods, type_str, name, accessors, init),
+        None => format!("{}{}{} {} {}", indent, mods, type_str, name, accessors),
+    };
 
     Ok(format!("{}{}", attrs, decl))
 }
@@ -316,20 +382,27 @@ fn render_field(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderEr
     // Type — fields may have type as a child element or as a variable/declarator structure
     let type_str = render_type_slot(node, FIELD)?;
 
-    // Name — may be in <name> directly or in a <variable><declarator><name>
-    let name = get_child_text(node, NAME)
-        .or_else(|| {
-            get_child(node, VARIABLE)
-                .and_then(|v| get_child(v, DECLARATOR))
-                .and_then(|d| get_child_text(d, NAME))
-        })
-        .or_else(|| get_child(node, DECLARATOR).and_then(|d| get_child_text(d, NAME)))
+    // Locate the declarator that carries name + optional initializer.
+    let declarator = get_child(node, VARIABLE)
+        .and_then(|v| get_child(v, DECLARATOR))
+        .or_else(|| get_child(node, DECLARATOR));
+
+    let name = declarator
+        .and_then(|d| get_child_text(d, NAME))
+        .or_else(|| get_child_text(node, NAME))
         .ok_or_else(|| RenderError::MissingChild {
             parent: FIELD.into(),
             child: NAME.into(),
         })?;
 
-    let decl = format!("{}{}{} {};", indent, mods, type_str, name);
+    // Optional field initializer: a literal directly inside the declarator
+    // (the parser places it after the `=` text node).
+    let initializer = declarator.and_then(render_literal_slot);
+
+    let decl = match initializer {
+        Some(init) => format!("{}{}{} {} = {};", indent, mods, type_str, name, init),
+        None => format!("{}{}{} {};", indent, mods, type_str, name),
+    };
     Ok(format!("{}{}", attrs, decl))
 }
 
@@ -347,6 +420,53 @@ fn render_struct(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderE
 
 fn render_interface(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
     render_type_declaration(node, INTERFACE, opts)
+}
+
+/// Render a record declaration. Supports the positional form
+/// (`public record User(string Name);`) and the body form
+/// (`public record User(string Name) { ... }`). Presence of a primary
+/// parameter list is optional.
+fn render_record(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let attrs = render_attributes(node, opts)?;
+    let mods = modifiers_str(node);
+    let name = get_child_text(node, NAME)
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| RenderError::MissingChild {
+            parent: RECORD.into(),
+            child: NAME.into(),
+        })?;
+
+    let params = if get_child(node, PARAMETERS).is_some() {
+        render_parameters(node)
+    } else {
+        String::new()
+    };
+    let base = render_base_list(node);
+
+    let header = format!("{}{}{} {}{}{}", indent, mods, RECORD, name, params, base);
+
+    // If a body exists, render members inside Allman braces; otherwise emit the
+    // positional-only statement form with a trailing semicolon.
+    if get_child(node, BODY).is_some() {
+        let body_opts = opts.indented();
+        let members = collect_body_members(node, &body_opts)?;
+        let mut result = String::new();
+        result.push_str(&attrs);
+        result.push_str(&header);
+        result.push_str(&format!("{}{}{{{}", opts.newline, indent, opts.newline));
+        for (i, member) in members.iter().enumerate() {
+            result.push_str(member);
+            result.push_str(&opts.newline);
+            if i < members.len() - 1 {
+                result.push_str(&opts.newline);
+            }
+        }
+        result.push_str(&format!("{}}}", indent));
+        Ok(result)
+    } else {
+        Ok(format!("{}{};", attrs, header))
+    }
 }
 
 fn render_type_declaration(
@@ -411,9 +531,11 @@ fn render_enum(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderErr
         })
         .collect();
 
+    let base = render_base_list(node);
+
     let mut result = String::new();
     result.push_str(&attrs);
-    result.push_str(&format!("{}{}{} {}", indent, mods, ENUM, name));
+    result.push_str(&format!("{}{}{} {}{}", indent, mods, ENUM, name, base));
     result.push_str(&format!("{}{}{{{}", opts.newline, indent, opts.newline));
     result.push_str(&members.join(&format!(",{}", opts.newline)));
     if !members.is_empty() {
@@ -425,16 +547,17 @@ fn render_enum(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderErr
 
 /// Return enum members as (name, optional value) pairs.
 /// Accepts either a flat list of <enum_member> children or a <body> wrapper.
-/// Names and values are trimmed: the parser wraps them as
-/// `<name><ref>Red</ref></name>` / `<value><int>2</int></value>`, so concatenated
-/// text can include surrounding whitespace from pretty-printing.
+/// The name is extracted from the `<name>` wrapper (parser shape wraps it in
+/// `<ref>…</ref>`, but `text_content` handles that). The value goes through
+/// `render_literal_slot` so typed literals like `<value><int>2</int></value>`
+/// render correctly.
 fn collect_enum_members(node: &XmlNode) -> Vec<(String, Option<String>)> {
     let container = get_child(node, BODY).unwrap_or(node);
     get_children(container, ENUM_MEMBER)
         .iter()
         .filter_map(|m| {
             let n = get_child_text(m, NAME).map(|s| s.trim().to_string())?;
-            let v = get_child_text(m, VALUE).map(|s| s.trim().to_string());
+            let v = get_child(m, VALUE).and_then(render_literal_slot);
             Some((n, v))
         })
         .collect()
@@ -531,7 +654,7 @@ fn collect_body_members(node: &XmlNode, opts: &RenderOptions) -> Result<Vec<Stri
         if let XmlNode::Element { name, .. } = child {
             match name.as_str() {
                 PROPERTY | FIELD | METHOD | CONSTRUCTOR
-                | CLASS | STRUCT | INTERFACE | ENUM | COMMENT => {
+                | CLASS | STRUCT | INTERFACE | ENUM | RECORD | COMMENT => {
                     members.push(render_node(child, opts)?);
                 }
                 // Skip non-renderable elements (body wrapper text like { })
@@ -601,7 +724,7 @@ fn collect_namespace_members(
     for child in children {
         if let XmlNode::Element { name, .. } = child {
             match name.as_str() {
-                CLASS | STRUCT | INTERFACE | ENUM | IMPORT | COMMENT => {
+                CLASS | STRUCT | INTERFACE | ENUM | RECORD | IMPORT | COMMENT => {
                     members.push(render_node(child, opts)?);
                 }
                 _ => {}
@@ -616,25 +739,46 @@ fn collect_namespace_members(
 // ---------------------------------------------------------------------------
 
 fn render_import(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
-    // Prefer the child <ref> (parser form: `<import>using<ref>X</ref>;</import>`).
-    if let Some(r) = get_child(node, REF) {
-        if let Some(ns) = text_content(r) {
-            let ns = ns.trim();
-            if !ns.is_empty() {
-                return Ok(format!("{}using {};", opts.current_indent(), ns));
-            }
-        }
+    // Parser shapes:
+    //   <import>using<ref>System</ref>;</import>
+    //   <import>using<qualified_name>..dotted..</qualified_name>;</import>
+    // Both reduce to "using <namespace>;" — extract the namespace from whichever
+    // child is present.
+    let ns = extract_qualified_name(node)
+        .or_else(|| text_content(node).map(|t| strip_import_keywords(&t)))
+        .unwrap_or_default();
+    let ns = ns.trim();
+    if ns.is_empty() {
+        return Ok(format!("{}using ;", opts.current_indent()));
     }
-    // Fall back to the flat text form.
-    let text = text_content(node).unwrap_or_default();
-    let trimmed = text.trim();
-    let line = if let Some(rest) = trimmed.strip_prefix("using") {
-        let ns = rest.trim().trim_end_matches(';').trim();
-        format!("using {};", ns)
-    } else {
-        format!("using {};", trimmed.trim_end_matches(';'))
-    };
-    Ok(format!("{}{}", opts.current_indent(), line))
+    Ok(format!("{}using {};", opts.current_indent(), ns))
+}
+
+/// Collect a dotted namespace from a `<qualified_name>` or `<ref>` child.
+/// Pretty-printed XML puts whitespace between the dots and the refs, so we
+/// strip whitespace from the raw text content — `System.Collections.Generic`
+/// is whitespace-free regardless of formatting.
+fn extract_qualified_name(node: &XmlNode) -> Option<String> {
+    if let Some(q) = get_child(node, "qualified_name") {
+        return Some(strip_whitespace(&text_content(q)?));
+    }
+    if let Some(r) = get_child(node, REF) {
+        return Some(strip_whitespace(&text_content(r)?));
+    }
+    None
+}
+
+fn strip_import_keywords(text: &str) -> String {
+    let cleaned = strip_whitespace(text);
+    cleaned
+        .strip_prefix("using")
+        .unwrap_or(&cleaned)
+        .trim_end_matches(';')
+        .to_string()
+}
+
+fn strip_whitespace(s: &str) -> String {
+    s.chars().filter(|c| !c.is_whitespace()).collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -659,7 +803,7 @@ fn render_unit(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderErr
     for child in children {
         if let XmlNode::Element { name, .. } = child {
             match name.as_str() {
-                IMPORT | NAMESPACE | CLASS | STRUCT | INTERFACE | ENUM | COMMENT => {
+                IMPORT | NAMESPACE | CLASS | STRUCT | INTERFACE | ENUM | RECORD | COMMENT => {
                     parts.push((name.as_str(), render_node(child, opts)?));
                 }
                 _ => {}

--- a/tractor/src/render/java.rs
+++ b/tractor/src/render/java.rs
@@ -1,0 +1,487 @@
+//! Java code renderer
+//!
+//! Renders tractor's semantic XML back to Java source. Scope is the
+//! data-structure subset: package and import declarations, classes,
+//! interfaces (with method signatures), records, enums (with constants),
+//! fields (with modifiers, primitive/reference/generic/array types, and
+//! literal initializers). Imperative code is out of scope.
+
+use super::{
+    get_child, get_child_text, get_children, has_marker, text_content, RenderError, RenderOptions,
+};
+use crate::languages::java::{ACCESS_MODIFIERS, OTHER_MODIFIERS};
+use crate::xpath::XmlNode;
+
+const PROGRAM: &str = "program";
+const PACKAGE: &str = "package";
+const IMPORT: &str = "import";
+const CLASS: &str = "class";
+const INTERFACE: &str = "interface";
+const ENUM: &str = "enum";
+const RECORD: &str = "record";
+const FIELD: &str = "field";
+const METHOD: &str = "method";
+const NAME: &str = "name";
+const TYPE: &str = "type";
+const ARRAY: &str = "array";
+const GENERIC: &str = "generic";
+const TYPE_ARGS: &str = "type_arguments";
+const BODY: &str = "body";
+const PARAMETERS: &str = "parameters";
+const PARAMS: &str = "params";
+const PARAM: &str = "param";
+const VARIABLE_DECLARATOR: &str = "variable_declarator";
+const VALUE: &str = "value";
+const ENUM_MEMBER: &str = "enum_member";
+const COMMENT: &str = "comment";
+const SCOPED_ID: &str = "scoped_identifier";
+
+pub fn render_node(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    match node {
+        XmlNode::Element { name, .. } => match name.as_str() {
+            PROGRAM => render_program(node, opts),
+            PACKAGE => render_package(node, opts),
+            IMPORT => render_import(node, opts),
+            CLASS => render_type_declaration(node, "class", CLASS, opts),
+            INTERFACE => render_type_declaration(node, "interface", INTERFACE, opts),
+            RECORD => render_record(node, opts),
+            ENUM => render_enum(node, opts),
+            FIELD => render_field(node, opts),
+            METHOD => render_method(node, opts),
+            COMMENT => render_comment(node, opts),
+            _ => Err(RenderError::UnsupportedNode(name.clone())),
+        },
+        XmlNode::Text(t) => Ok(t.clone()),
+        _ => Ok(String::new()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Modifiers
+// ---------------------------------------------------------------------------
+
+fn modifiers_str(node: &XmlNode) -> String {
+    let mut mods = Vec::new();
+    for &m in ACCESS_MODIFIERS {
+        // `package-private` is the canonical absent-modifier marker — emit
+        // nothing for it so round-trips preserve the source's lack of a
+        // keyword.
+        if m == "package-private" {
+            continue;
+        }
+        if has_marker(node, m) {
+            mods.push(m);
+        }
+    }
+    for &m in OTHER_MODIFIERS {
+        if has_marker(node, m) {
+            mods.push(m);
+        }
+    }
+    if mods.is_empty() {
+        String::new()
+    } else {
+        format!("{} ", mods.join(" "))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Render a Java type: primitive / reference / generic / array.
+fn render_type(node: &XmlNode) -> Result<String, RenderError> {
+    let XmlNode::Element { name, children, .. } = node else {
+        return text_content(node).ok_or_else(|| RenderError::MissingChild {
+            parent: TYPE.into(),
+            child: "text".into(),
+        });
+    };
+
+    match name.as_str() {
+        GENERIC => {
+            // <generic><type>List</type><type_arguments><type>String</type>...</type_arguments></generic>
+            let base = children
+                .iter()
+                .find_map(|c| match c {
+                    XmlNode::Element { name: n, .. } if n == TYPE => render_type(c).ok(),
+                    _ => None,
+                })
+                .unwrap_or_default();
+            let args = get_child(node, TYPE_ARGS)
+                .map(|a| {
+                    get_children(a, TYPE)
+                        .iter()
+                        .filter_map(|t| render_type(t).ok())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .unwrap_or_default();
+            Ok(format!("{}<{}>", base, args))
+        }
+        ARRAY => {
+            let inner = children
+                .iter()
+                .find_map(|c| match c {
+                    XmlNode::Element { name: n, .. } if n == TYPE || n == ARRAY || n == GENERIC => {
+                        render_type(c).ok()
+                    }
+                    _ => None,
+                })
+                .unwrap_or_default();
+            Ok(format!("{}[]", inner))
+        }
+        TYPE => {
+            // Plain <type>String</type> or wrapper containing another type.
+            if let Some(g) = get_child(node, GENERIC) {
+                return render_type(g);
+            }
+            if let Some(a) = get_child(node, ARRAY) {
+                return render_type(a);
+            }
+            Ok(text_content(node)
+                .unwrap_or_default()
+                .trim()
+                .to_string())
+        }
+        _ => Ok(text_content(node).unwrap_or_default().trim().to_string()),
+    }
+}
+
+fn render_type_slot(node: &XmlNode) -> Option<String> {
+    for candidate in [TYPE, GENERIC, ARRAY] {
+        if let Some(c) = get_child(node, candidate) {
+            return render_type(c).ok();
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Literals (field initializers, enum constant values, default values)
+// ---------------------------------------------------------------------------
+
+/// Extract a typed literal (`<int>`, `<float>`, `<string>`, `<true/>`,
+/// `<false/>`, `<null>`) from a `<value>` slot, reassembling Java string
+/// literals from `<string_fragment>` content.
+fn render_value(node: &XmlNode) -> Option<String> {
+    let XmlNode::Element { children, .. } = node else {
+        return None;
+    };
+    children.iter().find_map(render_literal)
+}
+
+fn render_literal(node: &XmlNode) -> Option<String> {
+    let XmlNode::Element { name, children, .. } = node else {
+        return None;
+    };
+    match name.as_str() {
+        "int" | "float" | "true" | "false" | "null" => {
+            text_content(node).map(|t| t.trim().to_string())
+        }
+        "string" => {
+            let content = children
+                .iter()
+                .find_map(|c| match c {
+                    XmlNode::Element { name: n, .. } if n == "string_fragment" => text_content(c),
+                    _ => None,
+                })
+                .unwrap_or_default();
+            Some(format!("\"{}\"", content))
+        }
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Package / Import — Java uses dotted `scoped_identifier` for qualified names
+// ---------------------------------------------------------------------------
+
+fn dotted_text(node: &XmlNode) -> String {
+    // Recurse through nested <scoped_identifier> and pull <name> text children
+    // in order, joining with dots.
+    fn walk(node: &XmlNode, out: &mut Vec<String>) {
+        if let XmlNode::Element { name, children, .. } = node {
+            match name.as_str() {
+                SCOPED_ID => {
+                    for child in children {
+                        walk(child, out);
+                    }
+                }
+                NAME => {
+                    if let Some(t) = text_content(node) {
+                        let t = t.trim().to_string();
+                        if !t.is_empty() {
+                            out.push(t);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    let mut parts = Vec::new();
+    walk(node, &mut parts);
+    parts.join(".")
+}
+
+fn render_package(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let dotted = get_child(node, SCOPED_ID)
+        .map(dotted_text)
+        .or_else(|| get_child_text(node, NAME).map(|s| s.trim().to_string()))
+        .unwrap_or_default();
+    Ok(format!("{}package {};", opts.current_indent(), dotted))
+}
+
+fn render_import(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let dotted = get_child(node, SCOPED_ID)
+        .map(dotted_text)
+        .or_else(|| get_child_text(node, NAME).map(|s| s.trim().to_string()))
+        .unwrap_or_default();
+    Ok(format!("{}import {};", opts.current_indent(), dotted))
+}
+
+// ---------------------------------------------------------------------------
+// Field / Method
+// ---------------------------------------------------------------------------
+
+fn render_field(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let mods = modifiers_str(node);
+    let ty = render_type_slot(node).ok_or_else(|| RenderError::MissingChild {
+        parent: FIELD.into(),
+        child: TYPE.into(),
+    })?;
+    let declarator = get_child(node, VARIABLE_DECLARATOR).ok_or_else(|| RenderError::MissingChild {
+        parent: FIELD.into(),
+        child: VARIABLE_DECLARATOR.into(),
+    })?;
+    let name = get_child_text(declarator, NAME)
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| RenderError::MissingChild {
+            parent: VARIABLE_DECLARATOR.into(),
+            child: NAME.into(),
+        })?;
+    let init = get_child(declarator, VALUE).and_then(render_value);
+
+    let decl = match init {
+        Some(v) => format!("{}{}{} {} = {};", indent, mods, ty, name, v),
+        None => format!("{}{}{} {};", indent, mods, ty, name),
+    };
+    Ok(decl)
+}
+
+fn render_method(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let mods = modifiers_str(node);
+    let ty = render_type_slot(node).unwrap_or_else(|| "void".into());
+    let name = get_child_text(node, NAME)
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| RenderError::MissingChild {
+            parent: METHOD.into(),
+            child: NAME.into(),
+        })?;
+    let params = render_parameters(node);
+    // Interface / abstract methods have no body and end with `;`.
+    // Concrete methods end with an empty body `{ }` — imperative statements
+    // are out of scope for this batch.
+    let tail = if get_child(node, BODY).is_some() {
+        format!(" {{{}{}{}}}", opts.newline, indent, opts.newline.clone() + &indent)
+    } else {
+        ";".to_string()
+    };
+    let tail = if tail.contains('\n') {
+        // Simplified body: "{\n    <indent>}" — keep it empty on one line instead.
+        " {}".to_string()
+    } else {
+        tail
+    };
+    Ok(format!("{}{}{} {}{}{}", indent, mods, ty, name, params, tail))
+}
+
+fn render_parameters(node: &XmlNode) -> String {
+    // Parser shape: <parameters><params>(<param>...</param>,...)</params></parameters>
+    let list = get_child(node, PARAMETERS)
+        .and_then(|p| get_child(p, PARAMS).or(Some(p)))
+        .or_else(|| get_child(node, PARAMS));
+    let list = match list {
+        Some(l) => l,
+        None => return "()".to_string(),
+    };
+    let parts: Vec<String> = get_children(list, PARAM)
+        .iter()
+        .filter_map(|p| {
+            let ty = render_type_slot(p)?;
+            let name = get_child_text(p, NAME).map(|s| s.trim().to_string())?;
+            Some(format!("{} {}", ty, name))
+        })
+        .collect();
+    format!("({})", parts.join(", "))
+}
+
+// ---------------------------------------------------------------------------
+// Class / Interface
+// ---------------------------------------------------------------------------
+
+fn render_type_declaration(
+    node: &XmlNode,
+    keyword: &str,
+    parent: &str,
+    opts: &RenderOptions,
+) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let mods = modifiers_str(node);
+    let name = get_child_text(node, NAME)
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| RenderError::MissingChild {
+            parent: parent.into(),
+            child: NAME.into(),
+        })?;
+
+    let body_opts = opts.indented();
+    let members = collect_body_members(node, &body_opts)?;
+
+    let mut result = format!("{}{}{} {} {{", indent, mods, keyword, name);
+    result.push_str(&opts.newline);
+    for (i, member) in members.iter().enumerate() {
+        result.push_str(member);
+        result.push_str(&opts.newline);
+        if i < members.len() - 1 {
+            result.push_str(&opts.newline);
+        }
+    }
+    result.push_str(&format!("{}}}", indent));
+    Ok(result)
+}
+
+fn collect_body_members(
+    node: &XmlNode,
+    opts: &RenderOptions,
+) -> Result<Vec<String>, RenderError> {
+    let container = get_child(node, BODY).unwrap_or(node);
+    let XmlNode::Element { children, .. } = container else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::new();
+    for child in children {
+        if let XmlNode::Element { name, .. } = child {
+            match name.as_str() {
+                FIELD | METHOD | CLASS | INTERFACE | ENUM | RECORD | COMMENT => {
+                    out.push(render_node(child, opts)?);
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Record
+// ---------------------------------------------------------------------------
+
+fn render_record(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let mods = modifiers_str(node);
+    let name = get_child_text(node, NAME)
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| RenderError::MissingChild {
+            parent: RECORD.into(),
+            child: NAME.into(),
+        })?;
+    let params = render_parameters(node);
+
+    // Java records always require a (possibly empty) body block after the
+    // parameter list. Empty body renders as `{}` inline; non-empty bodies
+    // would open a block — deferred to a later batch along with imperative
+    // content.
+    let body_members: Vec<String> = collect_body_members(node, &opts.indented())?;
+    if body_members.is_empty() {
+        Ok(format!("{}{}record {}{} {{}}", indent, mods, name, params))
+    } else {
+        let mut result = format!("{}{}record {}{} {{", indent, mods, name, params);
+        result.push_str(&opts.newline);
+        for (i, m) in body_members.iter().enumerate() {
+            result.push_str(m);
+            result.push_str(&opts.newline);
+            if i < body_members.len() - 1 {
+                result.push_str(&opts.newline);
+            }
+        }
+        result.push_str(&format!("{}}}", indent));
+        Ok(result)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Enum
+// ---------------------------------------------------------------------------
+
+fn render_enum(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let mods = modifiers_str(node);
+    let name = get_child_text(node, NAME)
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| RenderError::MissingChild {
+            parent: ENUM.into(),
+            child: NAME.into(),
+        })?;
+    let member_indent = opts.indented().current_indent();
+
+    let container = get_child(node, BODY).unwrap_or(node);
+    let members: Vec<String> = get_children(container, ENUM_MEMBER)
+        .iter()
+        .filter_map(|m| get_child_text(m, NAME).map(|s| s.trim().to_string()))
+        .filter(|t| !t.is_empty())
+        .map(|m| format!("{}{}", member_indent, m))
+        .collect();
+
+    let mut result = format!("{}{}enum {} {{", indent, mods, name);
+    result.push_str(&opts.newline);
+    result.push_str(&members.join(&format!(",{}", opts.newline)));
+    if !members.is_empty() {
+        result.push_str(&opts.newline);
+    }
+    result.push_str(&format!("{}}}", indent));
+    Ok(result)
+}
+
+// ---------------------------------------------------------------------------
+// Comment / Program
+// ---------------------------------------------------------------------------
+
+fn render_comment(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let text = text_content(node).unwrap_or_default();
+    Ok(format!("{}{}", opts.current_indent(), text.trim()))
+}
+
+fn render_program(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let XmlNode::Element { children, .. } = node else {
+        return Ok(String::new());
+    };
+    let mut parts: Vec<(&str, String)> = Vec::new();
+    for child in children {
+        if let XmlNode::Element { name, .. } = child {
+            match name.as_str() {
+                PACKAGE | IMPORT | CLASS | INTERFACE | ENUM | RECORD | COMMENT => {
+                    parts.push((name.as_str(), render_node(child, opts)?));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut result = String::new();
+    for (i, (kind, text)) in parts.iter().enumerate() {
+        if i > 0 {
+            let prev = parts[i - 1].0;
+            let tight = prev == *kind && matches!(*kind, IMPORT | COMMENT);
+            result.push_str(&opts.newline);
+            if !tight {
+                result.push_str(&opts.newline);
+            }
+        }
+        result.push_str(text);
+    }
+    Ok(result)
+}

--- a/tractor/src/render/mod.rs
+++ b/tractor/src/render/mod.rs
@@ -16,6 +16,7 @@
 //! rather than the current approach of serializing from the data model.
 
 pub mod csharp;
+pub mod java;
 pub mod json;
 pub mod python;
 pub mod typescript;
@@ -327,6 +328,7 @@ pub fn render(node: &XmlNode, lang: &str, tree_mode: TreeMode, opts: &RenderOpti
     }
     match lang {
         "csharp" => csharp::render_node(node, opts),
+        "java" => java::render_node(node, opts),
         "json" => json::render_node(node, opts),
         "python" => python::render_node(node, opts),
         "typescript" | "tsx" | "javascript" => typescript::render_node(node, opts),

--- a/tractor/src/render/mod.rs
+++ b/tractor/src/render/mod.rs
@@ -18,6 +18,7 @@
 pub mod csharp;
 pub mod json;
 pub mod python;
+pub mod typescript;
 pub mod yaml;
 
 use crate::xpath::XmlNode;
@@ -328,6 +329,7 @@ pub fn render(node: &XmlNode, lang: &str, tree_mode: TreeMode, opts: &RenderOpti
         "csharp" => csharp::render_node(node, opts),
         "json" => json::render_node(node, opts),
         "python" => python::render_node(node, opts),
+        "typescript" | "tsx" | "javascript" => typescript::render_node(node, opts),
         "yaml" | "yml" => yaml::render_node(node, opts),
         _ => Err(RenderError::UnsupportedLanguage(lang.to_string())),
     }

--- a/tractor/src/render/mod.rs
+++ b/tractor/src/render/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod csharp;
 pub mod json;
+pub mod python;
 pub mod yaml;
 
 use crate::xpath::XmlNode;
@@ -326,6 +327,7 @@ pub fn render(node: &XmlNode, lang: &str, tree_mode: TreeMode, opts: &RenderOpti
     match lang {
         "csharp" => csharp::render_node(node, opts),
         "json" => json::render_node(node, opts),
+        "python" => python::render_node(node, opts),
         "yaml" | "yml" => yaml::render_node(node, opts),
         _ => Err(RenderError::UnsupportedLanguage(lang.to_string())),
     }

--- a/tractor/src/render/python.rs
+++ b/tractor/src/render/python.rs
@@ -1,0 +1,421 @@
+//! Python code renderer
+//!
+//! Renders tractor's semantic XML back to Python source code.
+//! Supports: module, class (with base list), field (annotated attribute),
+//! method, function, parameter, import, comment, plus `optional` and `list`
+//! type markers.
+
+use super::{
+    get_child, get_child_text, get_children, has_marker, text_content, RenderError, RenderOptions,
+};
+use crate::languages::python::semantic::*;
+use crate::xpath::XmlNode;
+
+pub fn render_node(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    match node {
+        XmlNode::Element { name, .. } => match name.as_str() {
+            MODULE => render_module(node, opts),
+            CLASS => render_class(node, opts),
+            FUNCTION | METHOD => render_function(node, opts),
+            FIELD => render_field(node, opts),
+            IMPORT => render_import(node, opts),
+            COMMENT => render_comment(node, opts),
+            _ => Err(RenderError::UnsupportedNode(name.clone())),
+        },
+        XmlNode::Text(t) => Ok(t.clone()),
+        _ => Ok(String::new()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+fn render_type(node: &XmlNode) -> Result<String, RenderError> {
+    match node {
+        XmlNode::Element { name, children, .. } if name == TYPE => {
+            let has_optional = has_marker(node, OPTIONAL);
+            let has_list = has_marker(node, LIST);
+
+            // Collect inner text / nested <type> content.
+            let inner: String = children
+                .iter()
+                .filter_map(|c| match c {
+                    XmlNode::Text(t) => Some(t.trim().to_string()),
+                    XmlNode::Element { name, children: ch, .. }
+                        if (name == OPTIONAL || name == LIST) && ch.is_empty() =>
+                    {
+                        None
+                    }
+                    XmlNode::Element { name: n, .. } if n == TYPE => render_type(c).ok(),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("");
+
+            let mut out = inner;
+            if has_list {
+                out = format!("list[{}]", out);
+            }
+            if has_optional {
+                out = format!("{} | None", out);
+            }
+            Ok(out)
+        }
+        _ => text_content(node).ok_or_else(|| RenderError::MissingChild {
+            parent: TYPE.into(),
+            child: "text".into(),
+        }),
+    }
+}
+
+fn render_type_slot(node: &XmlNode) -> Option<String> {
+    get_child(node, TYPE).and_then(|t| render_type(t).ok())
+}
+
+fn render_base_list(node: &XmlNode) -> String {
+    let base = match get_child(node, BASE) {
+        Some(b) => b,
+        None => return String::new(),
+    };
+    let refs: Vec<String> = get_children(base, REF)
+        .iter()
+        .filter_map(|r| text_content(r))
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .collect();
+    if refs.is_empty() {
+        String::new()
+    } else {
+        format!("({})", refs.join(", "))
+    }
+}
+
+fn render_decorators(node: &XmlNode, opts: &RenderOptions) -> String {
+    let decorators_node = match get_child(node, DECORATORS) {
+        Some(d) => d,
+        None => return String::new(),
+    };
+    let indent = opts.current_indent();
+    get_children(decorators_node, DECORATOR)
+        .iter()
+        .filter_map(|d| text_content(d))
+        .map(|t| {
+            let raw = t.trim();
+            let body = raw.strip_prefix('@').unwrap_or(raw);
+            format!("{}@{}{}", indent, body, opts.newline)
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Field (annotated attribute)
+// ---------------------------------------------------------------------------
+
+fn render_field(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let name = get_child_text(node, NAME).ok_or_else(|| RenderError::MissingChild {
+        parent: FIELD.into(),
+        child: NAME.into(),
+    })?;
+    let type_str = render_type_slot(node);
+    let default = get_child_text(node, DEFAULT);
+
+    let line = match (type_str, default) {
+        (Some(t), Some(v)) => format!("{}{}: {} = {}", indent, name, t, v),
+        (Some(t), None) => format!("{}{}: {}", indent, name, t),
+        (None, Some(v)) => format!("{}{} = {}", indent, name, v),
+        (None, None) => format!("{}{}", indent, name),
+    };
+    Ok(line)
+}
+
+// ---------------------------------------------------------------------------
+// Parameters
+// ---------------------------------------------------------------------------
+
+fn render_parameter(node: &XmlNode) -> Option<String> {
+    let name = get_child_text(node, NAME)?;
+    let ty = render_type_slot(node);
+    let default = get_child_text(node, DEFAULT);
+    let annotated = match ty {
+        Some(t) => format!("{}: {}", name, t),
+        None => name,
+    };
+    Some(match default {
+        Some(d) => format!("{} = {}", annotated, d),
+        None => annotated,
+    })
+}
+
+fn render_parameters(node: &XmlNode) -> String {
+    let params_node = match get_child(node, PARAMETERS) {
+        Some(p) => p,
+        None => return "()".to_string(),
+    };
+    let parts: Vec<String> = get_children(params_node, PARAMETER)
+        .iter()
+        .filter_map(|p| render_parameter(p))
+        .collect();
+    format!("({})", parts.join(", "))
+}
+
+// ---------------------------------------------------------------------------
+// Function / Method
+// ---------------------------------------------------------------------------
+
+fn render_function(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let decorators = render_decorators(node, opts);
+    let name = get_child_text(node, NAME).ok_or_else(|| RenderError::MissingChild {
+        parent: FUNCTION.into(),
+        child: NAME.into(),
+    })?;
+    let params = render_parameters(node);
+    let returns = get_child(node, RETURNS)
+        .and_then(|r| render_type_slot(r).or_else(|| text_content(r)))
+        .map(|t| format!(" -> {}", t))
+        .unwrap_or_default();
+
+    let body_opts = opts.indented();
+    let body_indent = body_opts.current_indent();
+    let body = render_function_body(node, &body_opts)
+        .unwrap_or_else(|| format!("{}pass", body_indent));
+
+    Ok(format!(
+        "{}{}def {}{}{}:{}{}",
+        decorators, indent, name, params, returns, opts.newline, body
+    ))
+}
+
+/// Render a function/method body.
+/// Accepts a <body> wrapper or treats the function's direct children as statements.
+/// Currently supports <pass/>, <return> with text, <comment>, and raw text statements.
+fn render_function_body(node: &XmlNode, opts: &RenderOptions) -> Option<String> {
+    let body = get_child(node, BODY)?;
+    let XmlNode::Element { children, .. } = body else {
+        return None;
+    };
+    let indent = opts.current_indent();
+    let mut lines: Vec<String> = Vec::new();
+    for child in children {
+        match child {
+            XmlNode::Element { name, .. } if name == "pass" => {
+                lines.push(format!("{}pass", indent));
+            }
+            XmlNode::Element { name, .. } if name == COMMENT => {
+                if let Ok(s) = render_comment(child, opts) {
+                    lines.push(s);
+                }
+            }
+            XmlNode::Element { name, .. } if name == "raw" => {
+                if let Some(t) = text_content(child) {
+                    lines.push(format!("{}{}", indent, t.trim()));
+                }
+            }
+            _ => {}
+        }
+    }
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join(&opts.newline))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Class
+// ---------------------------------------------------------------------------
+
+fn render_class(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let decorators = render_decorators(node, opts);
+    let name = get_child_text(node, NAME).ok_or_else(|| RenderError::MissingChild {
+        parent: CLASS.into(),
+        child: NAME.into(),
+    })?;
+    let base = render_base_list(node);
+
+    let body_opts = opts.indented();
+    let body_indent = body_opts.current_indent();
+    let members = collect_body_members(node, &body_opts)?;
+
+    let body = if members.is_empty() {
+        format!("{}pass", body_indent)
+    } else {
+        let mut rendered = Vec::new();
+        let mut prev_kind: Option<&str> = None;
+        for (kind, text) in &members {
+            // Blank line between methods/functions and between a block of fields
+            // and a following method.
+            if let Some(pk) = prev_kind {
+                if is_callable(kind) || is_callable(pk) {
+                    rendered.push(String::new());
+                }
+            }
+            rendered.push(text.clone());
+            prev_kind = Some(kind);
+        }
+        rendered.join(&opts.newline)
+    };
+
+    Ok(format!(
+        "{}{}class {}{}:{}{}",
+        decorators, indent, name, base, opts.newline, body
+    ))
+}
+
+fn is_callable(kind: &str) -> bool {
+    matches!(kind, FUNCTION | METHOD)
+}
+
+/// Collect body members as (kind, rendered text) pairs.
+fn collect_body_members<'a>(
+    node: &'a XmlNode,
+    opts: &RenderOptions,
+) -> Result<Vec<(&'a str, String)>, RenderError> {
+    let container = get_child(node, BODY).unwrap_or(node);
+    let XmlNode::Element { children, .. } = container else {
+        return Ok(Vec::new());
+    };
+
+    let mut out = Vec::new();
+    for child in children {
+        if let XmlNode::Element { name, .. } = child {
+            match name.as_str() {
+                FIELD | FUNCTION | METHOD | COMMENT | CLASS => {
+                    out.push((name.as_str(), render_node(child, opts)?));
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Import / Comment / Module
+// ---------------------------------------------------------------------------
+
+fn render_import(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let text = text_content(node).unwrap_or_default();
+    let trimmed = text.trim();
+    let line = if trimmed.starts_with("import") || trimmed.starts_with("from") {
+        trimmed.to_string()
+    } else {
+        format!("import {}", trimmed)
+    };
+    Ok(format!("{}{}", opts.current_indent(), line))
+}
+
+fn render_comment(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let text = text_content(node).unwrap_or_default();
+    let trimmed = text.trim();
+    let body = trimmed.strip_prefix('#').map(|s| s.trim()).unwrap_or(trimmed);
+    Ok(format!("{}# {}", opts.current_indent(), body))
+}
+
+fn render_module(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let XmlNode::Element { children, .. } = node else {
+        return Ok(String::new());
+    };
+
+    let mut parts: Vec<(&str, String)> = Vec::new();
+    for child in children {
+        if let XmlNode::Element { name, .. } = child {
+            match name.as_str() {
+                IMPORT | CLASS | FUNCTION | COMMENT | FIELD => {
+                    parts.push((name.as_str(), render_node(child, opts)?));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Two blank lines before top-level class/function (PEP 8).
+    let mut result = String::new();
+    for (i, (kind, text)) in parts.iter().enumerate() {
+        if i > 0 {
+            let prev = parts[i - 1].0;
+            let blank = if matches!(*kind, CLASS | FUNCTION) || matches!(prev, CLASS | FUNCTION) {
+                format!("{}{}", opts.newline, opts.newline)
+            } else {
+                String::new()
+            };
+            result.push_str(&opts.newline);
+            result.push_str(&blank);
+        }
+        result.push_str(text);
+    }
+    Ok(result)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::parse_xml;
+
+    fn render(xml: &str) -> String {
+        let node = parse_xml(xml).unwrap();
+        render_node(&node, &RenderOptions::default()).unwrap()
+    }
+
+    #[test]
+    fn field_annotated() {
+        assert_eq!(
+            render(r#"<field><name>count</name><type>int</type></field>"#),
+            "count: int"
+        );
+    }
+
+    #[test]
+    fn field_optional() {
+        assert_eq!(
+            render(r#"<field><name>age</name><type><optional/>int</type></field>"#),
+            "age: int | None"
+        );
+    }
+
+    #[test]
+    fn field_list() {
+        assert_eq!(
+            render(r#"<field><name>tags</name><type><list/>str</type></field>"#),
+            "tags: list[str]"
+        );
+    }
+
+    #[test]
+    fn class_with_fields() {
+        let xml = r#"<class><name>User</name><body><field><name>name</name><type>str</type></field><field><name>id</name><type>int</type></field></body></class>"#;
+        let expected = "class User:\n    name: str\n    id: int";
+        assert_eq!(render(xml), expected);
+    }
+
+    #[test]
+    fn class_empty_is_pass() {
+        assert_eq!(render(r#"<class><name>Empty</name></class>"#), "class Empty:\n    pass");
+    }
+
+    #[test]
+    fn class_with_base() {
+        let xml = r#"<class><name>Dog</name><base><ref>Animal</ref></base><body><field><name>legs</name><type>int</type></field></body></class>"#;
+        assert_eq!(render(xml), "class Dog(Animal):\n    legs: int");
+    }
+
+    #[test]
+    fn function_signature() {
+        let xml = r#"<function><name>save</name><parameters><parameter><name>self</name></parameter><parameter><name>id</name><type>int</type></parameter></parameters><returns><type>None</type></returns></function>"#;
+        assert_eq!(render(xml), "def save(self, id: int) -> None:\n    pass");
+    }
+
+    #[test]
+    fn class_field_then_method_blank_line() {
+        let xml = r#"<class><name>User</name><body><field><name>id</name><type>int</type></field><method><name>save</name><parameters><parameter><name>self</name></parameter></parameters><returns><type>None</type></returns></method></body></class>"#;
+        let expected = "class User:\n    id: int\n\n    def save(self) -> None:\n        pass";
+        assert_eq!(render(xml), expected);
+    }
+}

--- a/tractor/src/render/python.rs
+++ b/tractor/src/render/python.rs
@@ -19,6 +19,8 @@ pub fn render_node(node: &XmlNode, opts: &RenderOptions) -> Result<String, Rende
             FUNCTION | METHOD => render_function(node, opts),
             FIELD => render_field(node, opts),
             IMPORT => render_import(node, opts),
+            "from" => render_from_import(node, opts),
+            "decorated" => render_decorated(node, opts),
             COMMENT => render_comment(node, opts),
             _ => Err(RenderError::UnsupportedNode(name.clone())),
         },
@@ -34,6 +36,11 @@ pub fn render_node(node: &XmlNode, opts: &RenderOptions) -> Result<String, Rende
 fn render_type(node: &XmlNode) -> Result<String, RenderError> {
     match node {
         XmlNode::Element { name, children, .. } if name == TYPE => {
+            // Parser shape: <type><generic_type><name>list</name><type_parameter>[<type>str</type>]</type_parameter></generic_type></type>
+            if let Some(g) = get_child(node, "generic_type") {
+                return render_generic_type(g);
+            }
+
             let has_optional = has_marker(node, OPTIONAL);
             let has_list = has_marker(node, LIST);
 
@@ -67,6 +74,26 @@ fn render_type(node: &XmlNode) -> Result<String, RenderError> {
             child: "text".into(),
         }),
     }
+}
+
+/// Render `<generic_type>` — parser form of `Name[T]` or `Name[K, V]` such as
+/// `list[str]`, `dict[str, int]`, `Optional[str]`. The name is read from the
+/// child `<name>` element, the arguments from the `<type_parameter>` wrapper
+/// which contains `[`, comma-separated `<type>` elements, and `]`.
+fn render_generic_type(node: &XmlNode) -> Result<String, RenderError> {
+    let name = get_child_text(node, NAME)
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default();
+    let args = get_child(node, "type_parameter")
+        .map(|p| {
+            get_children(p, TYPE)
+                .iter()
+                .filter_map(|t| render_type(t).ok())
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default();
+    Ok(format!("{}[{}]", name, args))
 }
 
 fn render_type_slot(node: &XmlNode) -> Option<String> {
@@ -114,12 +141,14 @@ fn render_decorators(node: &XmlNode, opts: &RenderOptions) -> String {
 
 fn render_field(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
     let indent = opts.current_indent();
-    let name = get_child_text(node, NAME).ok_or_else(|| RenderError::MissingChild {
-        parent: FIELD.into(),
-        child: NAME.into(),
-    })?;
+    let name = get_child_text(node, NAME)
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| RenderError::MissingChild {
+            parent: FIELD.into(),
+            child: NAME.into(),
+        })?;
     let type_str = render_type_slot(node);
-    let default = get_child_text(node, DEFAULT);
+    let default = get_child(node, DEFAULT).and_then(render_value_slot);
 
     let line = match (type_str, default) {
         (Some(t), Some(v)) => format!("{}{}: {} = {}", indent, name, t, v),
@@ -128,6 +157,53 @@ fn render_field(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderEr
         (None, None) => format!("{}{}", indent, name),
     };
     Ok(line)
+}
+
+/// Render a value slot (`<default>`, `<value>`, etc.) by extracting its first
+/// literal-shaped child. Handles Python literals: int, float, string, bool
+/// (`<true/>`/`<false/>`), and `<none>None</none>`. Strings and booleans are
+/// returned verbatim (quotes preserved from source via `text_content`).
+fn render_value_slot(node: &XmlNode) -> Option<String> {
+    let XmlNode::Element { children, .. } = node else {
+        return None;
+    };
+    children.iter().find_map(render_python_literal)
+}
+
+fn render_python_literal(node: &XmlNode) -> Option<String> {
+    let XmlNode::Element { name, children, .. } = node else {
+        return None;
+    };
+    match name.as_str() {
+        "int" | "float" | "true" | "false" | "none" => {
+            text_content(node).map(|t| t.trim().to_string())
+        }
+        // Python strings come in as
+        //   <string><string_start>"</string_start>
+        //           <string_content>…</string_content>?
+        //           <string_end>"</string_end></string>
+        // Reassemble quote + content + quote so embedded whitespace in the
+        // content survives even though pretty-printed XML adds whitespace
+        // around the child elements.
+        "string" => {
+            let get_part = |part: &str| -> String {
+                children
+                    .iter()
+                    .find_map(|c| match c {
+                        XmlNode::Element { name: n, .. } if n == part => text_content(c),
+                        _ => None,
+                    })
+                    .unwrap_or_default()
+            };
+            let start = get_part("string_start");
+            let end = get_part("string_end");
+            let content = get_part("string_content");
+            let quote = if !start.is_empty() { start } else { "\"".to_string() };
+            let closer = if !end.is_empty() { end } else { quote.clone() };
+            Some(format!("{}{}{}", quote, content, closer))
+        }
+        _ => None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -297,22 +373,138 @@ fn collect_body_members<'a>(
 // Import / Comment / Module
 // ---------------------------------------------------------------------------
 
+/// Render `<import>import<name><dotted_name>…</dotted_name></name></import>` as
+/// `import os.path`. Falls back to flat text content when the parser shape
+/// isn't recognised.
 fn render_import(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
-    let text = text_content(node).unwrap_or_default();
-    let trimmed = text.trim();
-    let line = if trimmed.starts_with("import") || trimmed.starts_with("from") {
-        trimmed.to_string()
-    } else {
-        format!("import {}", trimmed)
+    let module = find_import_module(node).unwrap_or_else(|| {
+        text_content(node)
+            .unwrap_or_default()
+            .trim()
+            .strip_prefix("import")
+            .unwrap_or_default()
+            .trim()
+            .to_string()
+    });
+    Ok(format!("{}import {}", opts.current_indent(), module))
+}
+
+/// Render `<from>from<dotted_name>M</dotted_name>import<name>A</name>,<name>B</name></from>`
+/// as `from M import A, B`.
+fn render_from_import(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let XmlNode::Element { children, .. } = node else {
+        return Ok(String::new());
     };
-    Ok(format!("{}{}", opts.current_indent(), line))
+
+    // The module is the FIRST <dotted_name> — it's the source of the import.
+    // Subsequent imported names live in <name> wrappers.
+    let module = children
+        .iter()
+        .find_map(|c| match c {
+            XmlNode::Element { name, .. } if name == "dotted_name" => dotted_name_text(c),
+            _ => None,
+        })
+        .unwrap_or_default();
+
+    let imports: Vec<String> = children
+        .iter()
+        .filter_map(|c| match c {
+            XmlNode::Element { name, .. } if name == NAME => {
+                // The <name> wrapper can itself contain <dotted_name> (the
+                // Python parser wraps imported names that way).
+                get_child(c, "dotted_name")
+                    .and_then(dotted_name_text)
+                    .or_else(|| text_content(c).map(|t| t.trim().to_string()))
+            }
+            _ => None,
+        })
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    let imports_str = imports.join(", ");
+    Ok(format!(
+        "{}from {} import {}",
+        opts.current_indent(),
+        module,
+        imports_str
+    ))
+}
+
+fn find_import_module(node: &XmlNode) -> Option<String> {
+    let name_child = get_child(node, NAME)?;
+    get_child(name_child, "dotted_name")
+        .and_then(dotted_name_text)
+        .or_else(|| text_content(name_child).map(|t| t.trim().to_string()))
+}
+
+/// Join the `<name>` children of a `<dotted_name>` with dots —
+/// `<dotted_name><name>os</name>.<name>path</name></dotted_name>` → `os.path`.
+fn dotted_name_text(node: &XmlNode) -> Option<String> {
+    let XmlNode::Element { children, .. } = node else {
+        return None;
+    };
+    let parts: Vec<String> = children
+        .iter()
+        .filter_map(|c| match c {
+            XmlNode::Element { name, .. } if name == NAME => {
+                text_content(c).map(|t| t.trim().to_string())
+            }
+            _ => None,
+        })
+        .filter(|s| !s.is_empty())
+        .collect();
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("."))
+    }
+}
+
+/// Render `<decorated><decorator>@X</decorator>...<class|function>…</class|function></decorated>`
+/// by prepending the decorator to the wrapped declaration.
+fn render_decorated(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let XmlNode::Element { children, .. } = node else {
+        return Ok(String::new());
+    };
+    let indent = opts.current_indent();
+    let mut decorators = Vec::new();
+    let mut inner: Option<String> = None;
+
+    for child in children {
+        if let XmlNode::Element { name, .. } = child {
+            match name.as_str() {
+                "decorator" => {
+                    let text = text_content(child).unwrap_or_default();
+                    let body = text
+                        .trim()
+                        .strip_prefix('@')
+                        .map(|s| s.trim())
+                        .unwrap_or_else(|| text.trim());
+                    decorators.push(format!("{}@{}", indent, body));
+                }
+                CLASS | FUNCTION | METHOD => {
+                    inner = Some(render_node(child, opts)?);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut parts = decorators;
+    if let Some(body) = inner {
+        parts.push(body);
+    }
+    Ok(parts.join(&opts.newline))
 }
 
 fn render_comment(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
     let text = text_content(node).unwrap_or_default();
-    let trimmed = text.trim();
-    let body = trimmed.strip_prefix('#').map(|s| s.trim()).unwrap_or(trimmed);
-    Ok(format!("{}# {}", opts.current_indent(), body))
+    // Preserve the comment verbatim (indentation trimmed). A bare `#` stays a
+    // bare `#`, `# foo` stays `# foo`; we don't reflow the body because round
+    // trips need byte equality.
+    let trimmed = text.trim_start_matches([' ', '\t']).trim_end_matches(['\r', '\n']);
+    let body = if trimmed.is_empty() { "#" } else { trimmed };
+    Ok(format!("{}{}", opts.current_indent(), body))
 }
 
 fn render_module(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
@@ -324,7 +516,7 @@ fn render_module(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderE
     for child in children {
         if let XmlNode::Element { name, .. } = child {
             match name.as_str() {
-                IMPORT | CLASS | FUNCTION | COMMENT | FIELD => {
+                IMPORT | "from" | CLASS | FUNCTION | "decorated" | COMMENT | FIELD => {
                     parts.push((name.as_str(), render_node(child, opts)?));
                 }
                 _ => {}
@@ -332,15 +524,30 @@ fn render_module(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderE
         }
     }
 
-    // Two blank lines before top-level class/function (PEP 8).
+    // Separation rules:
+    //   * Consecutive items of the same lightweight kind (imports, from
+    //     imports, comments) stay tight.
+    //   * Two blank lines around top-level class/function/decorated (PEP 8).
+    //   * Any other kind transition (e.g. comment → import, import → class)
+    //     gets a single blank line.
+    let is_decl = |k: &str| matches!(k, CLASS | FUNCTION | "decorated");
+    let is_import_like = |k: &str| matches!(k, IMPORT | "from");
     let mut result = String::new();
     for (i, (kind, text)) in parts.iter().enumerate() {
         if i > 0 {
             let prev = parts[i - 1].0;
-            let blank = if matches!(*kind, CLASS | FUNCTION) || matches!(prev, CLASS | FUNCTION) {
+            // Consecutive imports (any mix of `import X` / `from X import Y`)
+            // and consecutive comment lines stay tight.
+            let tight = (is_import_like(kind) && is_import_like(prev))
+                || (prev == *kind && *kind == COMMENT);
+            let blank = if tight {
+                String::new()
+            } else if is_decl(kind) || is_decl(prev) {
                 format!("{}{}", opts.newline, opts.newline)
             } else {
-                String::new()
+                // Different kind-on-kind transition (e.g. comment → import,
+                // import → from, from → import) gets one blank line.
+                opts.newline.clone()
             };
             result.push_str(&opts.newline);
             result.push_str(&blank);

--- a/tractor/src/render/typescript.rs
+++ b/tractor/src/render/typescript.rs
@@ -1,0 +1,268 @@
+//! TypeScript code renderer
+//!
+//! Renders tractor's semantic XML back to TypeScript source. Scope is
+//! data-structure constructs only — interfaces, type aliases, enums, and
+//! classes with typed fields — matching the supported-fixture round-trip
+//! test in `tractor/tests/render_roundtrip.rs`.
+
+use super::{
+    get_child, get_child_text, get_children, has_marker, text_content, RenderError, RenderOptions,
+};
+use crate::xpath::XmlNode;
+
+const PROGRAM: &str = "program";
+const INTERFACE: &str = "interface";
+const CLASS: &str = "class";
+const ENUM: &str = "enum";
+const TYPEALIAS: &str = "typealias";
+const FIELD: &str = "field";
+const NAME: &str = "name";
+const TYPE: &str = "type";
+const ARRAY: &str = "array";
+const BODY: &str = "body";
+const VALUE: &str = "value";
+const OPTIONAL: &str = "optional";
+const IMPORT: &str = "import";
+const EXPORT: &str = "export";
+const COMMENT: &str = "comment";
+
+pub fn render_node(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    match node {
+        XmlNode::Element { name, .. } => match name.as_str() {
+            PROGRAM => render_program(node, opts),
+            INTERFACE => render_interface(node, opts),
+            CLASS => render_class(node, opts),
+            ENUM => render_enum(node, opts),
+            TYPEALIAS => render_typealias(node, opts),
+            FIELD => render_field(node, opts),
+            IMPORT | EXPORT => render_passthrough(node, opts),
+            COMMENT => render_comment(node, opts),
+            _ => Err(RenderError::UnsupportedNode(name.clone())),
+        },
+        XmlNode::Text(t) => Ok(t.clone()),
+        _ => Ok(String::new()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Render a TypeScript type: `<type>string</type>` → `string`,
+/// `<array><type>string</type></array>` → `string[]`. When the node is a
+/// `<type>` containing a nested `<array>` we descend; generic types are out
+/// of scope for this batch.
+fn render_type(node: &XmlNode) -> Result<String, RenderError> {
+    let XmlNode::Element { name, children, .. } = node else {
+        return text_content(node).ok_or_else(|| RenderError::MissingChild {
+            parent: TYPE.into(),
+            child: "text".into(),
+        });
+    };
+
+    if name == ARRAY {
+        let inner = children
+            .iter()
+            .find_map(|c| match c {
+                XmlNode::Element { name: n, .. } if n == TYPE || n == ARRAY => render_type(c).ok(),
+                _ => None,
+            })
+            .unwrap_or_default();
+        return Ok(format!("{}[]", inner));
+    }
+
+    // <type> — may wrap another <array> for `string[]`, or hold plain text.
+    if let Some(a) = get_child(node, ARRAY) {
+        return render_type(a);
+    }
+    Ok(text_content(node)
+        .unwrap_or_default()
+        .trim()
+        .to_string())
+}
+
+fn render_type_slot(node: &XmlNode) -> Option<String> {
+    if let Some(t) = get_child(node, TYPE) {
+        return render_type(t).ok();
+    }
+    if let Some(a) = get_child(node, ARRAY) {
+        return render_type(a).ok();
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Field — shared shape with Python/C#: <field><required|optional/><name>…</name><type>…</type></field>
+// ---------------------------------------------------------------------------
+
+fn render_field(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let name = get_child_text(node, NAME)
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| RenderError::MissingChild {
+            parent: FIELD.into(),
+            child: NAME.into(),
+        })?;
+    let optional = if has_marker(node, OPTIONAL) { "?" } else { "" };
+    let ty = render_type_slot(node).unwrap_or_default();
+    if ty.is_empty() {
+        Ok(format!("{}{}{};", indent, name, optional))
+    } else {
+        Ok(format!("{}{}{}: {};", indent, name, optional, ty))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Interface / Class
+// ---------------------------------------------------------------------------
+
+fn render_interface(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    render_type_declaration(node, "interface", INTERFACE, opts)
+}
+
+fn render_class(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    render_type_declaration(node, "class", CLASS, opts)
+}
+
+fn render_type_declaration(
+    node: &XmlNode,
+    keyword: &str,
+    parent: &str,
+    opts: &RenderOptions,
+) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let name = declaration_name(node, parent)?;
+    let body_opts = opts.indented();
+    let members = collect_body_members(node, &body_opts)?;
+    let mut result = format!("{}{} {} {{", indent, keyword, name);
+    result.push_str(&opts.newline);
+    for member in &members {
+        result.push_str(member);
+        result.push_str(&opts.newline);
+    }
+    result.push_str(&format!("{}}}", indent));
+    Ok(result)
+}
+
+fn declaration_name(node: &XmlNode, parent: &str) -> Result<String, RenderError> {
+    get_child_text(node, NAME)
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| RenderError::MissingChild {
+            parent: parent.into(),
+            child: NAME.into(),
+        })
+}
+
+fn collect_body_members(
+    node: &XmlNode,
+    opts: &RenderOptions,
+) -> Result<Vec<String>, RenderError> {
+    let container = get_child(node, BODY).unwrap_or(node);
+    let XmlNode::Element { children, .. } = container else {
+        return Ok(Vec::new());
+    };
+    let mut out = Vec::new();
+    for child in children {
+        if let XmlNode::Element { name, .. } = child {
+            match name.as_str() {
+                FIELD | INTERFACE | CLASS | ENUM | TYPEALIAS | COMMENT => {
+                    out.push(render_node(child, opts)?);
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Enum
+// ---------------------------------------------------------------------------
+
+fn render_enum(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let name = declaration_name(node, ENUM)?;
+    let member_indent = opts.indented().current_indent();
+
+    let container = get_child(node, BODY).unwrap_or(node);
+    let members: Vec<String> = get_children(container, NAME)
+        .iter()
+        .filter_map(|m| text_content(m).map(|t| t.trim().to_string()))
+        .filter(|t| !t.is_empty())
+        .map(|m| format!("{}{}", member_indent, m))
+        .collect();
+
+    let mut result = format!("{}enum {} {{", indent, name);
+    result.push_str(&opts.newline);
+    result.push_str(&members.join(&format!(",{}", opts.newline)));
+    if !members.is_empty() {
+        result.push_str(&opts.newline);
+    }
+    result.push_str(&format!("{}}}", indent));
+    Ok(result)
+}
+
+// ---------------------------------------------------------------------------
+// Type alias: `type X = T;`
+// ---------------------------------------------------------------------------
+
+fn render_typealias(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let indent = opts.current_indent();
+    let name = declaration_name(node, TYPEALIAS)?;
+    let value = get_child(node, VALUE)
+        .and_then(|v| render_type_slot(v).or_else(|| text_content(v).map(|t| t.trim().to_string())))
+        .unwrap_or_default();
+    Ok(format!("{}type {} = {};", indent, name, value))
+}
+
+// ---------------------------------------------------------------------------
+// Pass-through for leaves like import/export rendered from raw text
+// ---------------------------------------------------------------------------
+
+fn render_passthrough(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let text = text_content(node).unwrap_or_default();
+    Ok(format!("{}{}", opts.current_indent(), text.trim()))
+}
+
+fn render_comment(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let text = text_content(node).unwrap_or_default();
+    Ok(format!("{}{}", opts.current_indent(), text.trim()))
+}
+
+// ---------------------------------------------------------------------------
+// Program (top-level)
+// ---------------------------------------------------------------------------
+
+fn render_program(node: &XmlNode, opts: &RenderOptions) -> Result<String, RenderError> {
+    let XmlNode::Element { children, .. } = node else {
+        return Ok(String::new());
+    };
+    let mut parts: Vec<(&str, String)> = Vec::new();
+    for child in children {
+        if let XmlNode::Element { name, .. } = child {
+            match name.as_str() {
+                IMPORT | EXPORT | INTERFACE | CLASS | ENUM | TYPEALIAS | COMMENT => {
+                    parts.push((name.as_str(), render_node(child, opts)?));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Consecutive imports/exports and consecutive comment lines stay tight.
+    // Any other transition (comment → decl, decl → decl, import → decl) gets
+    // a single blank line between them, which is the idiomatic TS style.
+    let mut result = String::new();
+    for (i, (kind, text)) in parts.iter().enumerate() {
+        if i > 0 {
+            let prev = parts[i - 1].0;
+            let tight = prev == *kind && matches!(*kind, IMPORT | EXPORT | COMMENT);
+            result.push_str(&opts.newline);
+            if !tight {
+                result.push_str(&opts.newline);
+            }
+        }
+        result.push_str(text);
+    }
+    Ok(result)
+}

--- a/tractor/tests/cli.rs
+++ b/tractor/tests/cli.rs
@@ -45,7 +45,7 @@ cli_suite! {
         binary_op => tractor query "sample.cs" -x "binary[op='+']" => count 1;
         call_rename => tractor query "sample.cs" -x "call" => count 4;
         ints_exist => tractor query "sample.cs" -x "int" => count 2;
-        public_methods => tractor query "sample.cs" -x "//method[public]" => count 1;
+        public_methods => tractor query "sample.cs" -x "//method[public]" => count 2;
         private_methods => tractor query "sample.cs" -x "//method[private]" => count 1;
         internal_methods => tractor query "sample.cs" -x "//method[internal]" => count 1;
         protected_methods => tractor query "sample.cs" -x "//method[protected]" => count 1;

--- a/tractor/tests/cli.rs
+++ b/tractor/tests/cli.rs
@@ -46,7 +46,7 @@ cli_suite! {
         call_rename => tractor query "sample.cs" -x "call" => count 4;
         ints_exist => tractor query "sample.cs" -x "int" => count 2;
         public_methods => tractor query "sample.cs" -x "//method[public]" => count 1;
-        private_methods => tractor query "sample.cs" -x "//method[private]" => count 2;
+        private_methods => tractor query "sample.cs" -x "//method[private]" => count 1;
         internal_methods => tractor query "sample.cs" -x "//method[internal]" => count 1;
         protected_methods => tractor query "sample.cs" -x "//method[protected]" => count 1;
         maxlength_missing_autotruncate => tractor query "attribute-maxlength-autotruncate.cs" -x "//property[attributes[contains(., 'MaxLength')]][not(attributes[contains(., 'AutoTruncate')])]/name" => count 1;

--- a/tractor/tests/render_roundtrip.rs
+++ b/tractor/tests/render_roundtrip.rs
@@ -95,3 +95,9 @@ fn csharp_supported_fixture_round_trips() {
     let path = fixture("csharp", "supported.cs");
     assert_fixture_round_trips(&path, "csharp");
 }
+
+#[test]
+fn python_supported_fixture_round_trips() {
+    let path = fixture("python", "supported.py");
+    assert_fixture_round_trips(&path, "python");
+}

--- a/tractor/tests/render_roundtrip.rs
+++ b/tractor/tests/render_roundtrip.rs
@@ -101,3 +101,9 @@ fn python_supported_fixture_round_trips() {
     let path = fixture("python", "supported.py");
     assert_fixture_round_trips(&path, "python");
 }
+
+#[test]
+fn typescript_supported_fixture_round_trips() {
+    let path = fixture("typescript", "supported.ts");
+    assert_fixture_round_trips(&path, "typescript");
+}

--- a/tractor/tests/render_roundtrip.rs
+++ b/tractor/tests/render_roundtrip.rs
@@ -107,3 +107,9 @@ fn typescript_supported_fixture_round_trips() {
     let path = fixture("typescript", "supported.ts");
     assert_fixture_round_trips(&path, "typescript");
 }
+
+#[test]
+fn java_supported_fixture_round_trips() {
+    let path = fixture("java", "supported.java");
+    assert_fixture_round_trips(&path, "java");
+}

--- a/tractor/tests/render_roundtrip.rs
+++ b/tractor/tests/render_roundtrip.rs
@@ -1,0 +1,97 @@
+//! Render round-trip integration tests.
+//!
+//! Each language has a single fixture file under
+//! `tests/integration/render/<lang>/supported.<ext>`. The test parses the
+//! fixture, renders the resulting semantic tree back to source, and asserts
+//! byte equality with the fixture.
+//!
+//! The fixture IS the snapshot of what the renderer supports: anything that
+//! stays in the file round-trips, anything new you add to the file must
+//! round-trip too. When the test fails, the fixture's git diff pinpoints the
+//! regression.
+
+use std::path::PathBuf;
+
+use tractor::parser::parse_string_to_xot;
+use tractor::render::{parse_xml, render, RenderOptions as CodeRenderOptions};
+use tractor::{render_document, RenderOptions as XmlRenderOptions, TreeMode};
+
+fn repo_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR points at `<repo>/tractor`; the fixtures live under
+    // the workspace-level `tests/` directory.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("repo root")
+        .to_path_buf()
+}
+
+fn fixture(lang_dir: &str, name: &str) -> PathBuf {
+    repo_root()
+        .join("tests/integration/render")
+        .join(lang_dir)
+        .join(name)
+}
+
+/// Parse `source` using the given language, render the tree back to source,
+/// and return the rendered string.
+fn round_trip(source: &str, lang: &str) -> String {
+    let parsed = parse_string_to_xot(source, lang, "<fixture>".to_string(), None)
+        .expect("parse_string_to_xot");
+    let xml_opts = XmlRenderOptions {
+        include_meta: false,
+        pretty_print: true,
+        use_color: false,
+        ..XmlRenderOptions::new()
+    };
+    let xml = render_document(&parsed.xot, parsed.root, &xml_opts);
+    let node = parse_xml(&xml).expect("parse_xml");
+    render(&node, lang, TreeMode::Data, &CodeRenderOptions::default()).expect("render")
+}
+
+/// Assert that the given fixture file round-trips through parse→render
+/// unchanged. Trailing newlines on the fixture are preserved; the renderer's
+/// output is compared against the file content byte-for-byte (after stripping
+/// a single optional trailing newline on either side so editors that save a
+/// final newline don't cause false failures).
+fn assert_fixture_round_trips(path: &PathBuf, lang: &str) {
+    let source = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read fixture {}: {e}", path.display()));
+    let rendered = round_trip(&source, lang);
+
+    let lhs = source.trim_end_matches('\n');
+    let rhs = rendered.trim_end_matches('\n');
+
+    if lhs != rhs {
+        // Render a compact diff for the failure message: show the first
+        // differing line so CI logs stay focused.
+        let first_diff = lhs
+            .lines()
+            .zip(rhs.lines())
+            .enumerate()
+            .find(|(_, (a, b))| a != b);
+        let where_ = match first_diff {
+            Some((line, (a, b))) => format!(
+                "\nfirst diff at line {}:\n  source:   {a}\n  rendered: {b}",
+                line + 1
+            ),
+            None => format!(
+                "\n(length differs: source={} lines, rendered={} lines)",
+                lhs.lines().count(),
+                rhs.lines().count()
+            ),
+        };
+        panic!(
+            "round-trip mismatch for {}{}\n\n--- source ---\n{}\n\n--- rendered ---\n{}\n",
+            path.display(),
+            where_,
+            lhs,
+            rhs
+        );
+    }
+}
+
+#[test]
+fn csharp_supported_fixture_round_trips() {
+    let path = fixture("csharp", "supported.cs");
+    assert_fixture_round_trips(&path, "csharp");
+}


### PR DESCRIPTION
Demonstrates transforming a TypeScript interface into a C# class by
composing two tractor commands: a query that map-projects the TS AST
into the data shape the C# renderer consumes, piped into `tractor render`.