### PR TITLE
Fix XPath 3-level predicate bug (closes #129)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ dependencies = [
 [[package]]
 name = "xee-interpreter"
 version = "0.2.0"
-source = "git+https://github.com/Paligo/xee#f1068e5788271316d4ee47333efc97d6a013f79f"
+source = "git+https://github.com/boukeversteegh/xee.git?rev=369f90e279a956425ff9dc0a755abc194699aefb#369f90e279a956425ff9dc0a755abc194699aefb"
 dependencies = [
  "ahash 0.8.12",
  "arrayvec",
@@ -2778,7 +2778,7 @@ dependencies = [
 [[package]]
 name = "xee-ir"
 version = "0.1.5"
-source = "git+https://github.com/Paligo/xee#f1068e5788271316d4ee47333efc97d6a013f79f"
+source = "git+https://github.com/boukeversteegh/xee.git?rev=369f90e279a956425ff9dc0a755abc194699aefb#369f90e279a956425ff9dc0a755abc194699aefb"
 dependencies = [
  "ahash 0.8.12",
  "ibig",
@@ -2793,7 +2793,7 @@ dependencies = [
 [[package]]
 name = "xee-name"
 version = "0.1.5"
-source = "git+https://github.com/Paligo/xee#f1068e5788271316d4ee47333efc97d6a013f79f"
+source = "git+https://github.com/boukeversteegh/xee.git?rev=369f90e279a956425ff9dc0a755abc194699aefb#369f90e279a956425ff9dc0a755abc194699aefb"
 dependencies = [
  "ahash 0.8.12",
  "xot",
@@ -2802,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "xee-schema-type"
 version = "0.1.4"
-source = "git+https://github.com/Paligo/xee#f1068e5788271316d4ee47333efc97d6a013f79f"
+source = "git+https://github.com/boukeversteegh/xee.git?rev=369f90e279a956425ff9dc0a755abc194699aefb#369f90e279a956425ff9dc0a755abc194699aefb"
 dependencies = [
  "ahash 0.8.12",
 ]
@@ -2810,7 +2810,7 @@ dependencies = [
 [[package]]
 name = "xee-xpath"
 version = "0.1.5"
-source = "git+https://github.com/Paligo/xee#f1068e5788271316d4ee47333efc97d6a013f79f"
+source = "git+https://github.com/boukeversteegh/xee.git?rev=369f90e279a956425ff9dc0a755abc194699aefb#369f90e279a956425ff9dc0a755abc194699aefb"
 dependencies = [
  "ahash 0.8.12",
  "chrono",
@@ -2830,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "xee-xpath-ast"
 version = "0.1.4"
-source = "git+https://github.com/Paligo/xee#f1068e5788271316d4ee47333efc97d6a013f79f"
+source = "git+https://github.com/boukeversteegh/xee.git?rev=369f90e279a956425ff9dc0a755abc194699aefb#369f90e279a956425ff9dc0a755abc194699aefb"
 dependencies = [
  "ahash 0.8.12",
  "blanket",
@@ -2849,7 +2849,7 @@ dependencies = [
 [[package]]
 name = "xee-xpath-compiler"
 version = "0.1.5"
-source = "git+https://github.com/Paligo/xee#f1068e5788271316d4ee47333efc97d6a013f79f"
+source = "git+https://github.com/boukeversteegh/xee.git?rev=369f90e279a956425ff9dc0a755abc194699aefb#369f90e279a956425ff9dc0a755abc194699aefb"
 dependencies = [
  "ahash 0.8.12",
  "ibig",
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "xee-xpath-lexer"
 version = "0.1.4"
-source = "git+https://github.com/Paligo/xee#f1068e5788271316d4ee47333efc97d6a013f79f"
+source = "git+https://github.com/boukeversteegh/xee.git?rev=369f90e279a956425ff9dc0a755abc194699aefb#369f90e279a956425ff9dc0a755abc194699aefb"
 dependencies = [
  "ibig",
  "itertools",
@@ -2878,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "xee-xpath-macros"
 version = "0.1.4"
-source = "git+https://github.com/Paligo/xee#f1068e5788271316d4ee47333efc97d6a013f79f"
+source = "git+https://github.com/boukeversteegh/xee.git?rev=369f90e279a956425ff9dc0a755abc194699aefb#369f90e279a956425ff9dc0a755abc194699aefb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2891,7 +2891,7 @@ dependencies = [
 [[package]]
 name = "xee-xpath-type"
 version = "0.1.4"
-source = "git+https://github.com/Paligo/xee#f1068e5788271316d4ee47333efc97d6a013f79f"
+source = "git+https://github.com/boukeversteegh/xee.git?rev=369f90e279a956425ff9dc0a755abc194699aefb#369f90e279a956425ff9dc0a755abc194699aefb"
 dependencies = [
  "xee-name",
  "xee-schema-type",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,9 @@ tree-sitter-ini = "1.4"
 tree-sitter-sequel-tsql = "0.4"
 
 # XPath 3.1
-xee = { git = "https://github.com/Paligo/xee" }
-xee-xpath = { git = "https://github.com/Paligo/xee" }
+# Fork pinned by SHA — see docs/workflow-xee-fork.md. Bump when `tractor` branch advances.
+xee = { git = "https://github.com/boukeversteegh/xee.git", rev = "369f90e279a956425ff9dc0a755abc194699aefb" }
+xee-xpath = { git = "https://github.com/boukeversteegh/xee.git", rev = "369f90e279a956425ff9dc0a755abc194699aefb" }
 xot = "0.31"
 
 # CLI and utilities

--- a/tractor/Cargo.toml
+++ b/tractor/Cargo.toml
@@ -91,7 +91,7 @@ tree-sitter-sequel-tsql = { workspace = true, optional = true }
 
 # XPath 3.1
 xee-xpath.workspace = true
-xee-interpreter = { git = "https://github.com/Paligo/xee" }
+xee-interpreter = { git = "https://github.com/boukeversteegh/xee.git", rev = "369f90e279a956425ff9dc0a755abc194699aefb" }
 xot.workspace = true
 
 # Utilities (always needed)

--- a/tractor/tests/cli.rs
+++ b/tractor/tests/cli.rs
@@ -158,6 +158,10 @@ cli_suite! {
         async_function => tractor query "sample.py" -x "function[async]" => count 1;
         multiline_lf => tractor query "multiline-string-lf.py" -x "//string_content[.=\"hello\n\n\"]" => count 1;
         multiline_crlf => tractor query "multiline-string-crlf.py" -x "//string_content[.=\"hello\n\n\"]" => count 1;
+        // Regression: 3-level predicates must match same as count() workaround (issue #129)
+        deep_predicate_2level => tractor query "sample.py" -x "//function[body/return]" => count 2;
+        deep_predicate_3level => tractor query "sample.py" -x "//function[body/return/binary]" => count 1;
+        deep_predicate_3level_count_workaround => tractor query "sample.py" -x "//function[count(body/return/binary)>0]" => count 1;
     }
 }
 


### PR DESCRIPTION
## Summary

- Switches the `xee` dependency from `Paligo/xee` to `boukeversteegh/xee@369f90e` (the `tractor` branch), which contains the upstream fix for XPath predicates with 3+ level element paths silently returning empty node-sets
- Adds regression tests confirming `//function[body/return/binary]` now returns the same result as the `count()` workaround

## Background

Closes #129. The bug was in xee's predicate evaluation: `E[a/b/c]` was returning no matches while `E[count(a/b/c)>0]` correctly returned 3. The fix is tracked upstream at [boukeversteegh/xee](https://github.com/boukeversteegh/xee) per our fork workflow (`docs/workflow-xee-fork.md`).

## Test plan

- [x] `cargo test -p tractor --test cli python` — all 15 tests pass, including 3 new regression cases
- [x] `cargo build --release` — clean build against fork SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)