### PR TITLE
Add user-defined variables to the XPath query context ($variables, $rule.variables, $rule.id)

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,192 @@
+---
+name: reviewer
+description: Continuous architectural reviewer. Use to review a branch or PR after implementation, or to watch work in progress while another agent implements it. Verifies committed work for correctness, in-flight work for architectural soundness, and records findings in a shared review document the implementing agent reads. Never edits source, commits, or manages the PR.
+tools: Read, Grep, Glob, Bash, Write, Edit, Skill, Monitor, TaskStop, WebFetch
+---
+
+# Reviewer
+
+You review someone else's work — usually another agent's, sometimes a human's — while they
+are still writing it. Your output is **findings**, never changes.
+
+**Load the `architecture` skill at the start of every review.** Its questions are the lens:
+invariants first, one owner per concern, normalize once, remove bypasses, is this defect
+local or class-level. Findings that do not come from that lens are usually noise.
+
+---
+
+## The one rule that shapes everything else
+
+**Committed work may be judged for correctness. Uncommitted work may only be judged for
+architectural soundness.**
+
+Work in progress is not wrong yet — it is unfinished. A half-written refactor that does not
+compile is not a defect, and reporting it as one wastes everyone's attention and teaches the
+implementer to ignore you.
+
+| State | What you may say |
+|---|---|
+| Committed | Anything: correctness, behaviour, tests, docs, architecture. Verify by running it. |
+| Uncommitted / in flight | Shape only: ownership, duplication, where policy lives, whether the invariant holds. **Never** "this is broken", "tests fail", "this does not compile". |
+
+Before claiming *any* correctness defect, confirm the code is committed (`git status`). If a
+build or test failure appears in a dirty tree, that is in-flight work — say nothing about it,
+or note it as "cannot verify while the tree is dirty".
+
+The valuable in-flight finding sounds like: *"the new type derives `Default`, which asserts a
+fact about an expression it never saw — that invariant will be maintained by convention at
+every construction site."* Said before the work is committed, it costs a rename. Said after,
+it costs a regression.
+
+---
+
+## Role boundary — findings only
+
+You do **not**:
+
+- edit source files in the repository,
+- commit, amend, stage, push, or rebase,
+- create, edit, or merge pull requests — body, title, labels, or state,
+- run formatters or apply fixes "while you are in there".
+
+The implementer owns the branch and the PR. When a fix is wanted — even when the user asks
+you directly for one — write it into the review document as an item and say the user asked
+for it. A request for a change is a request for the *item*, not for you to perform it.
+
+The single exception is the review document itself, which is yours to write.
+
+---
+
+## Verification happens in a worktree
+
+Any build, test run, repro, or experimental edit goes in a **separate detached git worktree**,
+never in the tree being written in:
+
+```bash
+git -C <repo> worktree add --detach <scratchpad>/wt-review <sha>
+cd <scratchpad>/wt-review && <build/test>
+git -C <scratchpad>/wt-review checkout --detach <new-sha>   # to re-verify a later commit
+```
+
+Two reasons, both learned the hard way:
+
+1. Reading the shared tree means reading half-finished edits as though they were committed
+   work — the exact mistake the rule above exists to prevent.
+2. Building in the shared `target/` contends with the implementer's builds.
+
+Give the worktree its own target directory (the default when you `cd` into it). The first
+build is cold and slow; every later one is incremental. If you need to *edit* code to test a
+hypothesis — a one-line patch to confirm a diagnosis — do it in the worktree, and say in your
+finding that you confirmed it that way.
+
+Tear the worktree down when the review ends: `git worktree remove <path>`.
+
+---
+
+## The shared review document
+
+One markdown file the implementer reads and you own. Default location
+`.agents/review-<branch-or-topic>.md` — untracked, and say so at the top: **do not commit
+this file.**
+
+Structure it as a **nested checklist**, so which items are addressed is obvious at a glance
+and the history of what an item turned into stays in one place.
+
+```markdown
+### - [x] 2. Short statement of the structural problem
+
+Why it is a problem, where it lives, and why it is foundation rather than local.
+
+**Done looks like:** the concrete end state.
+
+**Resolved** in `<sha>`. What you verified, and how.
+
+- [ ] **2a. A follow-up the fix surfaced.**
+  Nested under the item it came from — never appended to the bottom of the list.
+```
+
+Status legend to put in the file:
+
+- `- [ ]` open
+- `- [x]` verified fixed **by you** — the implementer never ticks their own box
+- `- [!]` you disagree with a claimed fix, or the fix introduced something new
+
+Include a **How to respond** section telling the implementer:
+
+- commits are the channel; reference the item number in the commit message,
+- do not tick boxes, do not delete items,
+- to disagree, add a child bullet with the exact marker `- **DISAGREE (dev):**` and their
+  reasoning; you reply in place with `- **REVIEWER:**` — conceded or stands, with reasons,
+- if an item's premise is factually wrong, say so plainly.
+
+### What belongs on the list
+
+Only **structural** items — where the current shape is a foundation later work inherits.
+Exclude:
+
+- purely local defects with no bearing on future work,
+- shapes that fit awkwardly with a hypothetical future feature but would be *obviously* wrong
+  the moment that feature arrives. That is not debt; it is a decision deferred to when it can
+  be made well.
+
+Put the small stuff in an **appendix** marked *observations, not action items — no response
+needed*, so the information is not lost without inflating the list. A short list gets read.
+
+---
+
+## Continuous watching
+
+Do not wait to be asked for each round. Arm a monitor and react as things land:
+
+```bash
+last=$(git rev-parse HEAD)
+while true; do
+  cur=$(git rev-parse HEAD)
+  if [ "$cur" != "$last" ]; then git log --oneline "$last..$cur" | sed 's/^/NEW COMMIT: /'; last=$cur; fi
+  # in-flight signal: which files are dirty right now
+  git status --porcelain | md5sum
+  # disagreement signal
+  grep -c 'DISAGREE (dev)' <review-file>
+  sleep 45
+done
+```
+
+Emit a line only when something *changed* — a monitor that reports every tick trains the
+reader to ignore it. Watch three things: new commits (verify, tick, nest follow-ups), the
+dirty-file set (in-flight architectural read), and new `DISAGREE (dev)` markers.
+
+On a new commit:
+
+1. Move the worktree to that sha and build/test there.
+2. **Verify the claim, not the commit message.** A commit saying "fixes X" is a hypothesis.
+   Reproduce the original failure and confirm it is gone; run the suite; check the behaviour
+   the item was actually about.
+3. Tick the box with *what you verified*, not "looks good".
+4. Nest anything the fix surfaced underneath the original item.
+
+On dirty files: read them for shape. If you see an invariant being established badly, say so
+now, while it is a rename rather than a migration. Frame it as in-flight: "while this is still
+being written —".
+
+---
+
+## Judgement
+
+**Verify before you assert.** Reproduce with a real command and real output. A finding you
+have not reproduced is a hypothesis, and should be labelled one.
+
+**You will be wrong sometimes.** When the implementer shows your premise was false, concede
+plainly in the document, in one paragraph, and move on. Do not defend a finding because you
+wrote it. Correcting yourself in writing is what makes the rest of your findings trustworthy.
+
+**Disagreements are outcomes, not failures.** Some items are decisions, not defects — say so
+in the item. When the implementer disagrees with reasoning, weigh it honestly: a maintainer's
+product decision is not yours to reverse, and "there was no contract here in the first place"
+is a legitimate refutation. **Always report a disagreement to the user**, whichever way it
+resolved.
+
+**Separate the halves of a compound item.** Often the design half is wrong and the
+compatibility half is right, or vice versa. Concede one, hold the other.
+
+**Do not pad.** If a round produces nothing structural, say that. An empty round is a real
+result and it buys credibility for the round that is not empty.

--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -1,0 +1,395 @@
+---
+name: architecture
+author: boukeversteegh
+description: Use when implementing a feature that needs changes in underlying layers, when reviewing code, when refactoring or migrating, or when discussing a technical design.
+---
+# Architecture Skill
+
+_Portable methodology — no project-specific paths or conventions inside._
+
+## When to use
+
+Reach for this skill when:
+
+- you're implementing a feature whose foundation isn't shaped for it — the underlying layer needs to change before the feature can land cleanly,
+- you're refactoring or migrating structure,
+- you're reviewing code (always — the questions here are the right lens for any review),
+- the user wants to discuss or design a technical solution.
+
+It guides the agent to extract invariants first, assign clear ownership boundaries, refactor structure before layering on patches when needed, normalize inputs once, remove bypasses and duplication, implement in stable incremental slices, and validate behavior with semantic tests before broad snapshots and doc updates. It is especially useful when there is risk of local fixes causing architectural drift, concern leakage, inconsistent behavior across entry points or output forms, or an end result with more factors rather than fewer.
+
+---
+
+## Purpose
+
+This workflow is for complex tasks that involve feature work, refactoring, architectural changes, migration behavior, or broad plumbing across a codebase.
+
+Its goal is not just to make the task "work." Its goal is to leave the codebase simpler, more coherent, and easier to extend than before.
+
+---
+
+## Core Principles
+
+1. Design invariants first, not implementation details.
+2. Normalize inputs once, close to the boundary.
+3. Keep concepts owned by one layer.
+4. Refactor structure before adding behavior when the old structure is fighting the new model.
+5. Delete duplication instead of wrapping it in more layers.
+6. Prefer one principled path over many special cases.
+7. Test semantics directly; use snapshots only as broad regression coverage.
+8. Commit when a stable invariant becomes true.
+
+---
+
+## Default Mindset
+
+Treat the task as a system-design problem first and an editing problem second.
+
+Before changing code, answer these questions:
+
+- What concepts are being introduced or changed?
+- What must become true everywhere when the task is complete?
+- Which existing shortcuts, bypasses, or exceptions conflict with that model?
+- Which layer should own each concern?
+- What behavior is part of the public contract?
+- What edge cases could force a redesign if ignored too long?
+
+Do not begin by patching the first visible symptom.
+
+---
+
+## Before Treating a Bug as Local
+
+Before fixing a bug, ask: is this an instance of a class?
+
+If the component you're fixing is one of several with the same role (caches, retries, validators, serializers, rate limiters, auth checks, deserialization paths), the defect is likely shared. The locality is often an illusion — you noticed it here because this is where it surfaced, not because this is where it lives.
+
+Do this:
+
+- name the role the component plays,
+- locate the siblings that play the same role,
+- check whether each one has the same defect,
+- decide whether to fix the class or document why this instance is genuinely special.
+
+A one-spot fix to a class-level bug guarantees you will fix it again, differently, in each sibling — and the inconsistencies between those fixes become their own architectural problem.
+
+The same prompt applies when adding behavior: if the new behavior is the kind of thing every sibling should also have (e.g. single-flight load coalescing on a cache, timeout on an outbound call, idempotency on a write), deciding now is cheaper than retrofitting later.
+
+---
+
+## Phase 1: Extract the Invariants
+
+Read the task, design notes, failing tests, and surrounding code until you can write a short list of global truths.
+
+Examples of good invariants:
+
+- "User inputs, defaults, and implicit behavior are normalized in one place."
+- "All externally visible behavior flows through one primary execution path."
+- "The internal model represents the concept directly instead of encoding it through scattered special cases."
+- "Boundary-specific requirements are handled at the boundary layer, not mixed into domain logic."
+- "Warnings, validation, and error behavior are determined from the normalized plan, not re-inferred later."
+- "The same feature behaves consistently across modes, entry points, and output forms."
+
+A good invariant is:
+
+- global, not local,
+- stable across entry points and modes,
+- strong enough to simplify future decisions.
+
+If you cannot state the invariants clearly, you are not ready to implement.
+
+---
+
+## Phase 2: Map Ownership Boundaries
+
+For each important concern, decide where it belongs.
+
+Common concerns to assign:
+
+- input parsing,
+- normalization and default resolution,
+- domain model construction,
+- validation,
+- execution orchestration,
+- rendering or serialization,
+- boundary adapters,
+- side effects,
+- migration behavior,
+- warnings and diagnostics.
+
+Use this rule:
+
+A concern should have one obvious owner.
+
+Warning signs that ownership is broken:
+
+- the same concept is interpreted in multiple layers,
+- entry-point code is shaping domain behavior,
+- boundary layers are compensating for model inconsistencies,
+- mode-specific code reimplements shared behavior,
+- one feature behaves differently for accidental rather than intentional reasons.
+
+If ownership is unclear, fix structure before adding more logic.
+
+---
+
+## Phase 3: Decide Whether to Refactor First
+
+Refactor first when one or more of these are true:
+
+- the feature would require special cases in several files,
+- existing shortcuts bypass the main pipeline,
+- the same transformation already exists in multiple places,
+- adding the feature on top would increase coupling,
+- the current model cannot express the intended design cleanly,
+- edge cases would be awkward or inconsistent under the current structure.
+
+Do not preserve bad structure just because it already exists.
+
+If the old structure fights the new concept, the refactor is part of the feature.
+
+---
+
+## Phase 4: Plan the Work as Invariant-Bearing Slices
+
+Break the task into slices where each slice establishes a stable improvement.
+
+Good slice types:
+
+- add the new model, type, enum, or state representation,
+- introduce normalized planning or execution context,
+- unify duplicate paths,
+- move special cases into the main pipeline,
+- update boundary layers to consume the unified model,
+- remove obsolete code,
+- add targeted tests for tricky contracts,
+- regenerate broad regression artifacts,
+- update docs and migration notes.
+
+Avoid slices that are only "some edits in many places." Each slice should have a purpose that can be described in one sentence.
+
+---
+
+## Phase 5: Implement from Structure Toward Behavior
+
+Preferred order:
+
+1. Introduce or reshape the model.
+2. Add normalization or planning.
+3. Route code through one path.
+4. Remove old bypasses and duplicate shaping.
+5. Add behavior on the unified path.
+6. Tighten edge cases and warnings.
+7. Expand test coverage.
+8. Update docs and broad regressions.
+
+This order reduces rework because later decisions are made on a cleaner foundation.
+
+Do not implement surface behavior first if the infrastructure underneath is known to be wrong.
+
+---
+
+## Phase 6: Handle Input Normalization Carefully
+
+Complex systems often fail at boundaries.
+
+When flags, modes, config, defaults, and implicit behavior interact, create one normalization step that produces an internal plan.
+
+That plan should answer questions such as:
+
+- what mode is actually active,
+- what feature variant is selected,
+- which defaults remain in effect,
+- which user inputs are ignored, replaced, or contradictory,
+- which warnings must be emitted,
+- which limits or implied values apply.
+
+Rules for normalization:
+
+- do it once,
+- make it explicit,
+- make contradictions fail early,
+- keep warnings consistent with actual behavior,
+- avoid recomputing policy later in the pipeline.
+
+If multiple downstream layers must "figure out what the user meant," the normalization is incomplete.
+
+---
+
+## Phase 7: Remove Bypasses Early
+
+Bypasses are often the source of long-term inconsistency.
+
+Examples:
+
+- early returns that skip the main pipeline,
+- entry-point-specific shaping,
+- boundary-specific special paths,
+- direct printing or emission of special values,
+- one-off optimizations that change semantics.
+
+When possible:
+
+- route the special case into the common model,
+- let the normal pipeline produce the result,
+- keep special behavior only where it is truly intrinsic.
+
+A feature becomes easier to reason about when fewer things are "handled specially."
+
+---
+
+## Phase 8: Prefer Direct Semantic Tests
+
+Add small focused tests for behavior that defines the contract.
+
+Examples of semantic contracts:
+
+- shape of output,
+- singular vs sequence behavior,
+- error and warning conditions,
+- empty-result behavior,
+- exit codes,
+- stderr vs stdout routing,
+- interactions between explicit and implicit settings,
+- mode-specific behavior,
+- migration behavior.
+
+Use broad snapshots or regression artifacts after the semantics are nailed down.
+
+Snapshots are useful for regression coverage, but they are weak at explaining why behavior is correct.
+
+If a bug would be hard to understand from a broad diff alone, write a direct test.
+
+---
+
+## Phase 9: Update Documentation Last, but Not as an Afterthought
+
+Only mark documentation, checklists, or validation items complete when they are:
+
+- covered by tests,
+- directly verified by execution,
+- or mechanically implied by already-verified behavior.
+
+Treat docs as design intent, not infallible truth.
+
+If you find contradictions:
+
+- resolve them against the intended conceptual model,
+- preserve the architectural principle,
+- and adjust the doc explicitly rather than silently drifting from it.
+
+Documentation should reflect the final ownership model and behavior contracts, not the implementation history.
+
+---
+
+## Communication Pattern During Work
+
+When working in steps, communicate like this:
+
+1. State the current objective.
+2. State what you are checking or changing next.
+3. Surface any architectural decision that constrains future work.
+4. Mention when a previous assumption turned out to be wrong.
+5. Distinguish clearly between verified behavior and planned work.
+
+Do not narrate every file edit.
+Do not claim completion until behavior, tests, and docs agree.
+
+---
+
+## Commit Strategy
+
+Commit when a stable invariant becomes true.
+
+Good commit examples:
+
+- "Introduce unified planning for feature selection"
+- "Route behavior through a single execution path"
+- "Remove bypass path for special-case output"
+- "Add contract tests for edge-case behavior"
+- "Regenerate regressions and update docs"
+
+Bad commit examples:
+
+- "WIP"
+- "Fix stuff"
+- "More changes"
+- "Try again"
+
+Each commit should make the codebase easier to understand, even if the feature is not fully complete yet.
+
+---
+
+## Heuristics for Good Structural Decisions
+
+Choose the refactor when it reduces future branching.
+Choose the common path when special handling would duplicate policy.
+Choose explicit internal models over implicit combinations of inputs.
+Choose deletion over compatibility layers when the old layer is redundant.
+Choose orthogonality over convenience when two concerns are starting to leak into each other.
+
+Ask repeatedly:
+
+- What is the owner of this concept?
+- Is this logic duplicated?
+- Is this policy being inferred too late?
+- Am I preserving a shortcut that should disappear?
+- If someone adds a related feature later, will this design help or hurt them?
+
+---
+
+## Common Failure Modes to Avoid
+
+1. Local patching without a global model.
+2. Adding wrappers around duplicated logic instead of removing duplication.
+3. Letting entry-point code, model code, and boundary code all participate in policy decisions.
+4. Preserving legacy shortcuts that conflict with composability.
+5. Writing only snapshot tests and missing behavioral contracts.
+6. Treating design docs as line-by-line law even when they contradict the actual model.
+7. Making every edge case a special case instead of improving the abstraction.
+8. Delaying refactors until after feature logic has already spread everywhere.
+9. Mixing normalization, validation, and rendering decisions across layers.
+10. Counting files changed instead of measuring conceptual simplification.
+11. Fixing a class-level defect in only the instance where it surfaced, leaving the same bug latent in sibling components.
+
+---
+
+## Quality Bar for Completion
+
+A complex task is done when all of these are true:
+
+- the feature works,
+- the main invariants are visible in the structure,
+- old bypasses or duplicate paths are removed or intentionally isolated,
+- edge cases are tested,
+- warnings and errors match the actual semantics,
+- docs match the implemented model,
+- the final design has fewer moving parts than the likely patch-based alternative.
+
+The standard is not "it passes."
+The standard is "the next related change will now be easier."
+
+---
+
+## Short Operating Checklist
+
+Use this before and during implementation:
+
+- Ask whether the bug or feature is class-level before treating it as local; locate sibling components that play the same role.
+- Identify the global invariants.
+- Identify the owner of each concern.
+- Decide whether the current structure can support the feature cleanly.
+- Refactor first if the structure would otherwise force exceptions.
+- Normalize inputs once into an internal plan.
+- Route behavior through one principled path.
+- Remove bypasses and duplicate shaping.
+- Add semantic tests for tricky contracts.
+- Regenerate broad regressions.
+- Update docs only where verified.
+- Commit when an invariant becomes true.
+
+---
+
+## One-Sentence Summary
+
+Do not build the feature by teaching every layer a new exception; build it by making one clean model true and routing the system through it.

--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -214,6 +214,23 @@ Rules for normalization:
 
 If multiple downstream layers must "figure out what the user meant," the normalization is incomplete.
 
+### Who guarantees the value is normalized?
+
+"Normalize once" says *where* normalization happens. It does not say what a function should do when its own correctness depends on having received a normalized value. That is a separate question, and answering it with "the caller will have done it" is how the invariant dies.
+
+If a function is only correct for normalized input, it owns that requirement. Two ways to discharge it, in order of preference:
+
+1. **Encode it in the type.** Accept the type that can only be constructed by normalizing, not the raw one. The compiler then proves what a comment could only assert, and "normalize once" still holds — the single normalizer is the only way to make the value.
+2. **Normalize on entry.** When no such type exists, normalize at the top of the function. Idempotent normalization is cheap, and it converts a caller obligation into a local guarantee.
+
+What not to do is rely on a convention. A function that takes the raw type and is correct only because every current caller happens to normalize first is one new caller away from a silent wrong answer — and that caller will look correct in review, because nothing at the call site says otherwise.
+
+The tell is a value that **some** callers normalize and others do not, flowing into one function. When that function misbehaves, the defect is in the function, not in whichever caller happened to surface it. Fixing the caller leaves the trap armed for the next one.
+
+This is not only about paths. It applies to any precondition a function depends on but does not enforce: sorted input, canonical case, absolute rather than relative, deduplicated sets, UTC rather than local time, validated identifiers, resolved rather than lazy values.
+
+A useful question when reviewing a signature: *if someone passed the un-normalized form tomorrow, would this be loudly wrong or quietly wrong?* Quietly wrong means the guarantee belongs inside.
+
 ---
 
 ## Phase 7: Remove Bypasses Early
@@ -334,6 +351,7 @@ Ask repeatedly:
 - Is this logic duplicated?
 - Is this policy being inferred too late?
 - Am I preserving a shortcut that should disappear?
+- Does this depend on a precondition it does not enforce?
 - If someone adds a related feature later, will this design help or hurt them?
 
 ---
@@ -351,6 +369,7 @@ Ask repeatedly:
 9. Mixing normalization, validation, and rendering decisions across layers.
 10. Counting files changed instead of measuring conceptual simplification.
 11. Fixing a class-level defect in only the instance where it surfaced, leaving the same bug latent in sibling components.
+12. Depending on a precondition the function does not enforce, so correctness rests on every caller remembering to establish it.
 
 ---
 
@@ -381,6 +400,7 @@ Use this before and during implementation:
 - Decide whether the current structure can support the feature cleanly.
 - Refactor first if the structure would otherwise force exceptions.
 - Normalize inputs once into an internal plan.
+- Make each function own the preconditions its correctness depends on — by type where possible.
 - Route behavior through one principled path.
 - Remove bypasses and duplicate shaping.
 - Add semantic tests for tricky contracts.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -159,35 +159,38 @@ tasks:
   setup:sccache:
     desc: Install sccache for faster Rust builds (compilation cache)
     internal: true
+    vars:
+      TMP_DIR: '{{.ROOT_DIR}}/target/tmp-sccache'
     status:
       - command -v sccache
     cmds:
       - |
         echo "Installing sccache..."
         VERSION="v0.14.0"
+        TMP_DIR="{{.TMP_DIR}}"
+        TAR="$(command -v tar)"
+        mkdir -p "$TMP_DIR"
         case "$(uname -s)" in
           MINGW*|MSYS*|CYGWIN*|*_NT*)
             ARCHIVE="sccache-${VERSION}-x86_64-pc-windows-msvc"
-            curl -fsSL "https://github.com/mozilla/sccache/releases/download/${VERSION}/${ARCHIVE}.tar.gz" -o /tmp/sccache.tar.gz
-            tar -xzf /tmp/sccache.tar.gz -C /tmp/
-            cp "/tmp/${ARCHIVE}/sccache.exe" "$HOME/.cargo/bin/"
-            rm -rf /tmp/sccache.tar.gz "/tmp/${ARCHIVE}"
+            curl -fsSL "https://github.com/mozilla/sccache/releases/download/${VERSION}/${ARCHIVE}.tar.gz" -o "$TMP_DIR/sccache.tar.gz"
+            (cd "$TMP_DIR" && "$TAR" -xzf sccache.tar.gz)
+            cp "$TMP_DIR/${ARCHIVE}/sccache.exe" "$HOME/.cargo/bin/"
             ;;
           Linux*)
             ARCHIVE="sccache-${VERSION}-x86_64-unknown-linux-musl"
-            curl -fsSL "https://github.com/mozilla/sccache/releases/download/${VERSION}/${ARCHIVE}.tar.gz" -o /tmp/sccache.tar.gz
-            tar -xzf /tmp/sccache.tar.gz -C /tmp/
-            cp "/tmp/${ARCHIVE}/sccache" "$HOME/.cargo/bin/"
-            rm -rf /tmp/sccache.tar.gz "/tmp/${ARCHIVE}"
+            curl -fsSL "https://github.com/mozilla/sccache/releases/download/${VERSION}/${ARCHIVE}.tar.gz" -o "$TMP_DIR/sccache.tar.gz"
+            (cd "$TMP_DIR" && "$TAR" -xzf sccache.tar.gz)
+            cp "$TMP_DIR/${ARCHIVE}/sccache" "$HOME/.cargo/bin/"
             ;;
           Darwin*)
             ARCHIVE="sccache-${VERSION}-aarch64-apple-darwin"
-            curl -fsSL "https://github.com/mozilla/sccache/releases/download/${VERSION}/${ARCHIVE}.tar.gz" -o /tmp/sccache.tar.gz
-            tar -xzf /tmp/sccache.tar.gz -C /tmp/
-            cp "/tmp/${ARCHIVE}/sccache" "$HOME/.cargo/bin/"
-            rm -rf /tmp/sccache.tar.gz "/tmp/${ARCHIVE}"
+            curl -fsSL "https://github.com/mozilla/sccache/releases/download/${VERSION}/${ARCHIVE}.tar.gz" -o "$TMP_DIR/sccache.tar.gz"
+            (cd "$TMP_DIR" && "$TAR" -xzf sccache.tar.gz)
+            cp "$TMP_DIR/${ARCHIVE}/sccache" "$HOME/.cargo/bin/"
             ;;
         esac
+        rm -rf "$TMP_DIR"
         echo "sccache installed: $(sccache --version)"
 
   setup:

--- a/tractor/src/cli/check.rs
+++ b/tractor/src/cli/check.rs
@@ -60,7 +60,6 @@ pub struct CheckArgs {
     #[arg(short = 'f', long = "format", default_value = "gcc", help_heading = "Format")]
     pub format: String,
 }
-use crate::executor;
 use crate::cli::context::RunContext;
 use crate::input::{plan_single, InputMode, Operation, SingleOpRequest};
 use crate::tractor_config::{CheckOperation, OperationInputs};
@@ -149,7 +148,7 @@ pub fn run_check(args: CheckArgs) -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     if let Some(plan) = plan {
-        executor::execute_rendering_partial_report(&[plan], &env, &mut builder, &ctx)?;
+        crate::cli::ops::execute_and_report_failures(&[plan], &env, &mut builder, &ctx)?;
     }
     let mut report = builder.build();
 

--- a/tractor/src/cli/check.rs
+++ b/tractor/src/cli/check.rs
@@ -149,7 +149,7 @@ pub fn run_check(args: CheckArgs) -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     if let Some(plan) = plan {
-        executor::execute(&[plan], &env, &mut builder)?;
+        executor::execute_rendering_partial_report(&[plan], &env, &mut builder, &ctx)?;
     }
     let mut report = builder.build();
 

--- a/tractor/src/cli/config.rs
+++ b/tractor/src/cli/config.rs
@@ -112,6 +112,10 @@ pub fn run_from_config(params: ConfigRunParams) -> Result<(), Box<dyn std::error
         params.view_override, params.message, None, false, params.default_group,
     )?;
 
+    // Config-declared variables become part of the run's environmental
+    // state, bound into every query's dynamic context via `ctx.exec_ctx()`.
+    ctx.variables = std::sync::Arc::new(loaded.variables);
+
     // The config-run `base_dir` is the directory of the config file,
     // absolutized. Planted on `RunContext` so the executor and resolver
     // both observe the same value via `ctx.exec_ctx()` — single source of

--- a/tractor/src/cli/config.rs
+++ b/tractor/src/cli/config.rs
@@ -162,7 +162,7 @@ pub fn run_from_config(params: ConfigRunParams) -> Result<(), Box<dyn std::error
             &mut builder,
         )?;
 
-        executor::execute(&plan.operations, &env, &mut builder)?;
+        executor::execute_rendering_partial_report(&plan.operations, &env, &mut builder, &ctx)?;
     }
 
     let mut report = builder.build();

--- a/tractor/src/cli/config.rs
+++ b/tractor/src/cli/config.rs
@@ -10,7 +10,6 @@
 use tractor::report::{ReportMatch, Severity};
 
 use crate::cli::SharedArgs;
-use crate::executor;
 use crate::cli::context::RunContext;
 use crate::format::{ViewField, GroupDimension, render_report};
 use crate::input::{plan_multi, resolve_input, InputMode, MultiOpRequest};
@@ -162,7 +161,7 @@ pub fn run_from_config(params: ConfigRunParams) -> Result<(), Box<dyn std::error
             &mut builder,
         )?;
 
-        executor::execute_rendering_partial_report(&plan.operations, &env, &mut builder, &ctx)?;
+        crate::cli::ops::execute_and_report_failures(&plan.operations, &env, &mut builder, &ctx)?;
     }
 
     let mut report = builder.build();

--- a/tractor/src/cli/context.rs
+++ b/tractor/src/cli/context.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use crate::cli::SharedArgs;
 use crate::format::options::HookType;
@@ -7,7 +8,7 @@ use crate::format::{
     Projection, ViewField, ViewSet,
 };
 use crate::input::{resolve_input, InputMode};
-use tractor::{output::should_use_color, output::RenderOptions, NormalizedXpath, TreeMode};
+use tractor::{output::should_use_color, output::RenderOptions, NormalizedXpath, QueryVariables, TreeMode};
 
 pub struct RunContext {
     pub xpath: Option<NormalizedXpath>,
@@ -35,6 +36,11 @@ pub struct RunContext {
     /// Base directory for resolving relative paths (config root). Set once
     /// per invocation — None for single-op CLI runs, Some for `run --config`.
     pub base_dir: Option<PathBuf>,
+    /// User-defined variables bound into every XPath query of the run.
+    /// Populated from the config file's `variables:` key; empty for
+    /// single-op CLI runs. Shared via `Arc` so rayon workers can attach it
+    /// to each parse result cheaply.
+    pub variables: Arc<QueryVariables>,
     pub lang: Option<String>,
     pub debug: bool,
     pub group_by: Vec<GroupDimension>,
@@ -52,6 +58,17 @@ pub struct RunContext {
 pub struct ExecCtx<'a> {
     pub verbose: bool,
     pub base_dir: Option<&'a Path>,
+    /// User-defined variables for this run. `None` (e.g. in `ExecCtx::default()`)
+    /// is equivalent to an empty set.
+    pub variables: Option<&'a Arc<QueryVariables>>,
+}
+
+impl ExecCtx<'_> {
+    /// The run's user-defined variables as a shareable handle
+    /// (empty when none were configured).
+    pub fn query_variables(&self) -> Arc<QueryVariables> {
+        self.variables.cloned().unwrap_or_default()
+    }
 }
 
 impl RunContext {
@@ -149,6 +166,7 @@ impl RunContext {
             ignore_whitespace: shared.ignore_whitespace,
             verbose: shared.verbose,
             base_dir: None,
+            variables: Arc::default(),
             lang: shared.lang.clone(),
             debug,
             group_by,
@@ -161,6 +179,7 @@ impl RunContext {
         ExecCtx {
             verbose: self.verbose,
             base_dir: self.base_dir.as_deref(),
+            variables: Some(&self.variables),
         }
     }
 

--- a/tractor/src/cli/mod.rs
+++ b/tractor/src/cli/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod help;
 pub mod context;
+pub mod ops;
 pub mod query;
 pub mod check;
 pub mod test;

--- a/tractor/src/cli/ops.rs
+++ b/tractor/src/cli/ops.rs
@@ -1,0 +1,77 @@
+//! Running a command's operations and reporting the outcome.
+//!
+//! Every command follows the same sequence: execute the planned operations,
+//! build the report, project it for output, render it. This module owns the
+//! part that must not differ between commands — what happens when an
+//! operation fails partway through.
+//!
+//! The executor deliberately knows nothing about presentation: it takes an
+//! [`ExecCtx`] (environment only) and pushes into a `ReportBuilder`. Deciding
+//! *how* a run is reported is the CLI's job, so the failure path lives here
+//! rather than wrapping the executor.
+
+use tractor::report::{ReportBuilder, ReportMatch, Severity, DiagnosticOrigin};
+
+use crate::cli::context::{ExecCtx, RunContext};
+use crate::executor::{self, OperationPlan};
+use crate::format::render_report;
+use crate::matcher::prepare_report_for_output;
+
+/// Execute operations, reporting a mid-run failure as part of the run's own
+/// report instead of discarding it.
+///
+/// On success the caller renders as usual — nothing here has run yet.
+///
+/// On failure the diagnostics accumulated so far are exactly what explains
+/// the failure (an advisory warning that a variable lookup was empty, say),
+/// and dropping them leaves the user with a bare error. So the failure is
+/// folded in as a fatal diagnostic and the whole thing is rendered once,
+/// through the same formatter the successful path uses. The returned
+/// `SilentExit` tells `main` the run has already reported itself, which is
+/// what keeps a machine-readable format to a **single** document: previously
+/// a partial report and `main`'s separate error report were both printed,
+/// producing two concatenated JSON objects and a `"success": true` summary
+/// next to a non-zero exit.
+pub fn execute_and_report_failures(
+    operations: &[OperationPlan],
+    env: &ExecCtx<'_>,
+    builder: &mut ReportBuilder,
+    ctx: &RunContext,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Err(error) = executor::execute(operations, env, builder) else {
+        return Ok(());
+    };
+
+    builder.add(fatal_diagnostic(error.to_string()));
+    let mut report = std::mem::replace(builder, ReportBuilder::new()).build();
+    prepare_report_for_output(&mut report, ctx);
+
+    // Rendering a failed report already yields SilentExit; the explicit
+    // error covers formats that don't (and a render error must not mask the
+    // failure being reported).
+    render_report(&report, ctx, None)?;
+    Err(Box::new(crate::SilentExit))
+}
+
+/// The run-ending error, as a report entry.
+fn fatal_diagnostic(reason: String) -> ReportMatch {
+    ReportMatch {
+        file: String::new(),
+        line: 0,
+        column: 0,
+        end_line: 0,
+        end_column: 0,
+        command: String::new(),
+        tree: None,
+        value: None,
+        source: None,
+        lines: None,
+        reason: Some(reason),
+        severity: Some(Severity::Fatal),
+        message: None,
+        origin: Some(DiagnosticOrigin::Cli),
+        rule_id: None,
+        status: None,
+        output: None,
+    }
+}

--- a/tractor/src/cli/query.rs
+++ b/tractor/src/cli/query.rs
@@ -104,7 +104,7 @@ pub fn run_query(args: QueryArgs) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let op = Operation::Query(QueryOperation {
-        queries: vec![QueryExpr { xpath: xpath_expr.clone(), variables: Default::default() }],
+        queries: vec![QueryExpr::new(xpath_expr.clone(), tractor::QueryVariables::new())],
         tree_mode: ctx.tree_mode,
         language: op_language,
         limit: ctx.limit,

--- a/tractor/src/cli/query.rs
+++ b/tractor/src/cli/query.rs
@@ -125,7 +125,7 @@ pub fn run_query(args: QueryArgs) -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     if let Some(plan) = plan {
-        executor::execute(&[plan], &env, &mut builder)?;
+        executor::execute_rendering_partial_report(&[plan], &env, &mut builder, &ctx)?;
     }
     let mut report = builder.build();
     prepare_report_for_output(&mut report, &ctx);

--- a/tractor/src/cli/query.rs
+++ b/tractor/src/cli/query.rs
@@ -104,7 +104,7 @@ pub fn run_query(args: QueryArgs) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let op = Operation::Query(QueryOperation {
-        queries: vec![QueryExpr { xpath: xpath_expr.clone() }],
+        queries: vec![QueryExpr { xpath: xpath_expr.clone(), variables: Default::default() }],
         tree_mode: ctx.tree_mode,
         language: op_language,
         limit: ctx.limit,

--- a/tractor/src/cli/query.rs
+++ b/tractor/src/cli/query.rs
@@ -110,6 +110,7 @@ pub fn run_query(args: QueryArgs) -> Result<(), Box<dyn std::error::Error>> {
         limit: ctx.limit,
         ignore_whitespace: ctx.ignore_whitespace,
         parse_depth: ctx.parse_depth,
+        output: None,
     });
 
     let mut builder = tractor::ReportBuilder::new();

--- a/tractor/src/cli/query.rs
+++ b/tractor/src/cli/query.rs
@@ -40,7 +40,7 @@ pub struct QueryArgs {
     #[arg(short = 'V', long = "version", help_heading = "Advanced")]
     pub version: bool,
 }
-use crate::executor::{self, QueryExpr, QueryOperation};
+use crate::executor::{QueryExpr, QueryOperation};
 use crate::cli::context::RunContext;
 use crate::input::{plan_single, InputMode, Operation, SingleOpRequest};
 use crate::tractor_config::OperationInputs;
@@ -126,7 +126,7 @@ pub fn run_query(args: QueryArgs) -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     if let Some(plan) = plan {
-        executor::execute_rendering_partial_report(&[plan], &env, &mut builder, &ctx)?;
+        crate::cli::ops::execute_and_report_failures(&[plan], &env, &mut builder, &ctx)?;
     }
     let mut report = builder.build();
     prepare_report_for_output(&mut report, &ctx);

--- a/tractor/src/cli/set.rs
+++ b/tractor/src/cli/set.rs
@@ -213,7 +213,7 @@ pub fn run_set(args: SetArgs) -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     if let Some(plan) = plan {
-        executor::execute(&[plan], &env, &mut builder)?;
+        executor::execute_rendering_partial_report(&[plan], &env, &mut builder, &ctx)?;
     }
     let mut report = builder.build();
 

--- a/tractor/src/cli/set.rs
+++ b/tractor/src/cli/set.rs
@@ -41,7 +41,7 @@ pub struct SetArgs {
     pub format: String,
 }
 use crate::executor::{
-    self, SetMapping, SetOperation, SetReportMode, SetWriteMode,
+    SetMapping, SetOperation, SetReportMode, SetWriteMode,
 };
 use crate::cli::context::RunContext;
 use crate::input::{plan_single, InputMode, Operation, SingleOpRequest};
@@ -213,7 +213,7 @@ pub fn run_set(args: SetArgs) -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     if let Some(plan) = plan {
-        executor::execute_rendering_partial_report(&[plan], &env, &mut builder, &ctx)?;
+        crate::cli::ops::execute_and_report_failures(&[plan], &env, &mut builder, &ctx)?;
     }
     let mut report = builder.build();
 

--- a/tractor/src/cli/set.rs
+++ b/tractor/src/cli/set.rs
@@ -89,30 +89,30 @@ fn normalize_set_mappings(
     if let Some(xpath) = xpath {
         let value = explicit_value
             .ok_or("set with -x requires --value")?;
-        return Ok(vec![SetMapping {
-            xpath: xpath.to_string(),
-            value: value.to_string(),
-            value_kind: Some("string".to_string()),
-            variables: Default::default(),
-        }]);
+        return Ok(vec![SetMapping::new(
+            xpath.to_string(),
+            value,
+            Some("string".to_string()),
+            tractor::QueryVariables::new(),
+        )]);
     }
 
     let expr = expr.ok_or("set requires either an XPath query (-x) or a path expression")?;
     if let Some(value) = explicit_value {
-        return Ok(vec![SetMapping {
-            xpath: selector_xpath(expr),
-            value: value.to_string(),
-            value_kind: Some("string".to_string()),
-            variables: Default::default(),
-        }]);
+        return Ok(vec![SetMapping::new(
+            selector_xpath(expr),
+            value,
+            Some("string".to_string()),
+            tractor::QueryVariables::new(),
+        )]);
     }
 
-    Ok(parse_set_expr(expr)?.into_iter().map(|op| SetMapping {
-        xpath: op.xpath,
-        value: op.value.text().to_string(),
-        value_kind: Some(op.value.kind().to_string()),
-        variables: Default::default(),
-    }).collect())
+    Ok(parse_set_expr(expr)?.into_iter().map(|op| SetMapping::new(
+        op.xpath,
+        op.value.text(),
+        Some(op.value.kind().to_string()),
+        tractor::QueryVariables::new(),
+    )).collect())
 }
 
 pub fn run_set(args: SetArgs) -> Result<(), Box<dyn std::error::Error>> {

--- a/tractor/src/cli/set.rs
+++ b/tractor/src/cli/set.rs
@@ -93,6 +93,7 @@ fn normalize_set_mappings(
             xpath: xpath.to_string(),
             value: value.to_string(),
             value_kind: Some("string".to_string()),
+            variables: Default::default(),
         }]);
     }
 
@@ -102,6 +103,7 @@ fn normalize_set_mappings(
             xpath: selector_xpath(expr),
             value: value.to_string(),
             value_kind: Some("string".to_string()),
+            variables: Default::default(),
         }]);
     }
 
@@ -109,6 +111,7 @@ fn normalize_set_mappings(
         xpath: op.xpath,
         value: op.value.text().to_string(),
         value_kind: Some(op.value.kind().to_string()),
+        variables: Default::default(),
     }).collect())
 }
 

--- a/tractor/src/cli/test.rs
+++ b/tractor/src/cli/test.rs
@@ -40,7 +40,7 @@ pub struct TestArgs {
     #[arg(short = 'f', long = "format", default_value = "text", help_heading = "Format")]
     pub format: String,
 }
-use crate::executor::{self, TestAssertion, TestOperation};
+use crate::executor::{TestAssertion, TestOperation};
 use crate::cli::context::RunContext;
 use crate::input::{plan_single, InputMode, Operation, SingleOpRequest};
 use crate::tractor_config::OperationInputs;
@@ -124,7 +124,7 @@ pub fn run_test(args: TestArgs) -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     if let Some(plan) = plan {
-        executor::execute_rendering_partial_report(&[plan], &env, &mut builder, &ctx)?;
+        crate::cli::ops::execute_and_report_failures(&[plan], &env, &mut builder, &ctx)?;
     }
     // Set expected value for test summary rendering (test-mode only, not shared with run mode)
     builder.set_expected(expect.clone());

--- a/tractor/src/cli/test.rs
+++ b/tractor/src/cli/test.rs
@@ -103,6 +103,7 @@ pub fn run_test(args: TestArgs) -> Result<(), Box<dyn std::error::Error>> {
         assertions: vec![TestAssertion {
             xpath: xpath_expr.clone(),
             expect: expect.clone(),
+            variables: Default::default(),
         }],
         tree_mode: ctx.tree_mode,
         language: op_language,

--- a/tractor/src/cli/test.rs
+++ b/tractor/src/cli/test.rs
@@ -100,11 +100,11 @@ pub fn run_test(args: TestArgs) -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let op = Operation::Test(TestOperation {
-        assertions: vec![TestAssertion {
-            xpath: xpath_expr.clone(),
-            expect: expect.clone(),
-            variables: Default::default(),
-        }],
+        assertions: vec![TestAssertion::new(
+            xpath_expr.clone(),
+            expect.clone(),
+            tractor::QueryVariables::new(),
+        )],
         tree_mode: ctx.tree_mode,
         language: op_language,
         limit: ctx.limit,

--- a/tractor/src/cli/test.rs
+++ b/tractor/src/cli/test.rs
@@ -124,7 +124,7 @@ pub fn run_test(args: TestArgs) -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     if let Some(plan) = plan {
-        executor::execute(&[plan], &env, &mut builder)?;
+        executor::execute_rendering_partial_report(&[plan], &env, &mut builder, &ctx)?;
     }
     // Set expected value for test summary rendering (test-mode only, not shared with run mode)
     builder.set_expected(expect.clone());

--- a/tractor/src/cli/update.rs
+++ b/tractor/src/cli/update.rs
@@ -15,7 +15,7 @@ pub struct UpdateArgs {
     #[command(flatten)]
     pub shared: SharedArgs,
 }
-use crate::executor::{self, UpdateOperation};
+use crate::executor::{UpdateOperation};
 use crate::cli::context::RunContext;
 use crate::input::{plan_single, InputMode, Operation, SingleOpRequest};
 use crate::tractor_config::OperationInputs;
@@ -68,7 +68,7 @@ pub fn run_update(args: UpdateArgs) -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     if let Some(plan) = plan {
-        executor::execute_rendering_partial_report(&[plan], &env, &mut builder, &ctx)?;
+        crate::cli::ops::execute_and_report_failures(&[plan], &env, &mut builder, &ctx)?;
     }
     let report = builder.build();
     if report.success == Some(false) {

--- a/tractor/src/cli/update.rs
+++ b/tractor/src/cli/update.rs
@@ -68,7 +68,7 @@ pub fn run_update(args: UpdateArgs) -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     if let Some(plan) = plan {
-        executor::execute(&[plan], &env, &mut builder)?;
+        executor::execute_rendering_partial_report(&[plan], &env, &mut builder, &ctx)?;
     }
     let report = builder.build();
     if report.success == Some(false) {

--- a/tractor/src/executor/check.rs
+++ b/tractor/src/executor/check.rs
@@ -175,7 +175,7 @@ fn validate_rule_examples(
             )?;
             result.bindings.variables = std::sync::Arc::clone(variables);
             result.bindings.entry = Some(tractor::EntryContext::rule(
-                std::sync::Arc::clone(&rule.variables),
+                std::sync::Arc::clone(rule.variables.declared()),
                 rule.id.clone(),
             ));
             let matches = result.query(rule.xpath.as_str())?;
@@ -206,7 +206,7 @@ fn validate_rule_examples(
             )?;
             result.bindings.variables = std::sync::Arc::clone(variables);
             result.bindings.entry = Some(tractor::EntryContext::rule(
-                std::sync::Arc::clone(&rule.variables),
+                std::sync::Arc::clone(rule.variables.declared()),
                 rule.id.clone(),
             ));
             let matches = result.query(rule.xpath.as_str())?;

--- a/tractor/src/executor/check.rs
+++ b/tractor/src/executor/check.rs
@@ -61,6 +61,10 @@ pub(crate) fn execute_check(
         return Ok(());
     }
 
+    // Run-level variables (bound as $variables); each rule's own set is
+    // bound as $rule.variables by run_rules / example validation.
+    let variables = ctx.query_variables();
+
     // --- Phase 0: Validate XPath expressions upfront ---
     let diagnostics: Vec<_> = op.compiled_rules.iter()
         .filter_map(|rule| validate_xpath_diagnostic(&rule.xpath, "check"))
@@ -70,8 +74,21 @@ pub(crate) fn execute_check(
         return Ok(());
     }
 
+    // Advisory: warn about `$variables?key` lookups on undefined keys.
+    // Warnings never fail the run — a missing key legally yields the empty
+    // sequence and may be intentional (optional flags, external variable
+    // files) — but a typo'd key silently disables a rule, so surface it.
+    for rule in &op.compiled_rules {
+        report.add_all(crate::matcher::undefined_variable_key_diagnostics(
+            &rule.id,
+            &rule.xpath,
+            &variables,
+            &rule.variables,
+        ));
+    }
+
     // --- Phase 1: Validate rule examples inline ---
-    validate_rule_examples(&op.compiled_rules, op.tree_mode, report)?;
+    validate_rule_examples(&op.compiled_rules, op.tree_mode, &variables, report)?;
 
     if op.sources.is_empty() {
         return Ok(());
@@ -85,6 +102,7 @@ pub(crate) fn execute_check(
         op.parse_depth,
         ctx.verbose,
         &op.filters,
+        &variables,
     )?;
 
     for rm in rule_matches {
@@ -123,6 +141,7 @@ pub(crate) fn execute_check(
 fn validate_rule_examples(
     rules: &[CompiledRule],
     default_tree_mode: Option<TreeMode>,
+    variables: &std::sync::Arc<tractor::QueryVariables>,
     report: &mut ReportBuilder,
 ) -> Result<(), Box<dyn std::error::Error>> {
     for rule in rules {
@@ -152,6 +171,9 @@ fn validate_rule_examples(
                     parse_depth: None,
                 },
             )?;
+            result.variables = std::sync::Arc::clone(variables);
+            result.rule_variables = std::sync::Arc::clone(&rule.variables);
+            result.rule_id = Some(rule.id.clone());
             let matches = result.query(rule.xpath.as_str())?;
             if !super::check_expectation("none", matches.len())? {
                 report.add(example_failure_match(
@@ -178,6 +200,9 @@ fn validate_rule_examples(
                     parse_depth: None,
                 },
             )?;
+            result.variables = std::sync::Arc::clone(variables);
+            result.rule_variables = std::sync::Arc::clone(&rule.variables);
+            result.rule_id = Some(rule.id.clone());
             let matches = result.query(rule.xpath.as_str())?;
             if !super::check_expectation("some", matches.len())? {
                 report.add(example_failure_match(
@@ -243,7 +268,7 @@ mod tests {
             None,
         )];
         let mut builder = ReportBuilder::new();
-        validate_rule_examples(&rules, None, &mut builder).unwrap();
+        validate_rule_examples(&rules, None, &std::sync::Arc::default(), &mut builder).unwrap();
         let report = builder.build();
         assert!(report.all_matches().is_empty(), "expected no failures: {:?}", report.all_matches());
     }
@@ -257,7 +282,7 @@ mod tests {
             None,
         )];
         let mut builder = ReportBuilder::new();
-        validate_rule_examples(&rules, None, &mut builder).unwrap();
+        validate_rule_examples(&rules, None, &std::sync::Arc::default(), &mut builder).unwrap();
         let report = builder.build();
         let matches = report.all_matches();
         assert_eq!(matches.len(), 1);
@@ -273,7 +298,7 @@ mod tests {
             None,
         )];
         let mut builder = ReportBuilder::new();
-        validate_rule_examples(&rules, None, &mut builder).unwrap();
+        validate_rule_examples(&rules, None, &std::sync::Arc::default(), &mut builder).unwrap();
         let report = builder.build();
         let matches = report.all_matches();
         assert_eq!(matches.len(), 1);
@@ -288,7 +313,7 @@ mod tests {
             Some("rust"),
         )];
         let mut builder = ReportBuilder::new();
-        validate_rule_examples(&rules, None, &mut builder).unwrap();
+        validate_rule_examples(&rules, None, &std::sync::Arc::default(), &mut builder).unwrap();
         let report = builder.build();
         assert!(report.all_matches().is_empty());
     }
@@ -301,7 +326,7 @@ mod tests {
             None,
         )];
         let mut builder = ReportBuilder::new();
-        let err = validate_rule_examples(&rules, None, &mut builder).unwrap_err();
+        let err = validate_rule_examples(&rules, None, &std::sync::Arc::default(), &mut builder).unwrap_err();
         assert!(err.to_string().contains("no language specified"));
     }
 
@@ -309,7 +334,7 @@ mod tests {
     fn test_validate_examples_no_examples_is_noop() {
         let rules = vec![compile(Rule::new("simple", "//function"), None)];
         let mut builder = ReportBuilder::new();
-        validate_rule_examples(&rules, None, &mut builder).unwrap();
+        validate_rule_examples(&rules, None, &std::sync::Arc::default(), &mut builder).unwrap();
         let report = builder.build();
         assert!(report.all_matches().is_empty());
     }

--- a/tractor/src/executor/check.rs
+++ b/tractor/src/executor/check.rs
@@ -173,8 +173,8 @@ fn validate_rule_examples(
                     parse_depth: None,
                 },
             )?;
-            result.variables = std::sync::Arc::clone(variables);
-            result.entry = Some(tractor::EntryContext::rule(
+            result.bindings.variables = std::sync::Arc::clone(variables);
+            result.bindings.entry = Some(tractor::EntryContext::rule(
                 std::sync::Arc::clone(&rule.variables),
                 rule.id.clone(),
             ));
@@ -204,8 +204,8 @@ fn validate_rule_examples(
                     parse_depth: None,
                 },
             )?;
-            result.variables = std::sync::Arc::clone(variables);
-            result.entry = Some(tractor::EntryContext::rule(
+            result.bindings.variables = std::sync::Arc::clone(variables);
+            result.bindings.entry = Some(tractor::EntryContext::rule(
                 std::sync::Arc::clone(&rule.variables),
                 rule.id.clone(),
             ));

--- a/tractor/src/executor/check.rs
+++ b/tractor/src/executor/check.rs
@@ -78,14 +78,14 @@ pub(crate) fn execute_check(
     // Warnings never fail the run — a missing key legally yields the empty
     // sequence and may be intentional (optional flags, external variable
     // files) — but a typo'd key silently disables a rule, so surface it.
-    for rule in &op.compiled_rules {
-        report.add_all(crate::matcher::undefined_variable_key_diagnostics(
-            "check",
-            &rule.id,
-            rule.xpath.as_str(),
-            &variables,
-            Some(tractor::EntryKind::Rule),
-            &rule.variables,
+    for (i, rule) in op.compiled_rules.iter().enumerate() {
+        let bindings = tractor::QueryBindings::run(std::sync::Arc::clone(&variables))
+            .with_entry(tractor::EntryContext::rule(
+                std::sync::Arc::clone(rule.variables.declared()),
+                rule.id.clone(),
+            ));
+        report.add_all(crate::matcher::variable_diagnostics(
+            "check", &bindings, i, rule.xpath.as_str(),
         ));
     }
 
@@ -104,7 +104,7 @@ pub(crate) fn execute_check(
         op.parse_depth,
         ctx.verbose,
         &op.filters,
-        &variables,
+        &tractor::QueryBindings::run(std::sync::Arc::clone(&variables)),
     )?;
 
     for rm in rule_matches {

--- a/tractor/src/executor/check.rs
+++ b/tractor/src/executor/check.rs
@@ -80,9 +80,11 @@ pub(crate) fn execute_check(
     // files) — but a typo'd key silently disables a rule, so surface it.
     for rule in &op.compiled_rules {
         report.add_all(crate::matcher::undefined_variable_key_diagnostics(
+            "check",
             &rule.id,
-            &rule.xpath,
+            rule.xpath.as_str(),
             &variables,
+            Some(tractor::EntryKind::Rule),
             &rule.variables,
         ));
     }
@@ -172,8 +174,10 @@ fn validate_rule_examples(
                 },
             )?;
             result.variables = std::sync::Arc::clone(variables);
-            result.rule_variables = std::sync::Arc::clone(&rule.variables);
-            result.rule_id = Some(rule.id.clone());
+            result.entry = Some(tractor::EntryContext::rule(
+                std::sync::Arc::clone(&rule.variables),
+                rule.id.clone(),
+            ));
             let matches = result.query(rule.xpath.as_str())?;
             if !super::check_expectation("none", matches.len())? {
                 report.add(example_failure_match(
@@ -201,8 +205,10 @@ fn validate_rule_examples(
                 },
             )?;
             result.variables = std::sync::Arc::clone(variables);
-            result.rule_variables = std::sync::Arc::clone(&rule.variables);
-            result.rule_id = Some(rule.id.clone());
+            result.entry = Some(tractor::EntryContext::rule(
+                std::sync::Arc::clone(&rule.variables),
+                rule.id.clone(),
+            ));
             let matches = result.query(rule.xpath.as_str())?;
             if !super::check_expectation("some", matches.len())? {
                 report.add(example_failure_match(

--- a/tractor/src/executor/mod.rs
+++ b/tractor/src/executor/mod.rs
@@ -131,10 +131,12 @@ pub(crate) fn match_to_report_match(m: Match, command: &str) -> ReportMatch {
 /// dispatches on content kind so the caller doesn't branch.
 ///
 /// `variables` are the run's user-defined variables, bound into each query's
-/// dynamic context alongside the built-in `$file`.
+/// dynamic context alongside the built-in `$file`. Each query carries its
+/// own optional entry context (e.g. a query entry's `variables:` bound as
+/// `$query.variables`), applied per expression.
 pub(crate) fn query_files_multi(
     sources: &[Source],
-    xpaths: &[&str],
+    queries: &[(&str, Option<tractor::EntryContext>)],
     lang: Option<&str>,
     tree_mode: Option<TreeMode>,
     ignore_whitespace: bool,
@@ -160,7 +162,8 @@ pub(crate) fn query_files_multi(
             result.variables = std::sync::Arc::clone(variables);
 
             let mut file_matches = Vec::new();
-            for xpath_expr in xpaths {
+            for (xpath_expr, entry) in queries {
+                result.entry = entry.clone();
                 match result.query(xpath_expr) {
                     Ok(matches) => file_matches.extend(matches),
                     Err(e) => {
@@ -540,6 +543,7 @@ mod tests {
                     xpath: "//host".into(),
                     value: "new-host".into(),
                     value_kind: Some("string".into()),
+                    variables: Default::default(),
                 }],
                 tree_mode: None,
                 limit: None,

--- a/tractor/src/executor/mod.rs
+++ b/tractor/src/executor/mod.rs
@@ -293,11 +293,11 @@ pub(crate) fn query_files_multi(
                     return None;
                 }
             };
-            result.variables = std::sync::Arc::clone(variables);
+            result.bindings.variables = std::sync::Arc::clone(variables);
 
             let mut file_matches = Vec::new();
             for (xpath_expr, entry) in queries {
-                result.entry = entry.clone();
+                result.bindings.entry = entry.clone();
                 match result.query(xpath_expr) {
                     Ok(matches) => file_matches.extend(matches),
                     Err(e) => {

--- a/tractor/src/executor/mod.rs
+++ b/tractor/src/executor/mod.rs
@@ -238,13 +238,13 @@ pub(crate) fn match_to_report_match(m: Match, command: &str) -> ReportMatch {
 /// Virtual and disk sources flow through the same loop — `source.parse()`
 /// dispatches on content kind so the caller doesn't branch.
 ///
-/// `variables` are the run's user-defined variables, bound into each query's
-/// dynamic context alongside the built-in `$file`. Each query carries its
-/// own optional entry context (e.g. a query entry's `variables:` bound as
-/// `$query.variables`), applied per expression.
+/// Each query carries the [`QueryBindings`](tractor::QueryBindings) it runs
+/// with — the run-level `$variables` plus its own entry context — so the
+/// bindings that were diagnosed are the bindings that execute.
+#[allow(clippy::too_many_arguments)] // parse options, not bindings
 pub(crate) fn query_files_multi(
     sources: &[Source],
-    queries: &[(&str, Option<tractor::EntryContext>)],
+    queries: &[(&str, tractor::QueryBindings)],
     lang: Option<&str>,
     tree_mode: Option<TreeMode>,
     ignore_whitespace: bool,
@@ -252,7 +252,6 @@ pub(crate) fn query_files_multi(
     limit: Option<usize>,
     verbose: bool,
     filters: &Filters,
-    variables: &std::sync::Arc<tractor::QueryVariables>,
 ) -> Result<Vec<Match>, Box<dyn std::error::Error>> {
     let mut all_matches: Vec<Match> = sources
         .par_iter()
@@ -267,11 +266,9 @@ pub(crate) fn query_files_multi(
                     return None;
                 }
             };
-            result.bindings.variables = std::sync::Arc::clone(variables);
-
             let mut file_matches = Vec::new();
-            for (xpath_expr, entry) in queries {
-                result.bindings.entry = entry.clone();
+            for (xpath_expr, bindings) in queries {
+                result.bindings = bindings.clone();
                 match result.query(xpath_expr) {
                     Ok(matches) => file_matches.extend(matches),
                     Err(e) => {

--- a/tractor/src/executor/mod.rs
+++ b/tractor/src/executor/mod.rs
@@ -95,10 +95,7 @@ pub fn execute(
         // at config load and travels on each entry's `EntryVariables` — the
         // executor only reads those records, it does not re-derive policy.
         // The run-level map serves every entry, so its reads are the union.
-        let run_reads = entry_variables(op)
-            .fold(tractor::variables::NamespaceReads::default(), |acc, v| {
-                acc.union(v.reads().run())
-            });
+        let run_reads = run_variable_reads(op);
         let run_vars = tractor::variables::bind_run_variables(
             &ctx.query_variables(),
             &run_reads,
@@ -121,6 +118,22 @@ pub fn execute(
     }
 
     Ok(())
+}
+
+/// What an operation reads from the run-level `$variables` — the union over
+/// everything in it that can read, since one map serves them all.
+///
+/// Every shape that runs an expression must contribute, or its reads are
+/// silently empty and the keys it looks up get omitted. Operations built
+/// from entries contribute those; `update` has none and carries its own
+/// record instead.
+fn run_variable_reads(op: &OperationPlan) -> tractor::NamespaceReads {
+    let from_entries = entry_variables(op)
+        .fold(tractor::NamespaceReads::default(), |acc, v| acc.union(v.reads().run()));
+    match op {
+        OperationPlan::Update(u) => from_entries.union(&u.reads),
+        _ => from_entries,
+    }
 }
 
 /// Every entry-level `EntryVariables` in an operation, in declaration order.

--- a/tractor/src/executor/mod.rs
+++ b/tractor/src/executor/mod.rs
@@ -90,6 +90,29 @@ pub fn execute(
     Ok(())
 }
 
+/// Execute like [`execute`], but when an operation fails, first render the
+/// diagnostics accumulated so far — advisory variable warnings, earlier
+/// operations' matches — before propagating the error. Without this, the
+/// report that often *explains* the failure (e.g. a warning that a set
+/// mapping's variable lookup is an empty map) is silently dropped on the
+/// error path.
+///
+/// Rendering is best-effort: a render failure never masks the original error.
+pub fn execute_rendering_partial_report(
+    operations: &[OperationPlan],
+    ctx: &ExecCtx<'_>,
+    report: &mut ReportBuilder,
+    run_ctx: &crate::cli::context::RunContext,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = execute(operations, ctx, report);
+    if result.is_err() {
+        let mut partial = std::mem::replace(report, ReportBuilder::new()).build();
+        crate::matcher::prepare_report_for_output(&mut partial, run_ctx);
+        let _ = crate::format::render_report(&partial, run_ctx, None);
+    }
+    result
+}
+
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------

--- a/tractor/src/executor/mod.rs
+++ b/tractor/src/executor/mod.rs
@@ -32,7 +32,7 @@ use crate::cli::context::ExecCtx;
 use crate::input::filter::Filters;
 use crate::input::Source;
 
-pub use query::{QueryOperation, QueryOperationPlan, QueryExpr};
+pub use query::{QueryOperation, QueryOperationPlan, QueryExpr, QueryOutput, QueryOutputField};
 pub use check::CheckOperationPlan;
 pub use test::{TestOperation, TestOperationPlan, TestAssertion};
 pub use set::{SetOperation, SetOperationPlan, SetMapping, SetWriteMode, SetReportMode};
@@ -72,22 +72,133 @@ pub const DEFAULT_MAX_FILES: usize = 10_000;
 /// is a thin dispatcher. The `ExecCtx` carries the environmental state
 /// (verbose, base_dir) that originates in `RunContext` — the single source
 /// of truth per CLI invocation.
+///
+/// Operations run strictly in order, and `$`-directive variable sources
+/// (`$file`) are resolved at each operation's start — so a file written by
+/// an earlier operation (e.g. a query op's `output:`) is read fresh by the
+/// next one. Each operation sees one consistent snapshot; the ordered
+/// `operations:` list is the dependency mechanism.
 pub fn execute(
     operations: &[OperationPlan],
     ctx: &ExecCtx<'_>,
     report: &mut ReportBuilder,
 ) -> Result<(), Box<dyn std::error::Error>> {
     for op in operations {
-        match op {
-            OperationPlan::Query(q) => query::execute_query(q, ctx, report)?,
-            OperationPlan::Check(c) => check::execute_check(c, ctx, report)?,
-            OperationPlan::Test(t) => test::execute_test(t, ctx, report)?,
-            OperationPlan::Set(s) => set::execute_set(s, ctx, report)?,
-            OperationPlan::Update(u) => update::execute_update(u, ctx, report)?,
+        let base_dir = ctx.base_dir.unwrap_or_else(|| std::path::Path::new("."));
+
+        // Fresh run-level snapshot for this op ($variables) — but only when
+        // the op actually references it. A producer op (e.g. a query with
+        // `output:`) must not fail resolving a $file source that IT is
+        // about to create; only consumers pay for (and depend on) their
+        // sources. `$variables` cannot be referenced dynamically in XPath,
+        // so the literal check is sound; `$rule.variables` etc. don't
+        // contain the substring (the `$` precedes `rule`).
+        let raw = ctx.query_variables();
+        let run_vars = if raw.has_sources() && op_references(op, "$variables") {
+            std::sync::Arc::new((*raw).clone().resolve_sources(base_dir)?)
+        } else {
+            raw
+        };
+        let op_ctx = ExecCtx { variables: Some(&run_vars), ..*ctx };
+
+        // Fresh entry-level snapshots ($rule.variables etc.); borrows the
+        // plan untouched when no entry declares a source.
+        let op = resolve_entry_variables(op, base_dir)?;
+
+        match op.as_ref() {
+            OperationPlan::Query(q) => query::execute_query(q, &op_ctx, report)?,
+            OperationPlan::Check(c) => check::execute_check(c, &op_ctx, report)?,
+            OperationPlan::Test(t) => test::execute_test(t, &op_ctx, report)?,
+            OperationPlan::Set(s) => set::execute_set(s, &op_ctx, report)?,
+            OperationPlan::Update(u) => update::execute_update(u, &op_ctx, report)?,
         }
     }
 
     Ok(())
+}
+
+/// Resolve `$`-directive sources in an operation's entry-level variables
+/// (rule / mapping / query / assertion `variables:`). Returns the plan
+/// unchanged (borrowed) when nothing declares a source — the common case.
+fn resolve_entry_variables<'a>(
+    op: &'a OperationPlan,
+    base_dir: &std::path::Path,
+) -> Result<std::borrow::Cow<'a, OperationPlan>, tractor::variables::VariableSourceError> {
+    use std::borrow::Cow;
+
+    fn resolve_arc(
+        variables: &mut std::sync::Arc<tractor::QueryVariables>,
+        base_dir: &std::path::Path,
+    ) -> Result<(), tractor::variables::VariableSourceError> {
+        if variables.has_sources() {
+            *variables = std::sync::Arc::new((**variables).clone().resolve_sources(base_dir)?);
+        }
+        Ok(())
+    }
+
+    // Same referenced-only rule as for run-level variables: an entry's
+    // sources resolve only when the op's xpaths mention its namespace.
+    let (declares, namespace) = match op {
+        OperationPlan::Check(c) => (
+            c.compiled_rules.iter().any(|r| r.variables.has_sources()),
+            "$rule.variables",
+        ),
+        OperationPlan::Set(s) => (
+            s.mappings.iter().any(|m| m.variables.has_sources()),
+            "$mapping.variables",
+        ),
+        OperationPlan::Query(q) => (
+            q.queries.iter().any(|q| q.variables.has_sources()),
+            "$query.variables",
+        ),
+        OperationPlan::Test(t) => (
+            t.assertions.iter().any(|a| a.variables.has_sources()),
+            "$assertion.variables",
+        ),
+        OperationPlan::Update(_) => (false, ""),
+    };
+    if !declares || !op_references(op, namespace) {
+        return Ok(Cow::Borrowed(op));
+    }
+
+    let mut op = op.clone();
+    match &mut op {
+        OperationPlan::Check(c) => {
+            for rule in &mut c.compiled_rules {
+                resolve_arc(&mut rule.variables, base_dir)?;
+            }
+        }
+        OperationPlan::Set(s) => {
+            for mapping in &mut s.mappings {
+                resolve_arc(&mut mapping.variables, base_dir)?;
+            }
+        }
+        OperationPlan::Query(q) => {
+            for query in &mut q.queries {
+                resolve_arc(&mut query.variables, base_dir)?;
+            }
+        }
+        OperationPlan::Test(t) => {
+            for assertion in &mut t.assertions {
+                resolve_arc(&mut assertion.variables, base_dir)?;
+            }
+        }
+        OperationPlan::Update(_) => {}
+    }
+    Ok(Cow::Owned(op))
+}
+
+/// Whether any of the operation's xpath expressions contains `needle`
+/// literally. XPath has no dynamic variable references, so a literal scan
+/// is a sound usage test for a variable namespace.
+fn op_references(op: &OperationPlan, needle: &str) -> bool {
+    match op {
+        OperationPlan::Check(c) => c.compiled_rules.iter().any(|r| r.xpath.as_str().contains(needle)),
+        OperationPlan::Set(s) => s.mappings.iter().any(|m| m.xpath.contains(needle)),
+        OperationPlan::Query(q) => q.queries.iter().any(|q| q.xpath.as_str().contains(needle)),
+        OperationPlan::Test(t) => t.assertions.iter().any(|a| a.xpath.as_str().contains(needle)),
+        OperationPlan::Update(u) => u.xpath.contains(needle),
+    }
 }
 
 /// Execute like [`execute`], but when an operation fails, first render the

--- a/tractor/src/executor/mod.rs
+++ b/tractor/src/executor/mod.rs
@@ -86,23 +86,19 @@ pub fn execute(
     for op in operations {
         let base_dir = ctx.base_dir.unwrap_or_else(|| std::path::Path::new("."));
 
-        // Fresh run-level snapshot for this op ($variables) — but only when
-        // the op actually references it. A producer op (e.g. a query with
-        // `output:`) must not fail resolving a $file source that IT is
-        // about to create; only consumers pay for (and depend on) their
-        // sources. `$variables` cannot be referenced dynamically in XPath,
-        // so the literal check is sound; `$rule.variables` etc. don't
-        // contain the substring (the `$` precedes `rule`).
-        let raw = ctx.query_variables();
-        let run_vars = if raw.has_sources() && op_references(op, "$variables") {
-            std::sync::Arc::new((*raw).clone().resolve_sources(base_dir)?)
-        } else {
-            raw
-        };
+        // Fresh snapshots for this operation. What gets resolved was decided
+        // at config load and travels on each entry's `EntryVariables` — the
+        // executor only reads those flags, it does not re-derive policy.
+        let run_vars = tractor::variables::bind_run_variables(
+            &ctx.query_variables(),
+            entries_read_run_variables(op),
+            base_dir,
+        )?;
         let op_ctx = ExecCtx { variables: Some(&run_vars), ..*ctx };
 
-        // Fresh entry-level snapshots ($rule.variables etc.); borrows the
-        // plan untouched when no entry declares a source.
+        // Entry namespaces resolve per entry: one rule reading its own
+        // variables must not force resolution for a sibling that doesn't.
+        // Borrows the plan untouched when no entry declares a source.
         let op = resolve_entry_variables(op, base_dir)?;
 
         match op.as_ref() {
@@ -117,88 +113,80 @@ pub fn execute(
     Ok(())
 }
 
+/// Every entry-level `EntryVariables` in an operation, in declaration order.
+fn entry_variables(op: &OperationPlan) -> Box<dyn Iterator<Item = &tractor::EntryVariables> + '_> {
+    match op {
+        OperationPlan::Check(c) => Box::new(c.compiled_rules.iter().map(|r| &r.variables)),
+        OperationPlan::Set(s) => Box::new(s.mappings.iter().map(|m| &m.variables)),
+        OperationPlan::Query(q) => Box::new(q.queries.iter().map(|q| &q.variables)),
+        OperationPlan::Test(t) => Box::new(t.assertions.iter().map(|a| &a.variables)),
+        OperationPlan::Update(_) => Box::new(std::iter::empty()),
+    }
+}
+
+/// Whether any of the operation's expressions reads the run-level
+/// `$variables`. Reads the flag each entry recorded at config load rather
+/// than re-scanning XPath strings.
+///
+/// `update` has no entries, so its own xpath is consulted directly.
+fn entries_read_run_variables(op: &OperationPlan) -> bool {
+    match op {
+        OperationPlan::Update(u) => tractor::variables::reads_run_variables(&u.xpath),
+        _ => entry_variables(op).any(|v| v.reads_run_variables()),
+    }
+}
+
 /// Resolve `$`-directive sources in an operation's entry-level variables
-/// (rule / mapping / query / assertion `variables:`). Returns the plan
-/// unchanged (borrowed) when nothing declares a source — the common case.
+/// (rule / mapping / query / assertion `variables:`), **per entry**: an
+/// entry that never reads its own namespace neither resolves its sources
+/// (so a file a later operation will write cannot fail this one) nor binds
+/// them raw. Returns the plan unchanged (borrowed) when no entry declares
+/// a source — the common case.
 fn resolve_entry_variables<'a>(
     op: &'a OperationPlan,
     base_dir: &std::path::Path,
 ) -> Result<std::borrow::Cow<'a, OperationPlan>, tractor::variables::VariableSourceError> {
     use std::borrow::Cow;
 
-    fn resolve_arc(
-        variables: &mut std::sync::Arc<tractor::QueryVariables>,
-        base_dir: &std::path::Path,
-    ) -> Result<(), tractor::variables::VariableSourceError> {
-        if variables.has_sources() {
-            *variables = std::sync::Arc::new((**variables).clone().resolve_sources(base_dir)?);
-        }
-        Ok(())
+    if !entry_variables(op).any(|v| v.has_sources()) {
+        return Ok(Cow::Borrowed(op));
     }
 
-    // Same referenced-only rule as for run-level variables: an entry's
-    // sources resolve only when the op's xpaths mention its namespace.
-    let (declares, namespace) = match op {
-        OperationPlan::Check(c) => (
-            c.compiled_rules.iter().any(|r| r.variables.has_sources()),
-            "$rule.variables",
-        ),
-        OperationPlan::Set(s) => (
-            s.mappings.iter().any(|m| m.variables.has_sources()),
-            "$mapping.variables",
-        ),
-        OperationPlan::Query(q) => (
-            q.queries.iter().any(|q| q.variables.has_sources()),
-            "$query.variables",
-        ),
-        OperationPlan::Test(t) => (
-            t.assertions.iter().any(|a| a.variables.has_sources()),
-            "$assertion.variables",
-        ),
-        OperationPlan::Update(_) => (false, ""),
-    };
-    if !declares || !op_references(op, namespace) {
-        return Ok(Cow::Borrowed(op));
+    /// Replace an entry's declared variables with what should be bound.
+    fn bind(
+        variables: &mut tractor::EntryVariables,
+        base_dir: &std::path::Path,
+    ) -> Result<(), tractor::variables::VariableSourceError> {
+        let bound = variables.bind(base_dir)?;
+        *variables = variables.clone().with_bound(bound);
+        Ok(())
     }
 
     let mut op = op.clone();
     match &mut op {
         OperationPlan::Check(c) => {
             for rule in &mut c.compiled_rules {
-                resolve_arc(&mut rule.variables, base_dir)?;
+                bind(&mut rule.variables, base_dir)?;
             }
         }
         OperationPlan::Set(s) => {
             for mapping in &mut s.mappings {
-                resolve_arc(&mut mapping.variables, base_dir)?;
+                bind(&mut mapping.variables, base_dir)?;
             }
         }
         OperationPlan::Query(q) => {
             for query in &mut q.queries {
-                resolve_arc(&mut query.variables, base_dir)?;
+                bind(&mut query.variables, base_dir)?;
             }
         }
         OperationPlan::Test(t) => {
             for assertion in &mut t.assertions {
-                resolve_arc(&mut assertion.variables, base_dir)?;
+                bind(&mut assertion.variables, base_dir)?;
             }
         }
         OperationPlan::Update(_) => {}
     }
     Ok(Cow::Owned(op))
-}
-
-/// Whether any of the operation's xpath expressions contains `needle`
-/// literally. XPath has no dynamic variable references, so a literal scan
-/// is a sound usage test for a variable namespace.
-fn op_references(op: &OperationPlan, needle: &str) -> bool {
-    match op {
-        OperationPlan::Check(c) => c.compiled_rules.iter().any(|r| r.xpath.as_str().contains(needle)),
-        OperationPlan::Set(s) => s.mappings.iter().any(|m| m.xpath.contains(needle)),
-        OperationPlan::Query(q) => q.queries.iter().any(|q| q.xpath.as_str().contains(needle)),
-        OperationPlan::Test(t) => t.assertions.iter().any(|a| a.xpath.as_str().contains(needle)),
-        OperationPlan::Update(u) => u.xpath.contains(needle),
-    }
 }
 
 /// Execute like [`execute`], but when an operation fails, first render the
@@ -529,6 +517,56 @@ mod tests {
         assert!(report.success.unwrap(), "rule should not fire when env = 'dev'");
     }
 
+    /// Resolution is per entry, not per operation: a rule that declares a
+    /// source it never reads must not resolve it — otherwise a sibling
+    /// rule's use of `$rule.variables` would drag it in and fail the run on
+    /// a file a later operation has yet to write.
+    #[test]
+    fn unread_rule_sources_do_not_resolve_when_a_sibling_reads_its_own() {
+        use tractor::variables::{QueryVariables, VariableValue};
+
+        let (_dir, path) = temp_json_file(r#"{"debug": true}"#);
+        let mut reader_vars = QueryVariables::new();
+        reader_vars.insert("flag", VariableValue::String("debug".into()));
+        // The sibling declares a `$file` source pointing at a file that does
+        // not exist — resolving it would be a hard error.
+        let declaring_vars: QueryVariables =
+            serde_yaml::from_str("data:\n  $file: written-by-a-later-op.json\n").unwrap();
+
+        let mut plan = CheckOperationPlan {
+            sources: disk_sources(&[&path]),
+            filters: Filters::default(),
+            compiled_rules: compile(
+                vec![
+                    // Reads its own namespace → its sources resolve.
+                    Rule::new("reader", "//*[local-name() = $rule.variables?flag]"),
+                    // Declares a source but never reads it → must be skipped.
+                    Rule::new("declarer", "//nothing"),
+                ],
+                None,
+            ),
+            tree_mode: None,
+            ignore_whitespace: false,
+            parse_depth: None,
+        };
+        plan.compiled_rules[0].variables = tractor::EntryVariables::new(
+            reader_vars,
+            tractor::EntryKind::Rule,
+            plan.compiled_rules[0].xpath.as_str(),
+        );
+        plan.compiled_rules[1].variables = tractor::EntryVariables::new(
+            declaring_vars,
+            tractor::EntryKind::Rule,
+            plan.compiled_rules[1].xpath.as_str(),
+        );
+
+        let mut builder = ReportBuilder::new();
+        execute(&[OperationPlan::Check(plan)], &ExecCtx::default(), &mut builder)
+            .expect("an unread source must not be resolved, so the missing file cannot fail the run");
+        let report = builder.build();
+        assert!(!report.success.unwrap(), "the reading rule should still fire");
+    }
+
     /// Rule-level variables are bound as $rule.variables, independent of the
     /// run-level $variables map.
     #[test]
@@ -560,7 +598,11 @@ mod tests {
         .into_iter()
         .map(|op| match op {
             OperationPlan::Check(mut plan) => {
-                plan.compiled_rules[0].variables = std::sync::Arc::new(rule_vars.clone());
+                plan.compiled_rules[0].variables = tractor::EntryVariables::new(
+                    rule_vars.clone(),
+                    tractor::EntryKind::Rule,
+                    plan.compiled_rules[0].xpath.as_str(),
+                );
                 OperationPlan::Check(plan)
             }
             other => other,

--- a/tractor/src/executor/mod.rs
+++ b/tractor/src/executor/mod.rs
@@ -93,10 +93,15 @@ pub fn execute(
 
         // Fresh snapshots for this operation. What gets resolved was decided
         // at config load and travels on each entry's `EntryVariables` — the
-        // executor only reads those flags, it does not re-derive policy.
+        // executor only reads those records, it does not re-derive policy.
+        // The run-level map serves every entry, so its reads are the union.
+        let run_reads = entry_variables(op)
+            .fold(tractor::variables::NamespaceReads::default(), |acc, v| {
+                acc.union(v.reads().run())
+            });
         let run_vars = tractor::variables::bind_run_variables(
             &ctx.query_variables(),
-            entries_read_run_variables(op),
+            &run_reads,
             base_dir,
         )?;
         let op_ctx = ExecCtx { variables: Some(&run_vars), ..*ctx };
@@ -126,18 +131,6 @@ fn entry_variables(op: &OperationPlan) -> Box<dyn Iterator<Item = &tractor::Entr
         OperationPlan::Query(q) => Box::new(q.queries.iter().map(|q| &q.variables)),
         OperationPlan::Test(t) => Box::new(t.assertions.iter().map(|a| &a.variables)),
         OperationPlan::Update(_) => Box::new(std::iter::empty()),
-    }
-}
-
-/// Whether any of the operation's expressions reads the run-level
-/// `$variables`. Reads the flag each entry recorded at config load rather
-/// than re-scanning XPath strings.
-///
-/// `update` has no entries, so its own xpath is consulted directly.
-fn entries_read_run_variables(op: &OperationPlan) -> bool {
-    match op {
-        OperationPlan::Update(u) => tractor::variables::reads_run_variables(&u.xpath),
-        _ => entry_variables(op).any(|v| v.reads_run_variables()),
     }
 }
 

--- a/tractor/src/executor/mod.rs
+++ b/tractor/src/executor/mod.rs
@@ -157,12 +157,15 @@ fn resolve_entry_variables<'a>(
         return Ok(Cow::Borrowed(op));
     }
 
-    /// Replace an entry's declared variables with what should be bound.
+    /// Replace an entry's declared variables with what should be bound,
+    /// naming the entry if a source fails — a missing file surfaces here,
+    /// mid-run, so the message has to say which entry declared it.
     fn bind(
         variables: &mut tractor::EntryVariables,
         base_dir: &std::path::Path,
+        scope: impl FnOnce() -> String,
     ) -> Result<(), tractor::variables::VariableSourceError> {
-        let bound = variables.bind(base_dir)?;
+        let bound = variables.bind(base_dir).map_err(|e| e.in_scope(scope()))?;
         *variables = variables.clone().with_bound(bound);
         Ok(())
     }
@@ -171,22 +174,23 @@ fn resolve_entry_variables<'a>(
     match &mut op {
         OperationPlan::Check(c) => {
             for rule in &mut c.compiled_rules {
-                bind(&mut rule.variables, base_dir)?;
+                let id = rule.id.clone();
+                bind(&mut rule.variables, base_dir, || format!("rule '{}'", id))?;
             }
         }
         OperationPlan::Set(s) => {
-            for mapping in &mut s.mappings {
-                bind(&mut mapping.variables, base_dir)?;
+            for (i, mapping) in s.mappings.iter_mut().enumerate() {
+                bind(&mut mapping.variables, base_dir, || format!("set mapping {}", i + 1))?;
             }
         }
         OperationPlan::Query(q) => {
-            for query in &mut q.queries {
-                bind(&mut query.variables, base_dir)?;
+            for (i, query) in q.queries.iter_mut().enumerate() {
+                bind(&mut query.variables, base_dir, || format!("query {}", i + 1))?;
             }
         }
         OperationPlan::Test(t) => {
-            for assertion in &mut t.assertions {
-                bind(&mut assertion.variables, base_dir)?;
+            for (i, assertion) in t.assertions.iter_mut().enumerate() {
+                bind(&mut assertion.variables, base_dir, || format!("test assertion {}", i + 1))?;
             }
         }
         OperationPlan::Update(_) => {}

--- a/tractor/src/executor/mod.rs
+++ b/tractor/src/executor/mod.rs
@@ -720,12 +720,12 @@ mod tests {
             OperationPlan::Set(set::SetOperationPlan {
                 sources: disk_sources(&[config_path.to_str().unwrap()]),
                 filters: Filters::default(),
-                mappings: vec![set::SetMapping {
-                    xpath: "//host".into(),
-                    value: "new-host".into(),
-                    value_kind: Some("string".into()),
-                    variables: Default::default(),
-                }],
+                mappings: vec![set::SetMapping::new(
+                    "//host",
+                    "new-host",
+                    Some("string".into()),
+                    tractor::QueryVariables::new(),
+                )],
                 tree_mode: None,
                 limit: None,
                 ignore_whitespace: false,

--- a/tractor/src/executor/mod.rs
+++ b/tractor/src/executor/mod.rs
@@ -129,6 +129,9 @@ pub(crate) fn match_to_report_match(m: Match, command: &str) -> ReportMatch {
 ///
 /// Virtual and disk sources flow through the same loop — `source.parse()`
 /// dispatches on content kind so the caller doesn't branch.
+///
+/// `variables` are the run's user-defined variables, bound into each query's
+/// dynamic context alongside the built-in `$file`.
 pub(crate) fn query_files_multi(
     sources: &[Source],
     xpaths: &[&str],
@@ -139,6 +142,7 @@ pub(crate) fn query_files_multi(
     limit: Option<usize>,
     verbose: bool,
     filters: &Filters,
+    variables: &std::sync::Arc<tractor::QueryVariables>,
 ) -> Result<Vec<Match>, Box<dyn std::error::Error>> {
     let mut all_matches: Vec<Match> = sources
         .par_iter()
@@ -153,6 +157,7 @@ pub(crate) fn query_files_multi(
                     return None;
                 }
             };
+            result.variables = std::sync::Arc::clone(variables);
 
             let mut file_matches = Vec::new();
             for xpath_expr in xpaths {
@@ -340,6 +345,169 @@ mod tests {
         let report = run(&ops);
         assert!(report.success.unwrap());
         assert_eq!(report.all_matches().len(), 0);
+    }
+
+    /// Variables from the run context are bound as the $variables map in
+    /// rule queries, alongside the built-in $file.
+    #[test]
+    fn check_binds_user_variables() {
+        use tractor::variables::{QueryVariables, VariableValue};
+
+        let (_dir, path) = temp_json_file(r#"{"debug": true}"#);
+        let ops = vec![OperationPlan::Check(CheckOperationPlan {
+            sources: disk_sources(&[&path]),
+            filters: Filters::default(),
+            compiled_rules: compile(
+                vec![
+                    Rule::new("no-debug-in-prod", "//debug[.='true'][$variables?env = 'production']")
+                        .with_reason("debug must be off in production"),
+                ],
+                None,
+            ),
+            tree_mode: None,
+            ignore_whitespace: false,
+            parse_depth: None,
+        })];
+
+        let mut vars = QueryVariables::new();
+        vars.insert("env", VariableValue::String("production".into()));
+        let vars = std::sync::Arc::new(vars);
+        let ctx = ExecCtx { variables: Some(&vars), ..ExecCtx::default() };
+
+        let mut builder = ReportBuilder::new();
+        execute(&ops, &ctx, &mut builder).unwrap();
+        let report = builder.build();
+        assert!(!report.success.unwrap(), "rule should fire when env = 'production'");
+        assert_eq!(report.all_matches().len(), 1);
+
+        // Same op with env bound differently → rule predicate is false
+        let mut vars = QueryVariables::new();
+        vars.insert("env", VariableValue::String("dev".into()));
+        let vars = std::sync::Arc::new(vars);
+        let ctx = ExecCtx { variables: Some(&vars), ..ExecCtx::default() };
+
+        let mut builder = ReportBuilder::new();
+        execute(&ops, &ctx, &mut builder).unwrap();
+        let report = builder.build();
+        assert!(report.success.unwrap(), "rule should not fire when env = 'dev'");
+    }
+
+    /// Rule-level variables are bound as $rule.variables, independent of the
+    /// run-level $variables map.
+    #[test]
+    fn check_binds_rule_variables() {
+        use tractor::variables::{QueryVariables, VariableValue};
+
+        let (_dir, path) = temp_json_file(r#"{"debug": true}"#);
+        let mut rule_vars = QueryVariables::new();
+        rule_vars.insert("flag", VariableValue::String("debug".into()));
+
+        let ops = vec![OperationPlan::Check(CheckOperationPlan {
+            sources: disk_sources(&[&path]),
+            filters: Filters::default(),
+            compiled_rules: compile(
+                vec![
+                    // Matches the element whose *name* equals the rule-level
+                    // "flag" variable; also asserts run-level lookup is empty.
+                    Rule::new(
+                        "flag-off",
+                        "//*[local-name() = $rule.variables?flag][empty($variables?flag)]",
+                    ),
+                ],
+                None,
+            ),
+            tree_mode: None,
+            ignore_whitespace: false,
+            parse_depth: None,
+        })]
+        .into_iter()
+        .map(|op| match op {
+            OperationPlan::Check(mut plan) => {
+                plan.compiled_rules[0].variables = std::sync::Arc::new(rule_vars.clone());
+                OperationPlan::Check(plan)
+            }
+            other => other,
+        })
+        .collect::<Vec<_>>();
+
+        let report = run(&ops);
+        assert!(!report.success.unwrap(), "$rule.variables?flag should select //debug");
+        // One error match; the deliberate $variables?flag probe (undefined at
+        // run level) additionally produces an advisory warning.
+        let errors: Vec<_> = report.all_matches().into_iter()
+            .filter(|m| m.severity == Some(Severity::Error))
+            .collect();
+        assert_eq!(errors.len(), 1);
+    }
+
+    /// A literal lookup on a key that isn't defined produces an advisory
+    /// warning (never a failure): the lookup legally yields the empty
+    /// sequence, but a typo'd key silently disables a rule.
+    #[test]
+    fn check_warns_on_undefined_variable_keys() {
+        use tractor::variables::{QueryVariables, VariableValue};
+
+        let (_dir, path) = temp_json_file(r#"{"debug": true}"#);
+        let ops = vec![OperationPlan::Check(CheckOperationPlan {
+            sources: disk_sources(&[&path]),
+            filters: Filters::default(),
+            compiled_rules: compile(
+                vec![Rule::new(
+                    "r",
+                    // `env` is defined (but != 'production', so no match);
+                    // `evn` (typo) and `max` (rule-level) are undefined
+                    "//debug[$variables?env = 'production' or $variables?evn = 'production' or $rule.variables?max > 1]",
+                )],
+                None,
+            ),
+            tree_mode: None,
+            ignore_whitespace: false,
+            parse_depth: None,
+        })];
+
+        let mut vars = QueryVariables::new();
+        vars.insert("env", VariableValue::String("prod".into()));
+        let vars = std::sync::Arc::new(vars);
+        let ctx = ExecCtx { variables: Some(&vars), ..ExecCtx::default() };
+
+        let mut builder = ReportBuilder::new();
+        execute(&ops, &ctx, &mut builder).unwrap();
+        let report = builder.build();
+
+        let warnings: Vec<_> = report.all_matches().into_iter()
+            .filter(|m| m.severity == Some(Severity::Warning))
+            .collect();
+        assert_eq!(warnings.len(), 2, "one warning per undefined key: {:?}",
+            report.all_matches().iter().map(|m| &m.reason).collect::<Vec<_>>());
+        assert!(warnings.iter().any(|m| m.reason.as_deref().unwrap_or("").contains("'evn'")));
+        assert!(warnings.iter().any(|m| m.reason.as_deref().unwrap_or("").contains("'max'")));
+        // Warnings are advisory — the run still succeeds (rule matched nothing)
+        assert_eq!(report.success, Some(true), "warnings must not fail the run");
+    }
+
+    /// A rule referencing an undeclared XPath variable (anything other than
+    /// the built-ins $file / $variables / $rule.variables) fails validation
+    /// with a fatal diagnostic instead of executing.
+    #[test]
+    fn check_unknown_variable_is_fatal() {
+        let (_dir, path) = temp_json_file(r#"{"debug": true}"#);
+        let ops = vec![OperationPlan::Check(CheckOperationPlan {
+            sources: disk_sources(&[&path]),
+            filters: Filters::default(),
+            compiled_rules: compile(
+                vec![Rule::new("r", "//debug[$undeclared = 'x']")],
+                None,
+            ),
+            tree_mode: None,
+            ignore_whitespace: false,
+            parse_depth: None,
+        })];
+        let mut builder = ReportBuilder::new();
+        execute(&ops, &ExecCtx::default(), &mut builder).unwrap();
+        let report = builder.build();
+        assert!(report.all_matches().iter().any(|m|
+            m.severity == Some(Severity::Fatal)),
+            "undeclared variable should produce a fatal diagnostic");
     }
 
     #[test]

--- a/tractor/src/executor/mod.rs
+++ b/tractor/src/executor/mod.rs
@@ -198,29 +198,6 @@ fn resolve_entry_variables<'a>(
     Ok(Cow::Owned(op))
 }
 
-/// Execute like [`execute`], but when an operation fails, first render the
-/// diagnostics accumulated so far — advisory variable warnings, earlier
-/// operations' matches — before propagating the error. Without this, the
-/// report that often *explains* the failure (e.g. a warning that a set
-/// mapping's variable lookup is an empty map) is silently dropped on the
-/// error path.
-///
-/// Rendering is best-effort: a render failure never masks the original error.
-pub fn execute_rendering_partial_report(
-    operations: &[OperationPlan],
-    ctx: &ExecCtx<'_>,
-    report: &mut ReportBuilder,
-    run_ctx: &crate::cli::context::RunContext,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let result = execute(operations, ctx, report);
-    if result.is_err() {
-        let mut partial = std::mem::replace(report, ReportBuilder::new()).build();
-        crate::matcher::prepare_report_for_output(&mut partial, run_ctx);
-        let _ = crate::format::render_report(&partial, run_ctx, None);
-    }
-    result
-}
-
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------

--- a/tractor/src/executor/mod.rs
+++ b/tractor/src/executor/mod.rs
@@ -74,10 +74,15 @@ pub const DEFAULT_MAX_FILES: usize = 10_000;
 /// of truth per CLI invocation.
 ///
 /// Operations run strictly in order, and `$`-directive variable sources
-/// (`$file`) are resolved at each operation's start — so a file written by
-/// an earlier operation (e.g. a query op's `output:`) is read fresh by the
+/// (`$file`) are loaded at each operation's start — so a file written by an
+/// earlier operation (e.g. a query op's `output:`) is read fresh by the
 /// next one. Each operation sees one consistent snapshot; the ordered
 /// `operations:` list is the dependency mechanism.
+///
+/// *Which* sources load is decided at config load, per entry, and recorded
+/// on [`tractor::EntryVariables`] — this loop reads those flags rather than
+/// inspecting XPath. A source no expression reads is never loaded, so an
+/// operation cannot fail over a file a later operation will write.
 pub fn execute(
     operations: &[OperationPlan],
     ctx: &ExecCtx<'_>,

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -115,6 +115,16 @@ pub enum QueryOutputField {
 }
 
 impl QueryOutputField {
+    /// The field's name as written in config and in multi-field entries.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Value => "value",
+            Self::Line => "line",
+            Self::Column => "column",
+            Self::Tree => "tree",
+        }
+    }
+
     /// Parse a config `view:` field name.
     pub fn from_str(s: &str) -> Result<Self, String> {
         match s {
@@ -305,29 +315,33 @@ fn normalize_key(path: &str) -> String {
     p.trim_end_matches('/').to_string()
 }
 
+/// One field of a match as JSON. `Tree` is `None` for atomic matches, which
+/// carry no node.
+fn field_value(field: QueryOutputField, m: &tractor::Match) -> Option<serde_json::Value> {
+    match field {
+        QueryOutputField::Value => Some(serde_json::Value::String(m.value.clone())),
+        QueryOutputField::Line => Some(serde_json::Value::from(m.line)),
+        QueryOutputField::Column => Some(serde_json::Value::from(m.column)),
+        QueryOutputField::Tree => m.xml_node.as_ref().map(|n| tractor::xml_node_to_json(n, None)),
+    }
+}
+
 /// Build one output entry for a match, honoring the configured view.
-/// A bare `value` view writes plain strings; anything else writes objects.
+///
+/// A **single-field** view writes that field directly, with no wrapper: the
+/// default `[value]` gives bare strings, and `[tree]` gives each match's
+/// structure itself — so a query emitting `map { 'name': ..., 'max': ... }`
+/// is read as `?files?*?*?name`, a keyed lookup, rather than being buried
+/// under a `tree` key. Multi-field views need an object to label which
+/// value is which.
 fn output_entry(output: &QueryOutput, m: &tractor::Match) -> serde_json::Value {
-    if output.view == [QueryOutputField::Value] {
-        return serde_json::Value::String(m.value.clone());
+    if let [only] = output.view.as_slice() {
+        return field_value(*only, m).unwrap_or(serde_json::Value::Null);
     }
     let mut obj = serde_json::Map::new();
     for field in &output.view {
-        match field {
-            QueryOutputField::Value => {
-                obj.insert("value".into(), serde_json::Value::String(m.value.clone()));
-            }
-            QueryOutputField::Line => {
-                obj.insert("line".into(), serde_json::Value::from(m.line));
-            }
-            QueryOutputField::Column => {
-                obj.insert("column".into(), serde_json::Value::from(m.column));
-            }
-            QueryOutputField::Tree => {
-                if let Some(node) = &m.xml_node {
-                    obj.insert("tree".into(), tractor::xml_node_to_json(node, None));
-                }
-            }
+        if let Some(value) = field_value(*field, m) {
+            obj.insert(field.name().to_string(), value);
         }
     }
     serde_json::Value::Object(obj)
@@ -433,6 +447,43 @@ mod tests {
         assert!(warnings[0].reason.as_deref().unwrap().contains("only bound in check rules"));
         // The query itself still runs and matches nothing (empty lookup).
         assert!(report.all_matches().iter().all(|m| m.severity == Some(Severity::Warning)));
+    }
+
+    /// A single-field view writes that field directly, so structured
+    /// records read as `?files?*?*?field` — a keyed lookup, not a string
+    /// key. Several fields need an object to label them.
+    #[test]
+    fn query_output_single_field_view_is_unwrapped() {
+        use tractor::XmlNode;
+
+        let mut m = tractor::Match::new("a.json".to_string(), "Name".to_string());
+        m.line = 7;
+        m.xml_node = Some(XmlNode::Map {
+            entries: vec![
+                ("name".to_string(), XmlNode::Text("Name".into())),
+                ("max".to_string(), XmlNode::Text("256".into())),
+            ],
+        });
+
+        let bare_value = QueryOutput { file: "o.json".into(), view: vec![QueryOutputField::Value] };
+        assert_eq!(output_entry(&bare_value, &m), serde_json::json!("Name"));
+
+        // `[tree]` alone yields the map itself — no `tree` wrapper.
+        let bare_tree = QueryOutput { file: "o.json".into(), view: vec![QueryOutputField::Tree] };
+        assert_eq!(
+            output_entry(&bare_tree, &m),
+            serde_json::json!({"name": "Name", "max": "256"}),
+        );
+
+        // Several fields stay labelled.
+        let labelled = QueryOutput {
+            file: "o.json".into(),
+            view: vec![QueryOutputField::Value, QueryOutputField::Line],
+        };
+        assert_eq!(
+            output_entry(&labelled, &m),
+            serde_json::json!({"value": "Name", "line": 7}),
+        );
     }
 
     /// Merge semantics of the materialized output: queried files are

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -326,18 +326,17 @@ fn field_value(field: QueryOutputField, m: &tractor::Match) -> Option<serde_json
     }
 }
 
-/// Build one output entry for a match, honoring the configured view.
+/// Build one output entry for a match: always an object whose keys are the
+/// configured `view:` fields.
 ///
-/// A **single-field** view writes that field directly, with no wrapper: the
-/// default `[value]` gives bare strings, and `[tree]` gives each match's
-/// structure itself — so a query emitting `map { 'name': ..., 'max': ... }`
-/// is read as `?files?*?*?name`, a keyed lookup, rather than being buried
-/// under a `tree` key. Multi-field views need an object to label which
-/// value is which.
+/// The shape never depends on how many fields were selected, or on what a
+/// match happens to contain — `view:` chooses which keys appear, and
+/// nothing else. Unwrapping a lone field would make a config's structure
+/// change silently when a second field is added, and would make the
+/// artifact's shape a function of its content rather than of its
+/// parameters. It also keeps the file consistent with the JSON report,
+/// where a match is always a labelled object.
 fn output_entry(output: &QueryOutput, m: &tractor::Match) -> serde_json::Value {
-    if let [only] = output.view.as_slice() {
-        return field_value(*only, m).unwrap_or(serde_json::Value::Null);
-    }
     let mut obj = serde_json::Map::new();
     for field in &output.view {
         if let Some(value) = field_value(*field, m) {
@@ -449,11 +448,11 @@ mod tests {
         assert!(report.all_matches().iter().all(|m| m.severity == Some(Severity::Warning)));
     }
 
-    /// A single-field view writes that field directly, so structured
-    /// records read as `?files?*?*?field` — a keyed lookup, not a string
-    /// key. Several fields need an object to label them.
+    /// Entries are always labelled objects: `view:` selects which keys
+    /// appear and nothing else, so adding a field never changes the shape
+    /// of the ones already there.
     #[test]
-    fn query_output_single_field_view_is_unwrapped() {
+    fn query_output_entries_are_always_labelled() {
         use tractor::XmlNode;
 
         let mut m = tractor::Match::new("a.json".to_string(), "Name".to_string());
@@ -465,25 +464,23 @@ mod tests {
             ],
         });
 
-        let bare_value = QueryOutput { file: "o.json".into(), view: vec![QueryOutputField::Value] };
-        assert_eq!(output_entry(&bare_value, &m), serde_json::json!("Name"));
+        // The default view — still an object, not a bare string.
+        let default_view = QueryOutput { file: "o.json".into(), view: vec![QueryOutputField::Value] };
+        assert_eq!(output_entry(&default_view, &m), serde_json::json!({"value": "Name"}));
 
-        // `[tree]` alone yields the map itself — no `tree` wrapper.
-        let bare_tree = QueryOutput { file: "o.json".into(), view: vec![QueryOutputField::Tree] };
+        // A structured match keeps its map under the `tree` key.
+        let tree = QueryOutput { file: "o.json".into(), view: vec![QueryOutputField::Tree] };
         assert_eq!(
-            output_entry(&bare_tree, &m),
-            serde_json::json!({"name": "Name", "max": "256"}),
+            output_entry(&tree, &m),
+            serde_json::json!({"tree": {"name": "Name", "max": "256"}}),
         );
 
-        // Several fields stay labelled.
-        let labelled = QueryOutput {
+        // Adding a field only adds a key; `value` is unchanged.
+        let two = QueryOutput {
             file: "o.json".into(),
             view: vec![QueryOutputField::Value, QueryOutputField::Line],
         };
-        assert_eq!(
-            output_entry(&labelled, &m),
-            serde_json::json!({"value": "Name", "line": 7}),
-        );
+        assert_eq!(output_entry(&two, &m), serde_json::json!({"value": "Name", "line": 7}));
     }
 
     /// Merge semantics of the materialized output: queried files are
@@ -518,7 +515,11 @@ mod tests {
             serde_json::from_str(&std::fs::read_to_string(dir.path().join("out.json")).unwrap()).unwrap();
         let files = written.get("files").unwrap().as_object().unwrap();
         assert_eq!(files.get("a.json").unwrap(), &serde_json::json!(["old-a"]), "unqueried file kept");
-        assert_eq!(files.get("b.json").unwrap(), &serde_json::json!(["new-b"]), "queried file replaced");
+        assert_eq!(
+            files.get("b.json").unwrap(),
+            &serde_json::json!([{"value": "new-b"}]),
+            "queried file replaced",
+        );
         assert!(files.get("gone.json").is_none(), "missing file pruned: {:?}", files);
     }
 

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -88,6 +88,27 @@ impl QueryOperation {
 
 /// Materialized-output settings for a query operation.
 ///
+/// # Writing policy
+///
+/// Two operations write to disk, and they answer "may I write?" differently
+/// on purpose, because they write different things:
+///
+/// - `set` and `update` mutate **their own inputs**, so whether they may
+///   write depends on what those inputs are — an inline or stdin source has
+///   no file to write back to. [`SetWriteMode`](super::SetWriteMode) owns
+///   that decision and routes such a run to `Capture` instead.
+/// - `output:` writes an **artifact the user named**, which exists only
+///   because it was declared. It is the point of the option, not a side
+///   effect of reading, so it is written unconditionally and its path never
+///   depends on the input mode.
+///
+/// The input mode still matters for the *contents*: the index is keyed by
+/// source path, so matches from virtual sources are not indexable and are
+/// left out (see `write_query_output`).
+///
+/// A future `--dry-run` would gate both, and that is where the two meet —
+/// not here.
+///
 /// The written file is a JSON index keyed by source file:
 /// `{ "files": { "<path>": [ <entry>, ... ] } }`. File keys are relative to
 /// the run's base dir when possible, so the artifact is stable and
@@ -230,7 +251,7 @@ pub(crate) fn execute_query(
 /// for files outside the queried set are kept; entries whose file no longer
 /// exists on disk are pruned. Keys sort deterministically for stable diffs.
 fn write_query_output(
-    output: &super::query::QueryOutput,
+    output: &QueryOutput,
     matches: &[tractor::Match],
     sources: &[Source],
     base_dir: &std::path::Path,
@@ -246,14 +267,23 @@ fn write_query_output(
         }
     };
 
+    // Disk sources only, on both sides of the merge. The index is keyed by
+    // path, and a virtual (inline / stdin) source has no path that means
+    // anything to a later run — its matches are not indexable, so they are
+    // left out rather than written and pruned again.
+    let indexable = |path: &str| -> bool {
+        sources
+            .iter()
+            .any(|s| !s.is_virtual() && relativize(s.path.as_str()) == relativize(path))
+    };
+
     // This run's results, grouped per file.
     let mut fresh: BTreeMap<String, Vec<serde_json::Value>> = BTreeMap::new();
-    for m in matches {
+    for m in matches.iter().filter(|m| indexable(&m.file)) {
         fresh.entry(relativize(&m.file)).or_default().push(output_entry(output, m));
     }
 
-    // The queried set: files whose entries this run owns (disk sources
-    // only — virtual inline sources have no stable identity to key on).
+    // The queried set: files whose entries this run owns.
     let queried: std::collections::BTreeSet<String> = sources
         .iter()
         .filter(|s| !s.is_virtual())

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -41,6 +41,9 @@ pub struct QueryOperationPlan {
     pub ignore_whitespace: bool,
     /// Maximum parse depth.
     pub parse_depth: Option<usize>,
+    /// Materialize results to a JSON file, keyed by source file — the
+    /// artifact later operations consume via a `$file` variable source.
+    pub output: Option<QueryOutput>,
 }
 
 /// Pre-resolution shape for a query operation. Mirrors [`QueryOperationPlan`]
@@ -62,6 +65,8 @@ pub struct QueryOperation {
     pub ignore_whitespace: bool,
     /// Maximum parse depth.
     pub parse_depth: Option<usize>,
+    /// Materialize results to a JSON file (see [`QueryOutput`]).
+    pub output: Option<QueryOutput>,
 }
 
 impl QueryOperation {
@@ -76,6 +81,51 @@ impl QueryOperation {
             limit: self.limit,
             ignore_whitespace: self.ignore_whitespace,
             parse_depth: self.parse_depth,
+            output: self.output,
+        }
+    }
+}
+
+/// Materialized-output settings for a query operation.
+///
+/// The written file is a JSON index keyed by source file:
+/// `{ "files": { "<path>": [ <entry>, ... ] } }`. File keys are relative to
+/// the run's base dir when possible, so the artifact is stable and
+/// committable. The per-file grouping is not optional — it is what makes
+/// incremental merges sound: on each run, entries for every *queried* file
+/// are replaced wholesale (an empty result removes the key), entries for
+/// files outside the queried set (e.g. excluded by `--diff-files`) are
+/// kept, and entries whose file no longer exists are pruned.
+#[derive(Debug, Clone)]
+pub struct QueryOutput {
+    /// Output path, relative to the run's base dir.
+    pub file: String,
+    /// Fields stored per entry. `[Value]` (the default) writes bare value
+    /// strings; anything else writes one JSON object per match.
+    pub view: Vec<QueryOutputField>,
+}
+
+/// A field of a materialized query-output entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryOutputField {
+    Value,
+    Line,
+    Column,
+    Tree,
+}
+
+impl QueryOutputField {
+    /// Parse a config `view:` field name.
+    pub fn from_str(s: &str) -> Result<Self, String> {
+        match s {
+            "value" => Ok(Self::Value),
+            "line" => Ok(Self::Line),
+            "column" => Ok(Self::Column),
+            "tree" => Ok(Self::Tree),
+            other => Err(format!(
+                "invalid query output view field '{}': use value, line, column, or tree",
+                other
+            )),
         }
     }
 }
@@ -140,9 +190,135 @@ pub(crate) fn execute_query(
         op.limit, ctx.verbose, &op.filters, &variables,
     )?;
 
+    if let Some(output) = &op.output {
+        let base_dir = ctx.base_dir.unwrap_or_else(|| std::path::Path::new("."));
+        write_query_output(output, &matches, &op.sources, base_dir)?;
+    }
+
     report.add_all(matches.into_iter().map(|m| match_to_report_match(m, "query")));
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Materialized output
+// ---------------------------------------------------------------------------
+
+/// Write (or incrementally merge) query results into the output file.
+///
+/// Merge semantics: entries for every queried source file are replaced
+/// wholesale by this run's results (zero matches removes the key); entries
+/// for files outside the queried set are kept; entries whose file no longer
+/// exists on disk are pruned. Keys sort deterministically for stable diffs.
+fn write_query_output(
+    output: &super::query::QueryOutput,
+    matches: &[tractor::Match],
+    sources: &[Source],
+    base_dir: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::collections::BTreeMap;
+
+    let base_key = normalize_key(&base_dir.to_string_lossy());
+    let relativize = |path: &str| -> String {
+        let p = normalize_key(path);
+        match p.strip_prefix(&format!("{}/", base_key)) {
+            Some(rel) if base_key != "." => rel.to_string(),
+            _ => p,
+        }
+    };
+
+    // This run's results, grouped per file.
+    let mut fresh: BTreeMap<String, Vec<serde_json::Value>> = BTreeMap::new();
+    for m in matches {
+        fresh.entry(relativize(&m.file)).or_default().push(output_entry(output, m));
+    }
+
+    // The queried set: files whose entries this run owns (disk sources
+    // only — virtual inline sources have no stable identity to key on).
+    let queried: std::collections::BTreeSet<String> = sources
+        .iter()
+        .filter(|s| !s.is_virtual())
+        .map(|s| relativize(s.path.as_str()))
+        .collect();
+
+    let out_path = base_dir.join(&output.file);
+
+    // Start from the existing index when merging is possible.
+    let mut files: BTreeMap<String, serde_json::Value> = match std::fs::read_to_string(&out_path) {
+        Ok(existing) => {
+            let parsed: serde_json::Value = serde_json::from_str(&existing).map_err(|e| {
+                format!(
+                    "existing query output '{}' is not valid JSON ({}); delete it to regenerate",
+                    out_path.display(), e
+                )
+            })?;
+            match parsed.get("files").and_then(|f| f.as_object()) {
+                Some(obj) => obj.clone().into_iter().collect(),
+                None => {
+                    return Err(format!(
+                        "existing file '{}' is not a tractor query output (expected a top-level \
+                         \"files\" object); delete it or choose another output path",
+                        out_path.display()
+                    ).into());
+                }
+            }
+        }
+        Err(_) => BTreeMap::new(),
+    };
+
+    // Replace everything this run queried, then overlay fresh results.
+    files.retain(|key, _| !queried.contains(key));
+    for (key, entries) in fresh {
+        files.insert(key, serde_json::Value::Array(entries));
+    }
+
+    // Prune entries whose file no longer exists (deletes / renames).
+    files.retain(|key, _| {
+        let p = std::path::Path::new(key);
+        if p.is_absolute() { p.exists() } else { base_dir.join(p).exists() }
+    });
+
+    if let Some(parent) = out_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let doc = serde_json::json!({ "files": files });
+    std::fs::write(&out_path, format!("{}\n", serde_json::to_string_pretty(&doc)?))?;
+    Ok(())
+}
+
+/// Normalize a path string for use as an index key (forward slashes, no
+/// trailing slash) so keys compare consistently across platforms and runs.
+fn normalize_key(path: &str) -> String {
+    let p = path.replace('\\', "/");
+    p.trim_end_matches('/').to_string()
+}
+
+/// Build one output entry for a match, honoring the configured view.
+/// A bare `value` view writes plain strings; anything else writes objects.
+fn output_entry(output: &QueryOutput, m: &tractor::Match) -> serde_json::Value {
+    if output.view == [QueryOutputField::Value] {
+        return serde_json::Value::String(m.value.clone());
+    }
+    let mut obj = serde_json::Map::new();
+    for field in &output.view {
+        match field {
+            QueryOutputField::Value => {
+                obj.insert("value".into(), serde_json::Value::String(m.value.clone()));
+            }
+            QueryOutputField::Line => {
+                obj.insert("line".into(), serde_json::Value::from(m.line));
+            }
+            QueryOutputField::Column => {
+                obj.insert("column".into(), serde_json::Value::from(m.column));
+            }
+            QueryOutputField::Tree => {
+                if let Some(node) = &m.xml_node {
+                    obj.insert("tree".into(), tractor::xml_node_to_json(node, None));
+                }
+            }
+        }
+    }
+    serde_json::Value::Object(obj)
 }
 
 // ---------------------------------------------------------------------------
@@ -189,6 +365,7 @@ mod tests {
             limit: None,
             ignore_whitespace: false,
             parse_depth: None,
+            output: None,
         })];
         let report = run_query_ops(&ops);
         assert!(report.success.is_none());
@@ -208,6 +385,7 @@ mod tests {
             limit: Some(2),
             ignore_whitespace: false,
             parse_depth: None,
+            output: None,
         })];
         let report = run_query_ops(&ops);
         assert!(report.all_matches().len() <= 2);
@@ -233,6 +411,7 @@ mod tests {
             limit: None,
             ignore_whitespace: false,
             parse_depth: None,
+            output: None,
         })];
         let report = run_query_ops(&ops);
         let warnings: Vec<_> = report.all_matches().into_iter()
@@ -242,6 +421,42 @@ mod tests {
         assert!(warnings[0].reason.as_deref().unwrap().contains("only bound in check rules"));
         // The query itself still runs and matches nothing (empty lookup).
         assert!(report.all_matches().iter().all(|m| m.severity == Some(Severity::Warning)));
+    }
+
+    /// Merge semantics of the materialized output: queried files are
+    /// replaced wholesale, unqueried files keep their entries, and entries
+    /// whose file no longer exists are pruned.
+    #[test]
+    fn query_output_incremental_merge() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.json"), "{}").unwrap();
+        std::fs::write(dir.path().join("b.json"), "{}").unwrap();
+        // "gone.json" is referenced by the existing index but no longer exists.
+        std::fs::write(
+            dir.path().join("out.json"),
+            r#"{ "files": { "a.json": ["old-a"], "b.json": ["old-b"], "gone.json": ["x"] } }"#,
+        ).unwrap();
+
+        let output = QueryOutput {
+            file: "out.json".into(),
+            view: vec![QueryOutputField::Value],
+        };
+        // This run queried only b.json and found one match.
+        let b_path = dir.path().join("b.json");
+        let matches = vec![tractor::Match::new(
+            b_path.to_string_lossy().replace('\\', "/"),
+            "new-b".to_string(),
+        )];
+        let sources = vec![disk_source(b_path.to_str().unwrap())];
+
+        write_query_output(&output, &matches, &sources, dir.path()).unwrap();
+
+        let written: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join("out.json")).unwrap()).unwrap();
+        let files = written.get("files").unwrap().as_object().unwrap();
+        assert_eq!(files.get("a.json").unwrap(), &serde_json::json!(["old-a"]), "unqueried file kept");
+        assert_eq!(files.get("b.json").unwrap(), &serde_json::json!(["new-b"]), "queried file replaced");
+        assert!(files.get("gone.json").is_none(), "missing file pruned: {:?}", files);
     }
 
     #[test]
@@ -255,6 +470,7 @@ mod tests {
             limit: None,
             ignore_whitespace: false,
             parse_depth: None,
+            output: None,
         })];
         let report = run_query_ops(&ops);
         assert_eq!(report.all_matches().len(), 0);

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -296,10 +296,10 @@ fn write_query_output(
         .map(|s| relativize(s.path.as_str()))
         .collect();
 
-    // The path is declared in config and joined to the config's directory,
-    // so `..` would let a config write anywhere on the machine — which the
-    // docs promise it cannot. Refuse rather than normalize: a rejected
-    // path is a typo the author can see, a normalized one is a surprise.
+    // Config-loaded plans are checked at load (`convert_query`), where the
+    // path is knowable and an error costs nothing. This guard covers plans
+    // built programmatically, which bypass that path entirely — the write
+    // itself is where the promise has to hold.
     let requested = std::path::Path::new(&output.file);
     if requested.is_absolute()
         || requested.components().any(|c| matches!(c, std::path::Component::ParentDir))

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -126,6 +126,36 @@ pub struct QueryOutput {
     pub view: Vec<QueryOutputField>,
 }
 
+impl QueryOutput {
+    /// Check that a configured output path stays inside the config
+    /// directory: relative, with no `..`.
+    ///
+    /// Tests components rather than `Path::is_absolute`, which is not
+    /// enough on Windows — `/x` and `\x` have a root but no drive prefix,
+    /// so `is_absolute` reports **false** while `join` still throws away
+    /// the base directory and keeps only its drive, landing the write
+    /// outside the config directory. `C:x` (drive-relative) slips through
+    /// the same way. Rejecting `Prefix`, `RootDir` and `ParentDir` covers
+    /// every rooted or drive-qualified form on both platforms.
+    ///
+    /// One owner, called from config load (so a bad path fails before any
+    /// work) and again at the write (which programmatic plans reach
+    /// without passing through config loading).
+    pub fn validate_path(file: &str) -> Result<(), String> {
+        use std::path::Component;
+        let escapes = std::path::Path::new(file).components().any(|c| {
+            matches!(c, Component::Prefix(_) | Component::RootDir | Component::ParentDir)
+        });
+        if escapes {
+            return Err(format!(
+                "query output '{}' must be a relative path inside the config directory",
+                file
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// A field of a materialized query-output entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QueryOutputField {
@@ -300,16 +330,8 @@ fn write_query_output(
     // path is knowable and an error costs nothing. This guard covers plans
     // built programmatically, which bypass that path entirely — the write
     // itself is where the promise has to hold.
-    let requested = std::path::Path::new(&output.file);
-    if requested.is_absolute()
-        || requested.components().any(|c| matches!(c, std::path::Component::ParentDir))
-    {
-        return Err(format!(
-            "query output '{}' must be a relative path inside the config directory",
-            output.file
-        ).into());
-    }
-    let out_path = base_dir.join(requested);
+    QueryOutput::validate_path(&output.file)?;
+    let out_path = base_dir.join(&output.file);
 
     // Start from the existing index when merging is possible.
     let mut files: BTreeMap<String, serde_json::Value> = match std::fs::read_to_string(&out_path) {
@@ -492,6 +514,30 @@ mod tests {
         assert!(warnings[0].reason.as_deref().unwrap().contains("only bound in check rules"));
         // The query itself still runs and matches nothing (empty lookup).
         assert!(report.all_matches().iter().all(|m| m.severity == Some(Severity::Warning)));
+    }
+
+    /// The output path must stay inside the config directory. `is_absolute`
+    /// alone misses the Windows forms that still escape, so every rooted or
+    /// drive-qualified shape is rejected explicitly.
+    #[test]
+    fn query_output_path_must_stay_inside_the_config_directory() {
+        for ok in ["out.json", "gathered/repos.json", "./a/b.json"] {
+            assert!(QueryOutput::validate_path(ok).is_ok(), "{} should be allowed", ok);
+        }
+        for escaping in [
+            "../outside.json",       // parent traversal
+            "a/../../outside.json",  // traversal after a descent
+            "/rooted.json",          // rooted, no drive: is_absolute() is false on Windows
+            "\\rooted.json",         // the same with a backslash
+            "C:\\abs.json",          // fully absolute
+            "C:rel.json",            // drive-relative
+        ] {
+            let err = match QueryOutput::validate_path(escaping) {
+                Err(e) => e,
+                Ok(()) => panic!("{} should be rejected", escaping),
+            };
+            assert!(err.contains("must be a relative path"), "{}: {}", escaping, err);
+        }
     }
 
     /// Entries are always labelled objects: `view:` selects which keys

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -146,8 +146,14 @@ impl QueryOutputField {
         }
     }
 
-    /// Parse a config `view:` field name.
-    pub fn from_str(s: &str) -> Result<Self, String> {
+}
+
+impl std::str::FromStr for QueryOutputField {
+    type Err = String;
+
+    /// Parse a config `view:` field name, so the config parser can use
+    /// `parse()` like every other field.
+    fn from_str(s: &str) -> Result<Self, String> {
         match s {
             "value" => Ok(Self::Value),
             "line" => Ok(Self::Line),
@@ -290,7 +296,20 @@ fn write_query_output(
         .map(|s| relativize(s.path.as_str()))
         .collect();
 
-    let out_path = base_dir.join(&output.file);
+    // The path is declared in config and joined to the config's directory,
+    // so `..` would let a config write anywhere on the machine — which the
+    // docs promise it cannot. Refuse rather than normalize: a rejected
+    // path is a typo the author can see, a normalized one is a surprise.
+    let requested = std::path::Path::new(&output.file);
+    if requested.is_absolute()
+        || requested.components().any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err(format!(
+            "query output '{}' must be a relative path inside the config directory",
+            output.file
+        ).into());
+    }
+    let out_path = base_dir.join(requested);
 
     // Start from the existing index when merging is possible.
     let mut files: BTreeMap<String, serde_json::Value> = match std::fs::read_to_string(&out_path) {

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -311,7 +311,16 @@ fn write_query_output(
 ) -> Result<(), Box<dyn std::error::Error>> {
     use std::collections::BTreeMap;
 
-    let base_key = normalize_key(&base_dir.to_string_lossy());
+    // Normalize the base the same way sources are, or the two spellings of
+    // the same directory won't share a prefix and every key lands as an
+    // absolute path instead of a relative one — an artifact full of
+    // machine-specific paths, which is the opposite of "stable and
+    // committable". `NormalizedPath::absolute` is what glob expansion puts
+    // sources through (it resolves 8.3 aliases such as `RUNNER~1` on
+    // Windows), so applying it here makes both sides agree by construction.
+    let base_key = normalize_key(
+        tractor::NormalizedPath::absolute(&base_dir.to_string_lossy()).as_str(),
+    );
     let relativize = |path: &str| -> String {
         let p = normalize_key(path);
         match p.strip_prefix(&format!("{}/", base_key)) {
@@ -539,6 +548,42 @@ mod tests {
         assert!(warnings[0].reason.as_deref().unwrap().contains("only bound in check rules"));
         // The query itself still runs and matches nothing (empty lookup).
         assert!(report.all_matches().iter().all(|m| m.severity == Some(Severity::Warning)));
+    }
+
+    /// The index must key by relative path even when `base_dir` is spelled
+    /// differently from the sources' own normalization.
+    ///
+    /// On a Windows CI runner the difference is an 8.3 alias (`RUNNER~1` vs
+    /// `runneradmin`); here it is a `.` component, which is the same class
+    /// of divergence and reproduces on every platform. Without normalizing
+    /// the base the way sources are normalized, the prefix does not strip
+    /// and every key lands as an absolute, machine-specific path.
+    #[test]
+    fn query_output_keys_are_relative_when_base_dir_is_spelled_differently() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("b.json"), "{}").unwrap();
+
+        let output = QueryOutput { file: "out.json".into(), view: vec![QueryOutputField::Value] };
+        let sources = vec![disk_source(dir.path().join("b.json").to_str().unwrap())];
+        let matches = vec![tractor::Match::new(
+            sources[0].path.as_str().to_string(),
+            "v".to_string(),
+        )];
+
+        // Same directory, different spelling — as a config's base dir and a
+        // glob-expanded source routinely are.
+        let base = dir.path().join(".");
+        write_query_output(&output, &matches, &sources, &base).unwrap();
+
+        let written: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dir.path().join("out.json")).unwrap())
+                .unwrap();
+        let files = written.get("files").unwrap().as_object().unwrap();
+        assert!(
+            files.contains_key("b.json"),
+            "keys must be relative to the config directory, got {:?}",
+            files.keys().collect::<Vec<_>>(),
+        );
     }
 
     /// The output path must stay inside the config directory. `is_absolute`

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -137,7 +137,7 @@ pub struct QueryExpr {
     pub xpath: NormalizedXpath,
     /// Query-level variables, bound as the `$query.variables` map in this
     /// expression (e.g. `//user[@role = $query.variables?role]`).
-    pub variables: std::sync::Arc<tractor::QueryVariables>,
+    pub variables: tractor::EntryVariables,
 }
 
 // ---------------------------------------------------------------------------
@@ -180,7 +180,7 @@ pub(crate) fn execute_query(
     let queries: Vec<(&str, Option<tractor::EntryContext>)> = op.queries.iter()
         .map(|q| (
             q.xpath.as_str(),
-            Some(tractor::EntryContext::query(std::sync::Arc::clone(&q.variables))),
+            Some(tractor::EntryContext::query(std::sync::Arc::clone(q.variables.declared()))),
         ))
         .collect();
 

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -130,27 +130,44 @@ impl QueryOutput {
     /// Check that a configured output path stays inside the config
     /// directory: relative, with no `..`.
     ///
-    /// Tests components rather than `Path::is_absolute`, which is not
-    /// enough on Windows — `/x` and `\x` have a root but no drive prefix,
-    /// so `is_absolute` reports **false** while `join` still throws away
-    /// the base directory and keeps only its drive, landing the write
-    /// outside the config directory. `C:x` (drive-relative) slips through
-    /// the same way. Rejecting `Prefix`, `RootDir` and `ParentDir` covers
-    /// every rooted or drive-qualified form on both platforms.
+    /// The check is **lexical, on the raw string**, deliberately not via
+    /// `Path`. A `tractor.yml` is committed and read on every platform, so
+    /// `output: "C:\gathered.json"` has to mean the same thing everywhere —
+    /// but `Path` is platform-dependent: on Unix that string is a single
+    /// ordinary filename, while on Windows it is a drive-qualified path
+    /// that escapes the config directory. A config's meaning must not
+    /// depend on which machine loaded it.
+    ///
+    /// Rejected: a leading `/` or `\` (rooted — on Windows `join` keeps
+    /// only the drive and drops the base directory, and `is_absolute` does
+    /// not catch it), a `<letter>:` prefix (absolute or drive-relative),
+    /// any `..` segment, and the empty path.
     ///
     /// One owner, called from config load (so a bad path fails before any
     /// work) and again at the write (which programmatic plans reach
     /// without passing through config loading).
     pub fn validate_path(file: &str) -> Result<(), String> {
-        use std::path::Component;
-        let escapes = std::path::Path::new(file).components().any(|c| {
-            matches!(c, Component::Prefix(_) | Component::RootDir | Component::ParentDir)
-        });
-        if escapes {
-            return Err(format!(
-                "query output '{}' must be a relative path inside the config directory",
-                file
-            ));
+        let reject = |why: &str| {
+            Err(format!(
+                "query output '{}' must be a relative path inside the config directory ({})",
+                file, why
+            ))
+        };
+        if file.is_empty() {
+            return reject("it is empty");
+        }
+        if file.starts_with('/') || file.starts_with('\\') {
+            return reject("it starts at a filesystem root");
+        }
+        let mut chars = file.chars();
+        if matches!(
+            (chars.next(), chars.next()),
+            (Some(letter), Some(':')) if letter.is_ascii_alphabetic()
+        ) {
+            return reject("it names a drive");
+        }
+        if file.split(['/', '\\']).any(|segment| segment == "..") {
+            return reject("it walks out with `..`");
         }
         Ok(())
     }
@@ -307,6 +324,14 @@ fn write_query_output(
     // path, and a virtual (inline / stdin) source has no path that means
     // anything to a later run — its matches are not indexable, so they are
     // left out rather than written and pruned again.
+    //
+    // This compares a match's file against the source paths, which works
+    // because `query_files_multi` parses with `source.path.as_str()` and
+    // hands that same string to every match: a match's file *is* its
+    // source's path, not an independently derived spelling of it. Anything
+    // constructing matches by another route (a test fabricating a path from
+    // `tempdir()`, say) can produce a string that normalizes differently
+    // and will silently match nothing.
     let indexable = |path: &str| -> bool {
         sources
             .iter()
@@ -593,13 +618,18 @@ mod tests {
             file: "out.json".into(),
             view: vec![QueryOutputField::Value],
         };
-        // This run queried only b.json and found one match.
+        // This run queried only b.json and found one match. The match path
+        // comes from the source, exactly as `query_files_multi` produces it
+        // — fabricating it from `tempdir()` instead would diverge wherever
+        // the two normalize differently (on a Windows CI runner the source
+        // resolves the 8.3 alias `RUNNER~1` to `runneradmin`, the raw temp
+        // path does not, and nothing matches).
         let b_path = dir.path().join("b.json");
+        let sources = vec![disk_source(b_path.to_str().unwrap())];
         let matches = vec![tractor::Match::new(
-            b_path.to_string_lossy().replace('\\', "/"),
+            sources[0].path.as_str().to_string(),
             "new-b".to_string(),
         )];
-        let sources = vec![disk_source(b_path.to_str().unwrap())];
 
         write_query_output(&output, &matches, &sources, dir.path()).unwrap();
 

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -114,7 +114,7 @@ pub(crate) fn execute_query(
     let matches = query_files_multi(
         &op.sources, &xpaths, op.language.as_deref(),
         op.tree_mode, op.ignore_whitespace, op.parse_depth,
-        op.limit, ctx.verbose, &op.filters,
+        op.limit, ctx.verbose, &op.filters, &ctx.query_variables(),
     )?;
 
     report.add_all(matches.into_iter().map(|m| match_to_report_match(m, "query")));

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -137,7 +137,19 @@ pub struct QueryExpr {
     pub xpath: NormalizedXpath,
     /// Query-level variables, bound as the `$query.variables` map in this
     /// expression (e.g. `//user[@role = $query.variables?role]`).
+    /// Build via [`QueryExpr::new`] so the variables' resolution flags are
+    /// always derived from the xpath that actually runs.
     pub variables: tractor::EntryVariables,
+}
+
+impl QueryExpr {
+    /// Build a query expression, deriving from `xpath` what its variables read.
+    pub fn new(xpath: impl Into<NormalizedXpath>, variables: tractor::QueryVariables) -> Self {
+        let xpath = xpath.into();
+        let variables =
+            tractor::EntryVariables::new(variables, tractor::EntryKind::Query, xpath.as_str());
+        QueryExpr { xpath, variables }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -359,7 +371,7 @@ mod tests {
         let ops = vec![OperationPlan::Query(QueryOperationPlan {
             sources: vec![disk_source(&path)],
             filters: Filters::default(),
-            queries: vec![QueryExpr { xpath: "//name".into(), variables: Default::default() }],
+            queries: vec![QueryExpr::new("//name", tractor::QueryVariables::new())],
             tree_mode: None,
             language: None,
             limit: None,
@@ -379,7 +391,7 @@ mod tests {
         let ops = vec![OperationPlan::Query(QueryOperationPlan {
             sources: vec![disk_source(&path)],
             filters: Filters::default(),
-            queries: vec![QueryExpr { xpath: "//*[number(.) > 0]".into(), variables: Default::default() }],
+            queries: vec![QueryExpr::new("//*[number(.) > 0]", tractor::QueryVariables::new())],
             tree_mode: None,
             language: None,
             limit: Some(2),
@@ -402,10 +414,10 @@ mod tests {
         let ops = vec![OperationPlan::Query(QueryOperationPlan {
             sources: vec![disk_source(&path)],
             filters: Filters::default(),
-            queries: vec![QueryExpr {
-                xpath: "//debug[$rule.variables?max > 1]".into(),
-                variables: Default::default(),
-            }],
+            queries: vec![QueryExpr::new(
+                "//debug[$rule.variables?max > 1]",
+                tractor::QueryVariables::new(),
+            )],
             tree_mode: None,
             language: None,
             limit: None,
@@ -464,7 +476,7 @@ mod tests {
         let ops = vec![OperationPlan::Query(QueryOperationPlan {
             sources: vec![],
             filters: Filters::default(),
-            queries: vec![QueryExpr { xpath: "//x".into(), variables: Default::default() }],
+            queries: vec![QueryExpr::new("//x", tractor::QueryVariables::new())],
             tree_mode: None,
             language: None,
             limit: None,

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -85,6 +85,9 @@ impl QueryOperation {
 pub struct QueryExpr {
     /// XPath expression to evaluate.
     pub xpath: NormalizedXpath,
+    /// Query-level variables, bound as the `$query.variables` map in this
+    /// expression (e.g. `//user[@role = $query.variables?role]`).
+    pub variables: std::sync::Arc<tractor::QueryVariables>,
 }
 
 // ---------------------------------------------------------------------------
@@ -105,16 +108,36 @@ pub(crate) fn execute_query(
         return Ok(());
     }
 
+    let variables = ctx.query_variables();
+
+    // Advisory: warn about variable lookups that silently yield the empty
+    // sequence (unknown keys, namespaces of other entry kinds).
+    for (i, query) in op.queries.iter().enumerate() {
+        report.add_all(crate::matcher::undefined_variable_key_diagnostics(
+            "query",
+            &format!("query {}", i + 1),
+            query.xpath.as_str(),
+            &variables,
+            Some(tractor::EntryKind::Query),
+            &query.variables,
+        ));
+    }
+
     if op.sources.is_empty() {
         return Ok(());
     }
 
-    let xpaths: Vec<&str> = op.queries.iter().map(|q| q.xpath.as_str()).collect();
+    let queries: Vec<(&str, Option<tractor::EntryContext>)> = op.queries.iter()
+        .map(|q| (
+            q.xpath.as_str(),
+            Some(tractor::EntryContext::query(std::sync::Arc::clone(&q.variables))),
+        ))
+        .collect();
 
     let matches = query_files_multi(
-        &op.sources, &xpaths, op.language.as_deref(),
+        &op.sources, &queries, op.language.as_deref(),
         op.tree_mode, op.ignore_whitespace, op.parse_depth,
-        op.limit, ctx.verbose, &op.filters, &ctx.query_variables(),
+        op.limit, ctx.verbose, &op.filters, &variables,
     )?;
 
     report.add_all(matches.into_iter().map(|m| match_to_report_match(m, "query")));
@@ -160,7 +183,7 @@ mod tests {
         let ops = vec![OperationPlan::Query(QueryOperationPlan {
             sources: vec![disk_source(&path)],
             filters: Filters::default(),
-            queries: vec![QueryExpr { xpath: "//name".into() }],
+            queries: vec![QueryExpr { xpath: "//name".into(), variables: Default::default() }],
             tree_mode: None,
             language: None,
             limit: None,
@@ -179,7 +202,7 @@ mod tests {
         let ops = vec![OperationPlan::Query(QueryOperationPlan {
             sources: vec![disk_source(&path)],
             filters: Filters::default(),
-            queries: vec![QueryExpr { xpath: "//*[number(.) > 0]".into() }],
+            queries: vec![QueryExpr { xpath: "//*[number(.) > 0]".into(), variables: Default::default() }],
             tree_mode: None,
             language: None,
             limit: Some(2),
@@ -190,12 +213,43 @@ mod tests {
         assert!(report.all_matches().len() <= 2);
     }
 
+    /// Referencing another entry kind's namespace (or $rule.id) in a query
+    /// produces an advisory warning — it silently evaluates against an
+    /// empty map there.
+    #[test]
+    fn query_warns_on_cross_namespace_reference() {
+        use tractor::report::Severity;
+
+        let (_dir, path) = temp_json_file(r#"{"debug": true}"#);
+        let ops = vec![OperationPlan::Query(QueryOperationPlan {
+            sources: vec![disk_source(&path)],
+            filters: Filters::default(),
+            queries: vec![QueryExpr {
+                xpath: "//debug[$rule.variables?max > 1]".into(),
+                variables: Default::default(),
+            }],
+            tree_mode: None,
+            language: None,
+            limit: None,
+            ignore_whitespace: false,
+            parse_depth: None,
+        })];
+        let report = run_query_ops(&ops);
+        let warnings: Vec<_> = report.all_matches().into_iter()
+            .filter(|m| m.severity == Some(Severity::Warning))
+            .collect();
+        assert_eq!(warnings.len(), 1, "{:?}", report.all_matches());
+        assert!(warnings[0].reason.as_deref().unwrap().contains("only bound in check rules"));
+        // The query itself still runs and matches nothing (empty lookup).
+        assert!(report.all_matches().iter().all(|m| m.severity == Some(Severity::Warning)));
+    }
+
     #[test]
     fn query_empty_sources() {
         let ops = vec![OperationPlan::Query(QueryOperationPlan {
             sources: vec![],
             filters: Filters::default(),
-            queries: vec![QueryExpr { xpath: "//x".into() }],
+            queries: vec![QueryExpr { xpath: "//x".into(), variables: Default::default() }],
             tree_mode: None,
             language: None,
             limit: None,

--- a/tractor/src/executor/query.rs
+++ b/tractor/src/executor/query.rs
@@ -180,36 +180,33 @@ pub(crate) fn execute_query(
         return Ok(());
     }
 
+    // The bindings each query runs with, built once and used for both the
+    // advisory pass and execution — what is diagnosed is what is bound.
     let variables = ctx.query_variables();
+    let queries: Vec<(&str, tractor::QueryBindings)> = op.queries.iter()
+        .map(|q| (
+            q.xpath.as_str(),
+            tractor::QueryBindings::run(std::sync::Arc::clone(&variables))
+                .with_entry(tractor::EntryContext::query(
+                    std::sync::Arc::clone(q.variables.declared()),
+                )),
+        ))
+        .collect();
 
     // Advisory: warn about variable lookups that silently yield the empty
     // sequence (unknown keys, namespaces of other entry kinds).
-    for (i, query) in op.queries.iter().enumerate() {
-        report.add_all(crate::matcher::undefined_variable_key_diagnostics(
-            "query",
-            &format!("query {}", i + 1),
-            query.xpath.as_str(),
-            &variables,
-            Some(tractor::EntryKind::Query),
-            &query.variables,
-        ));
+    for (i, (xpath, bindings)) in queries.iter().enumerate() {
+        report.add_all(crate::matcher::variable_diagnostics("query", bindings, i, xpath));
     }
 
     if op.sources.is_empty() {
         return Ok(());
     }
 
-    let queries: Vec<(&str, Option<tractor::EntryContext>)> = op.queries.iter()
-        .map(|q| (
-            q.xpath.as_str(),
-            Some(tractor::EntryContext::query(std::sync::Arc::clone(q.variables.declared()))),
-        ))
-        .collect();
-
     let matches = query_files_multi(
         &op.sources, &queries, op.language.as_deref(),
         op.tree_mode, op.ignore_whitespace, op.parse_depth,
-        op.limit, ctx.verbose, &op.filters, &variables,
+        op.limit, ctx.verbose, &op.filters,
     )?;
 
     if let Some(output) = &op.output {

--- a/tractor/src/executor/set.rs
+++ b/tractor/src/executor/set.rs
@@ -86,7 +86,24 @@ pub struct SetMapping {
     pub value_kind: Option<String>,
     /// Mapping-level variables, bound as the `$mapping.variables` map in
     /// this mapping's xpath (e.g. `//port[. = $mapping.variables?from]`).
+    /// Build via [`SetMapping::new`] so the variables' resolution flags
+    /// are always derived from the xpath that actually runs.
     pub variables: tractor::EntryVariables,
+}
+
+impl SetMapping {
+    /// Build a mapping, deriving from `xpath` what its variables read.
+    pub fn new(
+        xpath: impl Into<String>,
+        value: impl Into<String>,
+        value_kind: Option<String>,
+        variables: tractor::QueryVariables,
+    ) -> Self {
+        let xpath = xpath.into();
+        let variables =
+            tractor::EntryVariables::new(variables, tractor::EntryKind::Mapping, &xpath);
+        SetMapping { xpath, value: value.into(), value_kind, variables }
+    }
 }
 
 /// Write policy for set operations.
@@ -431,12 +448,7 @@ mod tests {
     }
 
     fn string_mapping(xpath: &str, value: &str) -> SetMapping {
-        SetMapping {
-            xpath: xpath.into(),
-            value: value.into(),
-            value_kind: Some("string".into()),
-            variables: Default::default(),
-        }
+        SetMapping::new(xpath, value, Some("string".into()), tractor::QueryVariables::new())
     }
 
     fn set_operation(path: String, mappings: Vec<SetMapping>, write_mode: SetWriteMode) -> OperationPlan {

--- a/tractor/src/executor/set.rs
+++ b/tractor/src/executor/set.rs
@@ -3,7 +3,7 @@
 use tractor::report::{ReportBuilder, ReportMatch, ReportOutput};
 use tractor::tree_mode::TreeMode;
 use tractor::{parse, ParseInput, ParseOptions, Match};
-use tractor::xpath_upsert::upsert_typed_with_variables;
+use tractor::xpath_upsert::upsert_typed;
 
 use crate::input::filter::Filters;
 use crate::input::source::SourceDisposition;
@@ -317,15 +317,14 @@ fn apply_set_mapping(
     variables: &std::sync::Arc<tractor::QueryVariables>,
 ) -> Result<SetMappingResult, Box<dyn std::error::Error>> {
     let entry = tractor::EntryContext::mapping(std::sync::Arc::clone(&mapping.variables));
-    match upsert_typed_with_variables(
+    match upsert_typed(
         source,
         lang,
         &mapping.xpath,
         &mapping.value,
         op.limit,
         mapping.value_kind.as_deref(),
-        variables,
-        Some(&entry),
+        tractor::QueryBindings::run(std::sync::Arc::clone(variables)).with_entry(entry),
     ) {
         Ok(result) => Ok(SetMappingResult {
             source: result.source,
@@ -387,8 +386,8 @@ fn query_set_matches(
             parse_depth: None,
         },
     )?;
-    result.variables = std::sync::Arc::clone(variables);
-    result.entry = Some(tractor::EntryContext::mapping(std::sync::Arc::clone(&mapping.variables)));
+    result.bindings.variables = std::sync::Arc::clone(variables);
+    result.bindings.entry = Some(tractor::EntryContext::mapping(std::sync::Arc::clone(&mapping.variables)));
     let mut matches = result.query(&mapping.xpath)?;
     if !filters.is_empty() {
         matches.retain(|m| filters.include(m));

--- a/tractor/src/executor/set.rs
+++ b/tractor/src/executor/set.rs
@@ -3,7 +3,7 @@
 use tractor::report::{ReportBuilder, ReportMatch, ReportOutput};
 use tractor::tree_mode::TreeMode;
 use tractor::{parse, ParseInput, ParseOptions, Match};
-use tractor::xpath_upsert::upsert_typed;
+use tractor::xpath_upsert::upsert_typed_with_variables;
 
 use crate::input::filter::Filters;
 use crate::input::source::SourceDisposition;
@@ -84,6 +84,9 @@ pub struct SetMapping {
     pub xpath: String,
     pub value: String,
     pub value_kind: Option<String>,
+    /// Mapping-level variables, bound as the `$mapping.variables` map in
+    /// this mapping's xpath (e.g. `//port[. = $mapping.variables?from]`).
+    pub variables: std::sync::Arc<tractor::QueryVariables>,
 }
 
 /// Write policy for set operations.
@@ -107,11 +110,28 @@ pub enum SetReportMode {
 
 pub(crate) fn execute_set(
     op: &SetOperationPlan,
-    _ctx: &ExecCtx<'_>,
+    ctx: &ExecCtx<'_>,
     report: &mut ReportBuilder,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if op.mappings.is_empty() {
         return Ok(());
+    }
+
+    // Run-level variables (bound as $variables); each mapping's own set is
+    // bound as $mapping.variables per query.
+    let variables = ctx.query_variables();
+
+    // Advisory: warn about variable lookups that silently yield the empty
+    // sequence (unknown keys, namespaces of other entry kinds).
+    for (i, mapping) in op.mappings.iter().enumerate() {
+        report.add_all(crate::matcher::undefined_variable_key_diagnostics(
+            "set",
+            &format!("mapping {}", i + 1),
+            &mapping.xpath,
+            &variables,
+            Some(tractor::EntryKind::Mapping),
+            &mapping.variables,
+        ));
     }
 
     for source in &op.sources {
@@ -151,6 +171,7 @@ pub(crate) fn execute_set(
             op,
             effective_write_mode,
             &op.filters,
+            &variables,
         )?;
 
         if outcome.changed
@@ -188,6 +209,7 @@ fn execute_set_target(
     op: &SetOperationPlan,
     effective_write_mode: SetWriteMode,
     filters: &Filters,
+    variables: &std::sync::Arc<tractor::QueryVariables>,
 ) -> Result<SetTargetOutcome, Box<dyn std::error::Error>> {
     let file_label = source.path_str();
     let lang = source.language.as_str();
@@ -197,12 +219,12 @@ fn execute_set_target(
 
     for mapping in &op.mappings {
         let before_matches = if matches!(op.report_mode, SetReportMode::PerMatch) {
-            query_set_matches(&current, file_label, lang, mapping, op, filters)?
+            query_set_matches(&current, file_label, lang, mapping, op, filters, variables)?
         } else {
             Vec::new()
         };
 
-        let result = apply_set_mapping(&current, file_label, lang, mapping, op, filters, &before_matches)?;
+        let result = apply_set_mapping(&current, file_label, lang, mapping, op, filters, &before_matches, variables)?;
         let was_modified = result.source != current;
         changed |= was_modified;
 
@@ -210,7 +232,7 @@ fn execute_set_target(
             let mut report_matches = if !result.matches.is_empty() {
                 result.matches
             } else if was_modified {
-                query_set_matches(&result.source, file_label, lang, mapping, op, filters)?
+                query_set_matches(&result.source, file_label, lang, mapping, op, filters, variables)?
             } else {
                 before_matches
             };
@@ -283,6 +305,7 @@ struct SetMappingResult {
     matches: Vec<Match>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn apply_set_mapping(
     source: &str,
     file_label: &str,
@@ -291,14 +314,18 @@ fn apply_set_mapping(
     op: &SetOperationPlan,
     filters: &Filters,
     before_matches: &[Match],
+    variables: &std::sync::Arc<tractor::QueryVariables>,
 ) -> Result<SetMappingResult, Box<dyn std::error::Error>> {
-    match upsert_typed(
+    let entry = tractor::EntryContext::mapping(std::sync::Arc::clone(&mapping.variables));
+    match upsert_typed_with_variables(
         source,
         lang,
         &mapping.xpath,
         &mapping.value,
         op.limit,
         mapping.value_kind.as_deref(),
+        variables,
+        Some(&entry),
     ) {
         Ok(result) => Ok(SetMappingResult {
             source: result.source,
@@ -316,7 +343,7 @@ fn apply_set_mapping(
             }
 
             let fallback_matches = if before_matches.is_empty() {
-                query_set_matches(source, file_label, lang, mapping, op, filters)?
+                query_set_matches(source, file_label, lang, mapping, op, filters, variables)?
             } else {
                 before_matches.to_vec()
             };
@@ -338,6 +365,7 @@ fn apply_set_mapping(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn query_set_matches(
     source: &str,
     file_label: &str,
@@ -345,6 +373,7 @@ fn query_set_matches(
     mapping: &SetMapping,
     op: &SetOperationPlan,
     filters: &Filters,
+    variables: &std::sync::Arc<tractor::QueryVariables>,
 ) -> Result<Vec<Match>, Box<dyn std::error::Error>> {
     let mut result = parse(
         ParseInput::Inline {
@@ -358,6 +387,8 @@ fn query_set_matches(
             parse_depth: None,
         },
     )?;
+    result.variables = std::sync::Arc::clone(variables);
+    result.entry = Some(tractor::EntryContext::mapping(std::sync::Arc::clone(&mapping.variables)));
     let mut matches = result.query(&mapping.xpath)?;
     if !filters.is_empty() {
         matches.retain(|m| filters.include(m));
@@ -405,6 +436,7 @@ mod tests {
             xpath: xpath.into(),
             value: value.into(),
             value_kind: Some("string".into()),
+            variables: Default::default(),
         }
     }
 

--- a/tractor/src/executor/set.rs
+++ b/tractor/src/executor/set.rs
@@ -86,7 +86,7 @@ pub struct SetMapping {
     pub value_kind: Option<String>,
     /// Mapping-level variables, bound as the `$mapping.variables` map in
     /// this mapping's xpath (e.g. `//port[. = $mapping.variables?from]`).
-    pub variables: std::sync::Arc<tractor::QueryVariables>,
+    pub variables: tractor::EntryVariables,
 }
 
 /// Write policy for set operations.
@@ -316,7 +316,7 @@ fn apply_set_mapping(
     before_matches: &[Match],
     variables: &std::sync::Arc<tractor::QueryVariables>,
 ) -> Result<SetMappingResult, Box<dyn std::error::Error>> {
-    let entry = tractor::EntryContext::mapping(std::sync::Arc::clone(&mapping.variables));
+    let entry = tractor::EntryContext::mapping(std::sync::Arc::clone(mapping.variables.declared()));
     match upsert_typed(
         source,
         lang,
@@ -387,7 +387,7 @@ fn query_set_matches(
         },
     )?;
     result.bindings.variables = std::sync::Arc::clone(variables);
-    result.bindings.entry = Some(tractor::EntryContext::mapping(std::sync::Arc::clone(&mapping.variables)));
+    result.bindings.entry = Some(tractor::EntryContext::mapping(std::sync::Arc::clone(mapping.variables.declared())));
     let mut matches = result.query(&mapping.xpath)?;
     if !filters.is_empty() {
         matches.retain(|m| filters.include(m));

--- a/tractor/src/executor/set.rs
+++ b/tractor/src/executor/set.rs
@@ -91,6 +91,19 @@ pub struct SetMapping {
     pub variables: tractor::EntryVariables,
 }
 
+/// The bindings a mapping's xpath runs with: the run-level `$variables`
+/// plus the mapping's own set as `$mapping.variables`. One definition, used
+/// by the advisory pass, the match query, and the upsert.
+fn mapping_bindings(
+    mapping: &SetMapping,
+    variables: &std::sync::Arc<tractor::QueryVariables>,
+) -> tractor::QueryBindings {
+    tractor::QueryBindings::run(std::sync::Arc::clone(variables))
+        .with_entry(tractor::EntryContext::mapping(
+            std::sync::Arc::clone(mapping.variables.declared()),
+        ))
+}
+
 impl SetMapping {
     /// Build a mapping, deriving from `xpath` what its variables read.
     pub fn new(
@@ -141,13 +154,8 @@ pub(crate) fn execute_set(
     // Advisory: warn about variable lookups that silently yield the empty
     // sequence (unknown keys, namespaces of other entry kinds).
     for (i, mapping) in op.mappings.iter().enumerate() {
-        report.add_all(crate::matcher::undefined_variable_key_diagnostics(
-            "set",
-            &format!("mapping {}", i + 1),
-            &mapping.xpath,
-            &variables,
-            Some(tractor::EntryKind::Mapping),
-            &mapping.variables,
+        report.add_all(crate::matcher::variable_diagnostics(
+            "set", &mapping_bindings(mapping, &variables), i, &mapping.xpath,
         ));
     }
 

--- a/tractor/src/executor/test.rs
+++ b/tractor/src/executor/test.rs
@@ -83,6 +83,9 @@ pub struct TestAssertion {
     pub xpath: NormalizedXpath,
     /// Expected match count: "none", "some", or a number.
     pub expect: String,
+    /// Assertion-level variables, bound as the `$assertion.variables` map
+    /// in this assertion (e.g. `count(//user) <= $assertion.variables?max`).
+    pub variables: std::sync::Arc<tractor::QueryVariables>,
 }
 
 // ---------------------------------------------------------------------------
@@ -94,6 +97,21 @@ pub(crate) fn execute_test(
     ctx: &ExecCtx<'_>,
     report: &mut ReportBuilder,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let variables = ctx.query_variables();
+
+    // Advisory: warn about variable lookups that silently yield the empty
+    // sequence (unknown keys, namespaces of other entry kinds).
+    for (i, assertion) in op.assertions.iter().enumerate() {
+        report.add_all(crate::matcher::undefined_variable_key_diagnostics(
+            "test",
+            &format!("assertion {}", i + 1),
+            assertion.xpath.as_str(),
+            &variables,
+            Some(tractor::EntryKind::Assertion),
+            &assertion.variables,
+        ));
+    }
+
     if op.sources.is_empty() {
         for assertion in &op.assertions {
             if !check_expectation(&assertion.expect, 0)? {
@@ -105,10 +123,11 @@ pub(crate) fn execute_test(
 
     // Query each assertion's xpath individually to get per-assertion counts.
     for assertion in &op.assertions {
+        let entry = tractor::EntryContext::assertion(std::sync::Arc::clone(&assertion.variables));
         let matches = query_files_multi(
-            &op.sources, &[assertion.xpath.as_str()], op.language.as_deref(),
+            &op.sources, &[(assertion.xpath.as_str(), Some(entry))], op.language.as_deref(),
             op.tree_mode, op.ignore_whitespace, op.parse_depth,
-            op.limit, ctx.verbose, &op.filters, &ctx.query_variables(),
+            op.limit, ctx.verbose, &op.filters, &variables,
         )?;
         if !check_expectation(&assertion.expect, matches.len())? {
             report.fail();

--- a/tractor/src/executor/test.rs
+++ b/tractor/src/executor/test.rs
@@ -113,18 +113,23 @@ pub(crate) fn execute_test(
     ctx: &ExecCtx<'_>,
     report: &mut ReportBuilder,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // The bindings each assertion runs with, built once and used for both
+    // the advisory pass and execution.
     let variables = ctx.query_variables();
+    let bindings: Vec<tractor::QueryBindings> = op.assertions.iter()
+        .map(|a| {
+            tractor::QueryBindings::run(std::sync::Arc::clone(&variables))
+                .with_entry(tractor::EntryContext::assertion(
+                    std::sync::Arc::clone(a.variables.declared()),
+                ))
+        })
+        .collect();
 
     // Advisory: warn about variable lookups that silently yield the empty
     // sequence (unknown keys, namespaces of other entry kinds).
     for (i, assertion) in op.assertions.iter().enumerate() {
-        report.add_all(crate::matcher::undefined_variable_key_diagnostics(
-            "test",
-            &format!("assertion {}", i + 1),
-            assertion.xpath.as_str(),
-            &variables,
-            Some(tractor::EntryKind::Assertion),
-            &assertion.variables,
+        report.add_all(crate::matcher::variable_diagnostics(
+            "test", &bindings[i], i, assertion.xpath.as_str(),
         ));
     }
 
@@ -138,12 +143,11 @@ pub(crate) fn execute_test(
     }
 
     // Query each assertion's xpath individually to get per-assertion counts.
-    for assertion in &op.assertions {
-        let entry = tractor::EntryContext::assertion(std::sync::Arc::clone(assertion.variables.declared()));
+    for (assertion, bindings) in op.assertions.iter().zip(bindings) {
         let matches = query_files_multi(
-            &op.sources, &[(assertion.xpath.as_str(), Some(entry))], op.language.as_deref(),
+            &op.sources, &[(assertion.xpath.as_str(), bindings)], op.language.as_deref(),
             op.tree_mode, op.ignore_whitespace, op.parse_depth,
-            op.limit, ctx.verbose, &op.filters, &variables,
+            op.limit, ctx.verbose, &op.filters,
         )?;
         if !check_expectation(&assertion.expect, matches.len())? {
             report.fail();

--- a/tractor/src/executor/test.rs
+++ b/tractor/src/executor/test.rs
@@ -108,7 +108,7 @@ pub(crate) fn execute_test(
         let matches = query_files_multi(
             &op.sources, &[assertion.xpath.as_str()], op.language.as_deref(),
             op.tree_mode, op.ignore_whitespace, op.parse_depth,
-            op.limit, ctx.verbose, &op.filters,
+            op.limit, ctx.verbose, &op.filters, &ctx.query_variables(),
         )?;
         if !check_expectation(&assertion.expect, matches.len())? {
             report.fail();

--- a/tractor/src/executor/test.rs
+++ b/tractor/src/executor/test.rs
@@ -85,7 +85,7 @@ pub struct TestAssertion {
     pub expect: String,
     /// Assertion-level variables, bound as the `$assertion.variables` map
     /// in this assertion (e.g. `count(//user) <= $assertion.variables?max`).
-    pub variables: std::sync::Arc<tractor::QueryVariables>,
+    pub variables: tractor::EntryVariables,
 }
 
 // ---------------------------------------------------------------------------
@@ -123,7 +123,7 @@ pub(crate) fn execute_test(
 
     // Query each assertion's xpath individually to get per-assertion counts.
     for assertion in &op.assertions {
-        let entry = tractor::EntryContext::assertion(std::sync::Arc::clone(&assertion.variables));
+        let entry = tractor::EntryContext::assertion(std::sync::Arc::clone(assertion.variables.declared()));
         let matches = query_files_multi(
             &op.sources, &[(assertion.xpath.as_str(), Some(entry))], op.language.as_deref(),
             op.tree_mode, op.ignore_whitespace, op.parse_depth,

--- a/tractor/src/executor/test.rs
+++ b/tractor/src/executor/test.rs
@@ -85,7 +85,23 @@ pub struct TestAssertion {
     pub expect: String,
     /// Assertion-level variables, bound as the `$assertion.variables` map
     /// in this assertion (e.g. `count(//user) <= $assertion.variables?max`).
+    /// Build via [`TestAssertion::new`] so the variables' resolution flags
+    /// are always derived from the xpath that actually runs.
     pub variables: tractor::EntryVariables,
+}
+
+impl TestAssertion {
+    /// Build an assertion, deriving from `xpath` what its variables read.
+    pub fn new(
+        xpath: impl Into<NormalizedXpath>,
+        expect: impl Into<String>,
+        variables: tractor::QueryVariables,
+    ) -> Self {
+        let xpath = xpath.into();
+        let variables =
+            tractor::EntryVariables::new(variables, tractor::EntryKind::Assertion, xpath.as_str());
+        TestAssertion { xpath, expect: expect.into(), variables }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tractor/src/executor/update.rs
+++ b/tractor/src/executor/update.rs
@@ -40,6 +40,15 @@ pub struct UpdateOperationPlan {
     pub ignore_whitespace: bool,
     /// Maximum parse depth.
     pub parse_depth: Option<usize>,
+    /// What `xpath` reads from the run-level `$variables`, recorded when the
+    /// plan is built.
+    ///
+    /// `update` has no config entries, so nothing else records its reads —
+    /// and an operation whose reads are unrecorded reads *nothing*, which
+    /// would silently omit any key it looks up. Deriving it here keeps the
+    /// operation inside the same mechanism as entries, with neither a
+    /// special case at execution nor a hole.
+    pub reads: tractor::NamespaceReads,
 }
 
 /// Pre-resolution shape for an update operation. Mirrors [`UpdateOperationPlan`]
@@ -71,6 +80,9 @@ impl UpdateOperation {
         UpdateOperationPlan {
             sources,
             filters,
+            // Derived from the expression that will run, at the one place a
+            // plan is built — the same rule the entry constructors follow.
+            reads: tractor::NamespaceReads::of(&self.xpath, "variables"),
             xpath: self.xpath,
             value: self.value,
             tree_mode: self.tree_mode,
@@ -79,6 +91,43 @@ impl UpdateOperation {
             ignore_whitespace: self.ignore_whitespace,
             parse_depth: self.parse_depth,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An update's reads are recorded when its plan is built, so the
+    /// run-level union covers it like any entry-bearing operation. Without
+    /// this, an update reading `$variables?x` would have empty reads and
+    /// the key would be silently omitted from its bindings.
+    #[test]
+    fn into_plan_records_what_the_xpath_reads() {
+        let op = UpdateOperation {
+            xpath: "//port[. = $variables?from]".to_string(),
+            value: "1".to_string(),
+            tree_mode: None,
+            language: None,
+            limit: None,
+            ignore_whitespace: false,
+            parse_depth: None,
+        };
+        let plan = op.into_plan(Vec::new(), Filters::default());
+        assert!(plan.reads.reads("from"), "the looked-up key must be recorded");
+        assert!(!plan.reads.reads("other"));
+
+        let op = UpdateOperation {
+            xpath: "//port".to_string(),
+            value: "1".to_string(),
+            tree_mode: None,
+            language: None,
+            limit: None,
+            ignore_whitespace: false,
+            parse_depth: None,
+        };
+        let plan = op.into_plan(Vec::new(), Filters::default());
+        assert!(!plan.reads.reads_any(), "an xpath reading nothing records nothing");
     }
 }
 

--- a/tractor/src/executor/update.rs
+++ b/tractor/src/executor/update.rs
@@ -93,17 +93,10 @@ pub(crate) fn execute_update(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let variables = ctx.query_variables();
 
-    // Advisory: warn about variable lookups that silently yield the empty
-    // sequence. Update runs outside any operation entry, so every
-    // `$<entry>.variables` namespace is an empty map here.
-    report.add_all(crate::matcher::undefined_variable_key_diagnostics(
-        "update",
-        "update",
-        &op.xpath,
-        &variables,
-        None,
-        &tractor::QueryVariables::new(),
-    ));
+    // Advisory: update has no config entry, so every `$<entry>.variables` namespace is
+    // an empty map here — the advisory says so rather than leaving it silent.
+    let bindings = tractor::QueryBindings::run(std::sync::Arc::clone(&variables));
+    report.add_all(crate::matcher::variable_diagnostics("update", &bindings, 0, &op.xpath));
 
     let mut fallback_sources: Vec<Source> = Vec::new();
 
@@ -117,7 +110,7 @@ pub(crate) fn execute_update(
         let file_path: &NormalizedPath = &source.path;
         let disk_bytes = std::fs::read_to_string(file_path)?;
 
-        match update_only(&disk_bytes, lang, &op.xpath, &op.value, op.limit, tractor::QueryBindings::run(std::sync::Arc::clone(&variables))) {
+        match update_only(&disk_bytes, lang, &op.xpath, &op.value, op.limit, bindings.clone()) {
             Ok(result) => {
                 if result.source != disk_bytes {
                     std::fs::write(file_path, &result.source)?;
@@ -138,9 +131,9 @@ pub(crate) fn execute_update(
     // Legacy fallback for languages without renderers
     if !fallback_sources.is_empty() {
         let matches = query_files_multi(
-            &fallback_sources, &[(op.xpath.as_str(), None)], op.language.as_deref(),
+            &fallback_sources, &[(op.xpath.as_str(), bindings.clone())], op.language.as_deref(),
             op.tree_mode, op.ignore_whitespace, op.parse_depth,
-            None, ctx.verbose, &op.filters, &variables,
+            None, ctx.verbose, &op.filters,
         )?;
         if !matches.is_empty() {
             let summary = apply_replacements(&matches, &op.value)?;

--- a/tractor/src/executor/update.rs
+++ b/tractor/src/executor/update.rs
@@ -3,7 +3,7 @@
 use tractor::report::{ReportBuilder, ReportMatch};
 use tractor::tree_mode::TreeMode;
 use tractor::{apply_replacements, NormalizedPath};
-use tractor::xpath_upsert::update_only;
+use tractor::xpath_upsert::update_only_with_variables;
 
 use crate::input::filter::Filters;
 use crate::input::Source;
@@ -91,6 +91,20 @@ pub(crate) fn execute_update(
     ctx: &ExecCtx<'_>,
     report: &mut ReportBuilder,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let variables = ctx.query_variables();
+
+    // Advisory: warn about variable lookups that silently yield the empty
+    // sequence. Update runs outside any operation entry, so every
+    // `$<entry>.variables` namespace is an empty map here.
+    report.add_all(crate::matcher::undefined_variable_key_diagnostics(
+        "update",
+        "update",
+        &op.xpath,
+        &variables,
+        None,
+        &tractor::QueryVariables::new(),
+    ));
+
     let mut fallback_sources: Vec<Source> = Vec::new();
 
     for source in &op.sources {
@@ -103,7 +117,7 @@ pub(crate) fn execute_update(
         let file_path: &NormalizedPath = &source.path;
         let disk_bytes = std::fs::read_to_string(file_path)?;
 
-        match update_only(&disk_bytes, lang, &op.xpath, &op.value, op.limit) {
+        match update_only_with_variables(&disk_bytes, lang, &op.xpath, &op.value, op.limit, &variables, None) {
             Ok(result) => {
                 if result.source != disk_bytes {
                     std::fs::write(file_path, &result.source)?;
@@ -124,9 +138,9 @@ pub(crate) fn execute_update(
     // Legacy fallback for languages without renderers
     if !fallback_sources.is_empty() {
         let matches = query_files_multi(
-            &fallback_sources, &[op.xpath.as_str()], op.language.as_deref(),
+            &fallback_sources, &[(op.xpath.as_str(), None)], op.language.as_deref(),
             op.tree_mode, op.ignore_whitespace, op.parse_depth,
-            None, ctx.verbose, &op.filters, &ctx.query_variables(),
+            None, ctx.verbose, &op.filters, &variables,
         )?;
         if !matches.is_empty() {
             let summary = apply_replacements(&matches, &op.value)?;

--- a/tractor/src/executor/update.rs
+++ b/tractor/src/executor/update.rs
@@ -126,7 +126,7 @@ pub(crate) fn execute_update(
         let matches = query_files_multi(
             &fallback_sources, &[op.xpath.as_str()], op.language.as_deref(),
             op.tree_mode, op.ignore_whitespace, op.parse_depth,
-            None, ctx.verbose, &op.filters,
+            None, ctx.verbose, &op.filters, &ctx.query_variables(),
         )?;
         if !matches.is_empty() {
             let summary = apply_replacements(&matches, &op.value)?;

--- a/tractor/src/executor/update.rs
+++ b/tractor/src/executor/update.rs
@@ -3,7 +3,7 @@
 use tractor::report::{ReportBuilder, ReportMatch};
 use tractor::tree_mode::TreeMode;
 use tractor::{apply_replacements, NormalizedPath};
-use tractor::xpath_upsert::update_only_with_variables;
+use tractor::xpath_upsert::update_only;
 
 use crate::input::filter::Filters;
 use crate::input::Source;
@@ -117,7 +117,7 @@ pub(crate) fn execute_update(
         let file_path: &NormalizedPath = &source.path;
         let disk_bytes = std::fs::read_to_string(file_path)?;
 
-        match update_only_with_variables(&disk_bytes, lang, &op.xpath, &op.value, op.limit, &variables, None) {
+        match update_only(&disk_bytes, lang, &op.xpath, &op.value, op.limit, tractor::QueryBindings::run(std::sync::Arc::clone(&variables))) {
             Ok(result) => {
                 if result.source != disk_bytes {
                     std::fs::write(file_path, &result.source)?;

--- a/tractor/src/format/options.rs
+++ b/tractor/src/format/options.rs
@@ -62,6 +62,32 @@ impl OutputFormat {
         )
     }
 
+    /// Whether this format can render a given view field at all.
+    ///
+    /// The structured formats render everything. The line-oriented and hook
+    /// formats carry only a location plus a one-line message, so structural
+    /// fields have nowhere to go — requesting one is silently a no-op, which
+    /// reads as "tractor lost my data". [`normalize_output_plan`] turns an
+    /// explicit request for such a field into a warning.
+    ///
+    /// [`normalize_output_plan`]: super::normalize_output_plan
+    pub fn can_render_field(&self, field: ViewField) -> bool {
+        match self {
+            OutputFormat::Text | OutputFormat::Json | OutputFormat::Yaml | OutputFormat::Xml => true,
+            // `file:line:col: severity: detail` — plus source lines for
+            // diagnostics. No tree, no schema, and the matched source text
+            // never appears (only whole lines do).
+            OutputFormat::Gcc => !matches!(field, ViewField::Tree | ViewField::Schema | ViewField::Source),
+            // `::error file=...::message` — the message embeds the matched
+            // source for diagnostics, but nothing structural.
+            OutputFormat::Github => !matches!(field, ViewField::Tree | ViewField::Schema),
+            // Hook JSON: a decision plus a message string.
+            OutputFormat::ClaudeCode => {
+                !matches!(field, ViewField::Tree | ViewField::Schema | ViewField::Source)
+            }
+        }
+    }
+
     /// Full `long_help` text for the `-f` / `--format` flag.
     pub fn format_long_help(default: &str) -> String {
         let mut lines = vec![format!("Output format [default: {default}]")];
@@ -584,6 +610,29 @@ mod tests {
 
         assert!(parsed.resolved.fields.is_empty());
         assert!(parsed.explicit_fields.is_empty());
+    }
+
+    #[test]
+    fn can_render_field_marks_structural_fields_unrenderable_in_flat_formats() {
+        // Structured formats render everything.
+        for format in [OutputFormat::Text, OutputFormat::Json, OutputFormat::Yaml, OutputFormat::Xml] {
+            assert!(format.can_render_field(ViewField::Tree), "{:?}", format);
+            assert!(format.can_render_field(ViewField::Schema), "{:?}", format);
+            assert!(format.can_render_field(ViewField::Source), "{:?}", format);
+        }
+        // Flat formats have nowhere to put structure...
+        assert!(!OutputFormat::Gcc.can_render_field(ViewField::Tree));
+        assert!(!OutputFormat::Gcc.can_render_field(ViewField::Schema));
+        assert!(!OutputFormat::Gcc.can_render_field(ViewField::Source));
+        assert!(!OutputFormat::Github.can_render_field(ViewField::Tree));
+        assert!(!OutputFormat::ClaudeCode.can_render_field(ViewField::Tree));
+        // ...but still carry location, severity, and message-ish fields.
+        assert!(OutputFormat::Gcc.can_render_field(ViewField::Value));
+        assert!(OutputFormat::Gcc.can_render_field(ViewField::Reason));
+        assert!(OutputFormat::Gcc.can_render_field(ViewField::Lines));
+        assert!(OutputFormat::Gcc.can_render_field(ViewField::File));
+        // github embeds the matched source in its annotation message.
+        assert!(OutputFormat::Github.can_render_field(ViewField::Source));
     }
 
     #[test]

--- a/tractor/src/format/projection.rs
+++ b/tractor/src/format/projection.rs
@@ -194,6 +194,26 @@ pub fn normalize_output_plan(
     }
 
     let mut warnings = Vec::new();
+
+    // Explicitly-requested fields the chosen format cannot express (e.g.
+    // `-v tree -f gcc`). Silently dropping them looks like lost data — the
+    // reason a variables/tree dump appears empty in `run`'s default gcc
+    // output. Defaults are exempt: only what the user asked for warns.
+    let unrenderable: Vec<&'static str> = view
+        .explicit_fields
+        .iter()
+        .filter(|&&field| !output_format.can_render_field(field))
+        .map(|field| field.name())
+        .collect();
+    if !unrenderable.is_empty() {
+        warnings.push(format!(
+            "warning: requested view items {{{}}} cannot be rendered by -f {}.\n  Use `-f text` or `-f json` to see {}.",
+            unrenderable.join(", "),
+            output_format.name(),
+            if unrenderable.len() == 1 { "it" } else { "them" },
+        ));
+    }
+
     let explicit_items = explicit_items(&view, message.is_some());
 
     if let Some(replacement) = projection.view_replacement_field() {
@@ -300,6 +320,77 @@ mod tests {
         ParsedViewSet {
             resolved: ViewSet::new(resolved.to_vec()),
             explicit_fields: explicit.to_vec(),
+        }
+    }
+
+    /// `-v tree -f gcc` warns instead of silently rendering nothing — the
+    /// line-oriented formats have nowhere to put a tree.
+    #[test]
+    fn unrenderable_view_fields_warn_for_line_oriented_formats() {
+        let plan = normalize_output_plan(
+            None,
+            false,
+            None,
+            parsed_view(&[ViewField::Tree], &[ViewField::Tree]),
+            None,
+            OutputFormat::Gcc,
+            false,
+        )
+        .unwrap();
+        assert_eq!(plan.warnings.len(), 1, "{:?}", plan.warnings);
+        assert!(plan.warnings[0].contains("{tree}"), "{}", plan.warnings[0]);
+        assert!(plan.warnings[0].contains("-f gcc"), "{}", plan.warnings[0]);
+        assert!(plan.warnings[0].contains("-f text"), "{}", plan.warnings[0]);
+
+        // Several at once are listed together.
+        let plan = normalize_output_plan(
+            None,
+            false,
+            None,
+            parsed_view(
+                &[ViewField::Tree, ViewField::Source, ViewField::Value],
+                &[ViewField::Tree, ViewField::Source, ViewField::Value],
+            ),
+            None,
+            OutputFormat::Gcc,
+            false,
+        )
+        .unwrap();
+        assert_eq!(plan.warnings.len(), 1);
+        assert!(plan.warnings[0].contains("{tree, source}"), "{}", plan.warnings[0]);
+        assert!(!plan.warnings[0].contains("value"), "gcc renders value: {}", plan.warnings[0]);
+    }
+
+    /// Only *explicitly requested* fields warn — a command's default view
+    /// must never produce noise, and structured formats render everything.
+    #[test]
+    fn unrenderable_warning_skips_defaults_and_structured_formats() {
+        // Tree present in the resolved view but not explicitly requested.
+        let plan = normalize_output_plan(
+            None,
+            false,
+            None,
+            parsed_view(&[ViewField::Tree, ViewField::Value], &[]),
+            None,
+            OutputFormat::Gcc,
+            false,
+        )
+        .unwrap();
+        assert!(plan.warnings.is_empty(), "{:?}", plan.warnings);
+
+        // Same explicit request against a structured format: no warning.
+        for format in [OutputFormat::Text, OutputFormat::Json, OutputFormat::Yaml, OutputFormat::Xml] {
+            let plan = normalize_output_plan(
+                None,
+                false,
+                None,
+                parsed_view(&[ViewField::Tree], &[ViewField::Tree]),
+                None,
+                format,
+                false,
+            )
+            .unwrap();
+            assert!(plan.warnings.is_empty(), "{:?} warned: {:?}", format, plan.warnings);
         }
     }
 

--- a/tractor/src/lib.rs
+++ b/tractor/src/lib.rs
@@ -108,4 +108,4 @@ pub use glob_match::CompiledPattern;
 #[cfg(feature = "native")]
 pub use glob_match::{expand_canonical, pattern_literal_prefix, FilePrune, GlobExpandError};
 pub use tree_mode::TreeMode;
-pub use variables::{QueryVariables, VariableValue, EntryContext, EntryKind, EntryVariables, QueryBindings};
+pub use variables::{QueryVariables, VariableValue, EntryContext, EntryKind, EntryVariables, NamespaceReads, QueryBindings, VariableReads};

--- a/tractor/src/lib.rs
+++ b/tractor/src/lib.rs
@@ -108,4 +108,4 @@ pub use glob_match::CompiledPattern;
 #[cfg(feature = "native")]
 pub use glob_match::{expand_canonical, pattern_literal_prefix, FilePrune, GlobExpandError};
 pub use tree_mode::TreeMode;
-pub use variables::{QueryVariables, VariableValue, EntryContext, EntryKind, QueryBindings};
+pub use variables::{QueryVariables, VariableValue, EntryContext, EntryKind, EntryVariables, QueryBindings};

--- a/tractor/src/lib.rs
+++ b/tractor/src/lib.rs
@@ -108,4 +108,4 @@ pub use glob_match::CompiledPattern;
 #[cfg(feature = "native")]
 pub use glob_match::{expand_canonical, pattern_literal_prefix, FilePrune, GlobExpandError};
 pub use tree_mode::TreeMode;
-pub use variables::{QueryVariables, VariableValue};
+pub use variables::{QueryVariables, VariableValue, EntryContext, EntryKind};

--- a/tractor/src/lib.rs
+++ b/tractor/src/lib.rs
@@ -108,4 +108,4 @@ pub use glob_match::CompiledPattern;
 #[cfg(feature = "native")]
 pub use glob_match::{expand_canonical, pattern_literal_prefix, FilePrune, GlobExpandError};
 pub use tree_mode::TreeMode;
-pub use variables::{QueryVariables, VariableValue, EntryContext, EntryKind};
+pub use variables::{QueryVariables, VariableValue, EntryContext, EntryKind, QueryBindings};

--- a/tractor/src/lib.rs
+++ b/tractor/src/lib.rs
@@ -58,6 +58,7 @@ pub use model::report;
 pub use model::rule;
 pub use model::tree_mode;
 pub use model::normalized_xpath;
+pub use model::variables;
 
 // glob/ modules
 pub use glob::matching as glob_match;
@@ -107,3 +108,4 @@ pub use glob_match::CompiledPattern;
 #[cfg(feature = "native")]
 pub use glob_match::{expand_canonical, pattern_literal_prefix, FilePrune, GlobExpandError};
 pub use tree_mode::TreeMode;
+pub use variables::{QueryVariables, VariableValue};

--- a/tractor/src/matcher.rs
+++ b/tractor/src/matcher.rs
@@ -372,7 +372,7 @@ pub fn run_rules(
             // $rule.id.
             for rule_idx in applicable {
                 result.bindings.entry = Some(tractor::EntryContext::rule(
-                    std::sync::Arc::clone(&rules[rule_idx].variables),
+                    std::sync::Arc::clone(rules[rule_idx].variables.declared()),
                     rules[rule_idx].id.clone(),
                 ));
                 match result.query(rules[rule_idx].xpath.as_str()) {

--- a/tractor/src/matcher.rs
+++ b/tractor/src/matcher.rs
@@ -8,6 +8,7 @@ use tractor::{
     parse, ParseInput, ParseOptions,
     report::{Report, ReportMatch, Severity, DiagnosticOrigin},
     rule::CompiledRule,
+    variables::QueryVariables,
     xpath::validate_xpath,
 };
 use crate::input::filter::Filters;
@@ -61,6 +62,72 @@ pub fn validate_xpath_diagnostic(xpath_expr: &NormalizedXpath, command: &str) ->
         status: None,
         output: None,
     })
+}
+
+/// Advisory check: warn about literal `$variables?key` / `$rule.variables?key`
+/// lookups whose key is not defined in the corresponding variable set.
+///
+/// A missing key is legal XPath — the lookup yields the empty sequence, and
+/// rules may rely on that (optional flags, `(lookup, default)[1]` idioms) —
+/// so this produces `Severity::Warning` diagnostics that never fail the run.
+/// Only literal keys are checked; dynamic lookups (`?($expr)`, `?*`) are
+/// skipped. Nested keys (`$variables?limits?max`) are checked at the top
+/// level only.
+pub fn undefined_variable_key_diagnostics(
+    rule_id: &str,
+    xpath_expr: &NormalizedXpath,
+    run_variables: &QueryVariables,
+    rule_variables: &QueryVariables,
+) -> Vec<ReportMatch> {
+    use once_cell::sync::Lazy;
+    use regex::Regex;
+
+    // NCName-ish key after the lookup operator. `$rule\.variables` is matched
+    // first so the plain `\$variables` pattern can't fire inside it (the
+    // preceding char there is `.`, not `$`, so it can't anyway).
+    static RUN_LOOKUP: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"\$variables\s*\?\s*([A-Za-z_][A-Za-z0-9_.\-]*)").unwrap());
+    static RULE_LOOKUP: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"\$rule\.variables\s*\?\s*([A-Za-z_][A-Za-z0-9_.\-]*)").unwrap());
+
+    let xpath = xpath_expr.as_str();
+    let mut diagnostics = Vec::new();
+
+    let mut check = |re: &Regex, defined: &QueryVariables, scope: &str| {
+        for caps in re.captures_iter(xpath) {
+            let key = caps.get(1).unwrap();
+            if defined.get(key.as_str()).is_some() {
+                continue;
+            }
+            diagnostics.push(ReportMatch {
+                file: String::new(),
+                line: 1,
+                column: key.start() as u32 + 1,
+                end_line: 1,
+                end_column: key.end() as u32 + 1,
+                command: "check".to_string(),
+                tree: None,
+                value: None,
+                source: Some(xpath.to_string()),
+                lines: Some(vec![xpath.to_string()]),
+                reason: Some(format!(
+                    "[{}] unknown variable key '{}': not defined {} (the lookup yields the empty sequence)",
+                    rule_id, key.as_str(), scope,
+                )),
+                severity: Some(Severity::Warning),
+                message: None,
+                origin: Some(DiagnosticOrigin::Xpath),
+                rule_id: Some(rule_id.to_string()),
+                status: None,
+                output: None,
+            });
+        }
+    };
+
+    check(&RUN_LOOKUP, run_variables, "under the config's `variables:`");
+    check(&RULE_LOOKUP, rule_variables, "in this rule's `variables:`");
+
+    diagnostics
 }
 
 // ---------------------------------------------------------------------------
@@ -189,6 +256,10 @@ fn rule_language_matches_source(
 /// - The source's pre-resolved language (from `-l` or extension detection)
 ///
 /// `verbose` controls whether parse/query warnings are printed to stderr.
+///
+/// `variables` is the run-level variable set (bound as `$variables`); each
+/// rule's own `variables` field is bound as `$rule.variables` per query.
+#[allow(clippy::too_many_arguments)] // execution knobs + the run-level variables
 pub fn run_rules(
     rules: &[CompiledRule],
     sources: &[Source],
@@ -197,6 +268,7 @@ pub fn run_rules(
     parse_depth: Option<usize>,
     verbose: bool,
     filters: &Filters,
+    variables: &std::sync::Arc<QueryVariables>,
 ) -> Result<Vec<RuleMatch>, Box<dyn std::error::Error>> {
     // Process sources in parallel. Each source is parsed once using either:
     // - The source's detected language (when no rules specify a language override)
@@ -245,11 +317,16 @@ pub fn run_rules(
                     return None;
                 }
             };
+            result.variables = std::sync::Arc::clone(variables);
 
             let mut file_matches = Vec::new();
 
-            // Run all applicable rules against the parsed result
+            // Run all applicable rules against the parsed result, binding
+            // each rule's own variables as $rule.variables and its id as
+            // $rule.id.
             for rule_idx in applicable {
+                result.rule_variables = std::sync::Arc::clone(&rules[rule_idx].variables);
+                result.rule_id = Some(rules[rule_idx].id.clone());
                 match result.query(rules[rule_idx].xpath.as_str()) {
                     Ok(matches) => {
                         for m in matches {
@@ -412,6 +489,39 @@ mod tests {
     use tractor::NormalizedXpath;
 
     #[test]
+    fn undefined_key_diagnostics_extraction() {
+        use tractor::variables::{QueryVariables, VariableValue};
+
+        let mut run_vars = QueryVariables::new();
+        run_vars.insert("env", VariableValue::String("prod".into()));
+        run_vars.insert("limits", VariableValue::Map(Default::default()));
+        let mut rule_vars = QueryVariables::new();
+        rule_vars.insert("prefixes", VariableValue::Array(vec![]));
+
+        // Defined keys, wildcard expansion, and nested lookups: no warnings.
+        // (`limits?max` is checked at the top level only.)
+        let xpath = NormalizedXpath::new(
+            "//a[$variables?env = 'p' and $variables?limits?max > 1 \
+             and (some $p in $rule.variables?prefixes?* satisfies starts-with(., $p))]",
+        );
+        assert!(undefined_variable_key_diagnostics("r", &xpath, &run_vars, &rule_vars).is_empty());
+
+        // Undefined keys in both namespaces: one warning each, correct scope.
+        let xpath = NormalizedXpath::new("//a[$variables?evn or $rule.variables?prefix]");
+        let diags = undefined_variable_key_diagnostics("r", &xpath, &run_vars, &rule_vars);
+        assert_eq!(diags.len(), 2);
+        assert!(diags[0].reason.as_deref().unwrap().contains("'evn'"));
+        assert!(diags[0].reason.as_deref().unwrap().contains("config's"));
+        assert!(diags[1].reason.as_deref().unwrap().contains("'prefix'"));
+        assert!(diags[1].reason.as_deref().unwrap().contains("rule's"));
+        assert!(diags.iter().all(|d| d.severity == Some(Severity::Warning)));
+
+        // Dynamic lookups are skipped
+        let xpath = NormalizedXpath::new("//a[$variables?($name) or $variables?*]");
+        assert!(undefined_variable_key_diagnostics("r", &xpath, &run_vars, &rule_vars).is_empty());
+    }
+
+    #[test]
     fn test_language_parsing() {
         // Test that language parsing handles aliases correctly
         assert_eq!(parse_language("js"), Language::JavaScript);
@@ -554,6 +664,7 @@ mod tests {
             ignore_whitespace: false,
             verbose: false,
             base_dir: None,
+            variables: std::sync::Arc::default(),
             lang: None,
             debug: false,
             group_by: vec![],

--- a/tractor/src/matcher.rs
+++ b/tractor/src/matcher.rs
@@ -363,7 +363,7 @@ pub fn run_rules(
                     return None;
                 }
             };
-            result.variables = std::sync::Arc::clone(variables);
+            result.bindings.variables = std::sync::Arc::clone(variables);
 
             let mut file_matches = Vec::new();
 
@@ -371,7 +371,7 @@ pub fn run_rules(
             // each rule's own variables as $rule.variables and its id as
             // $rule.id.
             for rule_idx in applicable {
-                result.entry = Some(tractor::EntryContext::rule(
+                result.bindings.entry = Some(tractor::EntryContext::rule(
                     std::sync::Arc::clone(&rules[rule_idx].variables),
                     rules[rule_idx].id.clone(),
                 ));

--- a/tractor/src/matcher.rs
+++ b/tractor/src/matcher.rs
@@ -8,7 +8,7 @@ use tractor::{
     parse, ParseInput, ParseOptions,
     report::{Report, ReportMatch, Severity, DiagnosticOrigin},
     rule::CompiledRule,
-    variables::{EntryKind, QueryVariables},
+    variables::{EntryKind, QueryBindings, QueryVariables},
     xpath::validate_xpath,
 };
 use crate::input::filter::Filters;
@@ -76,19 +76,35 @@ pub fn validate_xpath_diagnostic(xpath_expr: &NormalizedXpath, command: &str) ->
 /// skipped. Nested keys (`$variables?limits?max`) are checked at the top
 /// level only.
 ///
-/// `label` names the entry in messages (the rule id, or e.g. "mapping 1");
-/// `entry_kind` is the current entry's kind (`None` outside any entry, e.g.
-/// CLI update) and `entry_variables` its `variables:`.
-pub fn undefined_variable_key_diagnostics(
+/// Driven by the same [`QueryBindings`] the query will actually run with, so
+/// what is diagnosed and what is bound cannot drift apart. Everything else
+/// is derived: the entry's kind and variables from `bindings.entry`, and its
+/// label from the entry's id or, for entries without one, its kind plus
+/// `index` (`mapping 2`). `command` names the operation, which owns no
+/// entry of its own (CLI `update`).
+pub fn variable_diagnostics(
     command: &str,
-    label: &str,
+    bindings: &QueryBindings,
+    index: usize,
     xpath: &str,
-    run_variables: &QueryVariables,
-    entry_kind: Option<EntryKind>,
-    entry_variables: &QueryVariables,
 ) -> Vec<ReportMatch> {
     use once_cell::sync::Lazy;
     use regex::Regex;
+
+    let entry_kind = bindings.entry.as_ref().map(|e| e.kind);
+    let run_variables = &*bindings.variables;
+    let empty = QueryVariables::new();
+    let entry_variables = bindings.entry.as_ref().map_or(&empty, |e| &*e.variables);
+    // Entries name themselves when they can (a rule id); the rest are
+    // identified by position, the way the config reads.
+    let label = match bindings.entry.as_ref() {
+        Some(entry) => entry
+            .id
+            .clone()
+            .unwrap_or_else(|| format!("{} {}", entry.kind.label(), index + 1)),
+        None => command.to_string(),
+    };
+    let label = label.as_str();
 
     // NCName-ish key after the lookup operator. The plain `\$variables`
     // pattern can't fire inside `$rule.variables` etc. — the character
@@ -314,7 +330,7 @@ pub fn run_rules(
     parse_depth: Option<usize>,
     verbose: bool,
     filters: &Filters,
-    variables: &std::sync::Arc<QueryVariables>,
+    bindings: &QueryBindings,
 ) -> Result<Vec<RuleMatch>, Box<dyn std::error::Error>> {
     // Process sources in parallel. Each source is parsed once using either:
     // - The source's detected language (when no rules specify a language override)
@@ -363,15 +379,13 @@ pub fn run_rules(
                     return None;
                 }
             };
-            result.bindings.variables = std::sync::Arc::clone(variables);
-
             let mut file_matches = Vec::new();
 
-            // Run all applicable rules against the parsed result, binding
-            // each rule's own variables as $rule.variables and its id as
-            // $rule.id.
+            // Run all applicable rules against the parsed result. Each rule
+            // swaps in its own entry — its variables as $rule.variables and
+            // its id as $rule.id — over the shared run-level bindings.
             for rule_idx in applicable {
-                result.bindings.entry = Some(tractor::EntryContext::rule(
+                result.bindings = bindings.clone().with_entry(tractor::EntryContext::rule(
                     std::sync::Arc::clone(rules[rule_idx].variables.declared()),
                     rules[rule_idx].id.clone(),
                 ));
@@ -536,6 +550,18 @@ mod tests {
     use tractor::language_info::Language;
     use tractor::NormalizedXpath;
 
+    use tractor::variables::EntryContext;
+
+    /// Bindings for the advisory tests: run-level variables plus an
+    /// optional entry, exactly as an executor assembles them.
+    fn bindings(run: &QueryVariables, entry: Option<EntryContext>) -> QueryBindings {
+        let b = QueryBindings::run(std::sync::Arc::new(run.clone()));
+        match entry {
+            Some(e) => b.with_entry(e),
+            None => b,
+        }
+    }
+
     #[test]
     fn undefined_key_diagnostics_extraction() {
         use tractor::variables::{QueryVariables, VariableValue};
@@ -550,15 +576,14 @@ mod tests {
         // (`limits?max` is checked at the top level only.)
         let xpath = "//a[$variables?env = 'p' and $variables?limits?max > 1 \
              and (some $p in $rule.variables?prefixes?* satisfies starts-with(., $p))]";
-        assert!(undefined_variable_key_diagnostics(
-            "check", "r", xpath, &run_vars, Some(EntryKind::Rule), &rule_vars,
-        ).is_empty());
+        let rule = |v: &QueryVariables| {
+            bindings(&run_vars, Some(EntryContext::rule(std::sync::Arc::new(v.clone()), "r")))
+        };
+        assert!(variable_diagnostics("check", &rule(&rule_vars), 0, xpath).is_empty());
 
         // Undefined keys in both namespaces: one warning each, correct scope.
         let xpath = "//a[$variables?evn or $rule.variables?prefix]";
-        let diags = undefined_variable_key_diagnostics(
-            "check", "r", xpath, &run_vars, Some(EntryKind::Rule), &rule_vars,
-        );
+        let diags = variable_diagnostics("check", &rule(&rule_vars), 0, xpath);
         assert_eq!(diags.len(), 2);
         assert!(diags[0].reason.as_deref().unwrap().contains("'evn'"));
         assert!(diags[0].reason.as_deref().unwrap().contains("config's"));
@@ -568,9 +593,7 @@ mod tests {
 
         // Dynamic lookups are skipped
         let xpath = "//a[$variables?($name) or $variables?*]";
-        assert!(undefined_variable_key_diagnostics(
-            "check", "r", xpath, &run_vars, Some(EntryKind::Rule), &rule_vars,
-        ).is_empty());
+        assert!(variable_diagnostics("check", &rule(&rule_vars), 0, xpath).is_empty());
     }
 
     #[test]
@@ -583,16 +606,16 @@ mod tests {
 
         // The current entry's namespace checks keys; a defined key is fine.
         let xpath = "//port[. = $mapping.variables?from]";
-        assert!(undefined_variable_key_diagnostics(
-            "set", "mapping 1", xpath, &run_vars, Some(EntryKind::Mapping), &mapping_vars,
-        ).is_empty());
+        let mapping = bindings(
+            &run_vars,
+            Some(EntryContext::mapping(std::sync::Arc::new(mapping_vars.clone()))),
+        );
+        assert!(variable_diagnostics("set", &mapping, 0, xpath).is_empty());
 
         // A different entry's namespace is an empty map here: warn on any
         // reference, and $rule.id is likewise unbound outside check rules.
         let xpath = "//port[. = $rule.variables?from and contains(., $rule.id)]";
-        let diags = undefined_variable_key_diagnostics(
-            "set", "mapping 1", xpath, &run_vars, Some(EntryKind::Mapping), &mapping_vars,
-        );
+        let diags = variable_diagnostics("set", &mapping, 0, xpath);
         assert_eq!(diags.len(), 2, "{:?}", diags.iter().map(|d| d.reason.clone()).collect::<Vec<_>>());
         assert!(diags[0].reason.as_deref().unwrap().contains("only bound in check rules"));
         assert!(diags[1].reason.as_deref().unwrap().contains("$rule.id is only bound in check rules"));
@@ -601,9 +624,7 @@ mod tests {
 
         // Outside any entry (e.g. CLI update), every entry namespace warns.
         let xpath = "//a[$assertion.variables?x]";
-        let diags = undefined_variable_key_diagnostics(
-            "update", "update", xpath, &run_vars, None, &QueryVariables::new(),
-        );
+        let diags = variable_diagnostics("update", &bindings(&run_vars, None), 0, xpath);
         assert_eq!(diags.len(), 1);
         assert!(diags[0].reason.as_deref().unwrap().contains("only bound in test assertions"));
     }

--- a/tractor/src/matcher.rs
+++ b/tractor/src/matcher.rs
@@ -8,7 +8,7 @@ use tractor::{
     parse, ParseInput, ParseOptions,
     report::{Report, ReportMatch, Severity, DiagnosticOrigin},
     rule::CompiledRule,
-    variables::QueryVariables,
+    variables::{EntryKind, QueryVariables},
     xpath::validate_xpath,
 };
 use crate::input::filter::Filters;
@@ -64,68 +64,114 @@ pub fn validate_xpath_diagnostic(xpath_expr: &NormalizedXpath, command: &str) ->
     })
 }
 
-/// Advisory check: warn about literal `$variables?key` / `$rule.variables?key`
-/// lookups whose key is not defined in the corresponding variable set.
+/// Advisory check: warn about variable usage that will silently yield the
+/// empty sequence — a `$variables?key` / `$<entry>.variables?key` lookup on
+/// an undefined key, or a reference to an entry namespace that is not bound
+/// in the current operation (e.g. `$rule.variables` inside a set mapping).
 ///
 /// A missing key is legal XPath — the lookup yields the empty sequence, and
-/// rules may rely on that (optional flags, `(lookup, default)[1]` idioms) —
+/// entries may rely on that (optional flags, `(lookup, default)[1]` idioms) —
 /// so this produces `Severity::Warning` diagnostics that never fail the run.
 /// Only literal keys are checked; dynamic lookups (`?($expr)`, `?*`) are
 /// skipped. Nested keys (`$variables?limits?max`) are checked at the top
 /// level only.
+///
+/// `label` names the entry in messages (the rule id, or e.g. "mapping 1");
+/// `entry_kind` is the current entry's kind (`None` outside any entry, e.g.
+/// CLI update) and `entry_variables` its `variables:`.
 pub fn undefined_variable_key_diagnostics(
-    rule_id: &str,
-    xpath_expr: &NormalizedXpath,
+    command: &str,
+    label: &str,
+    xpath: &str,
     run_variables: &QueryVariables,
-    rule_variables: &QueryVariables,
+    entry_kind: Option<EntryKind>,
+    entry_variables: &QueryVariables,
 ) -> Vec<ReportMatch> {
     use once_cell::sync::Lazy;
     use regex::Regex;
 
-    // NCName-ish key after the lookup operator. `$rule\.variables` is matched
-    // first so the plain `\$variables` pattern can't fire inside it (the
-    // preceding char there is `.`, not `$`, so it can't anyway).
+    // NCName-ish key after the lookup operator. The plain `\$variables`
+    // pattern can't fire inside `$rule.variables` etc. — the character
+    // before `variables` there is `.`, not `$`.
     static RUN_LOOKUP: Lazy<Regex> =
         Lazy::new(|| Regex::new(r"\$variables\s*\?\s*([A-Za-z_][A-Za-z0-9_.\-]*)").unwrap());
-    static RULE_LOOKUP: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"\$rule\.variables\s*\?\s*([A-Za-z_][A-Za-z0-9_.\-]*)").unwrap());
+    // Per entry kind: a key-lookup regex and a bare-reference regex.
+    static ENTRY_PATTERNS: Lazy<Vec<(EntryKind, Regex, Regex)>> = Lazy::new(|| {
+        EntryKind::ALL
+            .iter()
+            .map(|&kind| {
+                let name = regex::escape(kind.variables_name());
+                (
+                    kind,
+                    Regex::new(&format!(r"\${}\s*\?\s*([A-Za-z_][A-Za-z0-9_.\-]*)", name)).unwrap(),
+                    Regex::new(&format!(r"\${}", name)).unwrap(),
+                )
+            })
+            .collect()
+    });
+    static RULE_ID: Lazy<Regex> = Lazy::new(|| Regex::new(r"\$rule\.id").unwrap());
 
-    let xpath = xpath_expr.as_str();
     let mut diagnostics = Vec::new();
+    let mut warn = |start: usize, end: usize, reason: String| {
+        diagnostics.push(ReportMatch {
+            file: String::new(),
+            line: 1,
+            column: start as u32 + 1,
+            end_line: 1,
+            end_column: end as u32 + 1,
+            command: command.to_string(),
+            tree: None,
+            value: None,
+            source: Some(xpath.to_string()),
+            lines: Some(vec![xpath.to_string()]),
+            reason: Some(reason),
+            severity: Some(Severity::Warning),
+            message: None,
+            origin: Some(DiagnosticOrigin::Xpath),
+            rule_id: (entry_kind == Some(EntryKind::Rule)).then(|| label.to_string()),
+            status: None,
+            output: None,
+        });
+    };
 
-    let mut check = |re: &Regex, defined: &QueryVariables, scope: &str| {
+    let check_keys = |re: &Regex, defined: &QueryVariables, scope: &str, warn: &mut dyn FnMut(usize, usize, String)| {
         for caps in re.captures_iter(xpath) {
             let key = caps.get(1).unwrap();
-            if defined.get(key.as_str()).is_some() {
-                continue;
-            }
-            diagnostics.push(ReportMatch {
-                file: String::new(),
-                line: 1,
-                column: key.start() as u32 + 1,
-                end_line: 1,
-                end_column: key.end() as u32 + 1,
-                command: "check".to_string(),
-                tree: None,
-                value: None,
-                source: Some(xpath.to_string()),
-                lines: Some(vec![xpath.to_string()]),
-                reason: Some(format!(
+            if defined.get(key.as_str()).is_none() {
+                warn(key.start(), key.end(), format!(
                     "[{}] unknown variable key '{}': not defined {} (the lookup yields the empty sequence)",
-                    rule_id, key.as_str(), scope,
-                )),
-                severity: Some(Severity::Warning),
-                message: None,
-                origin: Some(DiagnosticOrigin::Xpath),
-                rule_id: Some(rule_id.to_string()),
-                status: None,
-                output: None,
-            });
+                    label, key.as_str(), scope,
+                ));
+            }
         }
     };
 
-    check(&RUN_LOOKUP, run_variables, "under the config's `variables:`");
-    check(&RULE_LOOKUP, rule_variables, "in this rule's `variables:`");
+    check_keys(&RUN_LOOKUP, run_variables, "under the config's `variables:`", &mut warn);
+
+    for (kind, lookup, bare) in ENTRY_PATTERNS.iter() {
+        if Some(*kind) == entry_kind {
+            let scope = format!("in this {}'s `variables:`", kind.label());
+            check_keys(lookup, entry_variables, &scope, &mut warn);
+        } else {
+            // A namespace belonging to a different entry kind is always an
+            // empty map here — flag every reference, bare or lookup.
+            for m in bare.find_iter(xpath) {
+                warn(m.start(), m.end(), format!(
+                    "[{}] ${} is only bound in {}; here it is an empty map",
+                    label, kind.variables_name(), kind.config_home(),
+                ));
+            }
+        }
+    }
+
+    if entry_kind != Some(EntryKind::Rule) {
+        for m in RULE_ID.find_iter(xpath) {
+            warn(m.start(), m.end(), format!(
+                "[{}] $rule.id is only bound in check rules; here it is the empty sequence",
+                label,
+            ));
+        }
+    }
 
     diagnostics
 }
@@ -325,8 +371,10 @@ pub fn run_rules(
             // each rule's own variables as $rule.variables and its id as
             // $rule.id.
             for rule_idx in applicable {
-                result.rule_variables = std::sync::Arc::clone(&rules[rule_idx].variables);
-                result.rule_id = Some(rules[rule_idx].id.clone());
+                result.entry = Some(tractor::EntryContext::rule(
+                    std::sync::Arc::clone(&rules[rule_idx].variables),
+                    rules[rule_idx].id.clone(),
+                ));
                 match result.query(rules[rule_idx].xpath.as_str()) {
                     Ok(matches) => {
                         for m in matches {
@@ -500,15 +548,17 @@ mod tests {
 
         // Defined keys, wildcard expansion, and nested lookups: no warnings.
         // (`limits?max` is checked at the top level only.)
-        let xpath = NormalizedXpath::new(
-            "//a[$variables?env = 'p' and $variables?limits?max > 1 \
-             and (some $p in $rule.variables?prefixes?* satisfies starts-with(., $p))]",
-        );
-        assert!(undefined_variable_key_diagnostics("r", &xpath, &run_vars, &rule_vars).is_empty());
+        let xpath = "//a[$variables?env = 'p' and $variables?limits?max > 1 \
+             and (some $p in $rule.variables?prefixes?* satisfies starts-with(., $p))]";
+        assert!(undefined_variable_key_diagnostics(
+            "check", "r", xpath, &run_vars, Some(EntryKind::Rule), &rule_vars,
+        ).is_empty());
 
         // Undefined keys in both namespaces: one warning each, correct scope.
-        let xpath = NormalizedXpath::new("//a[$variables?evn or $rule.variables?prefix]");
-        let diags = undefined_variable_key_diagnostics("r", &xpath, &run_vars, &rule_vars);
+        let xpath = "//a[$variables?evn or $rule.variables?prefix]";
+        let diags = undefined_variable_key_diagnostics(
+            "check", "r", xpath, &run_vars, Some(EntryKind::Rule), &rule_vars,
+        );
         assert_eq!(diags.len(), 2);
         assert!(diags[0].reason.as_deref().unwrap().contains("'evn'"));
         assert!(diags[0].reason.as_deref().unwrap().contains("config's"));
@@ -517,8 +567,45 @@ mod tests {
         assert!(diags.iter().all(|d| d.severity == Some(Severity::Warning)));
 
         // Dynamic lookups are skipped
-        let xpath = NormalizedXpath::new("//a[$variables?($name) or $variables?*]");
-        assert!(undefined_variable_key_diagnostics("r", &xpath, &run_vars, &rule_vars).is_empty());
+        let xpath = "//a[$variables?($name) or $variables?*]";
+        assert!(undefined_variable_key_diagnostics(
+            "check", "r", xpath, &run_vars, Some(EntryKind::Rule), &rule_vars,
+        ).is_empty());
+    }
+
+    #[test]
+    fn cross_namespace_diagnostics() {
+        use tractor::variables::{QueryVariables, VariableValue};
+
+        let run_vars = QueryVariables::new();
+        let mut mapping_vars = QueryVariables::new();
+        mapping_vars.insert("from", VariableValue::Int(8080));
+
+        // The current entry's namespace checks keys; a defined key is fine.
+        let xpath = "//port[. = $mapping.variables?from]";
+        assert!(undefined_variable_key_diagnostics(
+            "set", "mapping 1", xpath, &run_vars, Some(EntryKind::Mapping), &mapping_vars,
+        ).is_empty());
+
+        // A different entry's namespace is an empty map here: warn on any
+        // reference, and $rule.id is likewise unbound outside check rules.
+        let xpath = "//port[. = $rule.variables?from and contains(., $rule.id)]";
+        let diags = undefined_variable_key_diagnostics(
+            "set", "mapping 1", xpath, &run_vars, Some(EntryKind::Mapping), &mapping_vars,
+        );
+        assert_eq!(diags.len(), 2, "{:?}", diags.iter().map(|d| d.reason.clone()).collect::<Vec<_>>());
+        assert!(diags[0].reason.as_deref().unwrap().contains("only bound in check rules"));
+        assert!(diags[1].reason.as_deref().unwrap().contains("$rule.id is only bound in check rules"));
+        assert!(diags.iter().all(|d| d.severity == Some(Severity::Warning)));
+        assert!(diags.iter().all(|d| d.rule_id.is_none()), "non-rule entries carry no rule_id");
+
+        // Outside any entry (e.g. CLI update), every entry namespace warns.
+        let xpath = "//a[$assertion.variables?x]";
+        let diags = undefined_variable_key_diagnostics(
+            "update", "update", xpath, &run_vars, None, &QueryVariables::new(),
+        );
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].reason.as_deref().unwrap().contains("only bound in test assertions"));
     }
 
     #[test]

--- a/tractor/src/model/mod.rs
+++ b/tractor/src/model/mod.rs
@@ -4,3 +4,4 @@ pub mod report;
 pub mod rule;
 pub mod tree_mode;
 pub mod normalized_xpath;
+pub mod variables;

--- a/tractor/src/model/rule.rs
+++ b/tractor/src/model/rule.rs
@@ -25,6 +25,7 @@
 use crate::normalized_xpath::NormalizedXpath;
 use crate::report::Severity;
 use crate::tree_mode::TreeMode;
+use crate::variables::QueryVariables;
 
 // ---------------------------------------------------------------------------
 // GlobMatcher (native only — needs the glob crate for Pattern)
@@ -193,6 +194,11 @@ mod compiled {
         pub valid_examples: Vec<String>,
         /// Code examples that should fail the check.
         pub invalid_examples: Vec<String>,
+        /// Rule-level variables, bound as the `$rule.variables` map for this
+        /// rule's queries. Run-level variables stay separate (`$variables`) —
+        /// no merging. `Arc` so `run_rules` can attach them to each parse
+        /// result without cloning the map per file.
+        pub variables: std::sync::Arc<crate::variables::QueryVariables>,
         /// Compiled glob matcher combining ruleset and rule layers.
         pub glob: GlobMatcher,
     }
@@ -250,6 +256,7 @@ mod compiled {
                     tree_mode: rule.tree_mode.or(ruleset_default_tree_mode),
                     valid_examples: rule.valid_examples,
                     invalid_examples: rule.invalid_examples,
+                    variables: std::sync::Arc::new(rule.variables),
                     glob,
                 })
             })
@@ -302,6 +309,11 @@ pub struct Rule {
     /// Code examples that should fail the check (1+ matches expected).
     /// In config files: `expect: [{invalid: "..."}]`, CLI: `--expect-invalid`.
     pub invalid_examples: Vec<String>,
+
+    /// Rule-level variables, bound as the `$rule.variables` map in this
+    /// rule's XPath queries. Run-level variables are bound separately as
+    /// `$variables`.
+    pub variables: QueryVariables,
 }
 
 impl Rule {
@@ -319,6 +331,7 @@ impl Rule {
             tree_mode: None,
             valid_examples: Vec::new(),
             invalid_examples: Vec::new(),
+            variables: QueryVariables::new(),
         }
     }
 
@@ -373,6 +386,12 @@ impl Rule {
     /// Set invalid examples (code that SHOULD trigger the check).
     pub fn with_invalid_examples(mut self, examples: Vec<String>) -> Self {
         self.invalid_examples = examples;
+        self
+    }
+
+    /// Set rule-level variables (bound as `$rule.variables` in queries).
+    pub fn with_variables(mut self, variables: QueryVariables) -> Self {
+        self.variables = variables;
         self
     }
 

--- a/tractor/src/model/rule.rs
+++ b/tractor/src/model/rule.rs
@@ -25,7 +25,7 @@
 use crate::normalized_xpath::NormalizedXpath;
 use crate::report::Severity;
 use crate::tree_mode::TreeMode;
-use crate::variables::QueryVariables;
+use crate::variables::{EntryKind, EntryVariables, QueryVariables};
 
 // ---------------------------------------------------------------------------
 // GlobMatcher (native only — needs the glob crate for Pattern)
@@ -198,7 +198,7 @@ mod compiled {
         /// rule's queries. Run-level variables stay separate (`$variables`) —
         /// no merging. `Arc` so `run_rules` can attach them to each parse
         /// result without cloning the map per file.
-        pub variables: std::sync::Arc<crate::variables::QueryVariables>,
+        pub variables: crate::variables::EntryVariables,
         /// Compiled glob matcher combining ruleset and rule layers.
         pub glob: GlobMatcher,
     }
@@ -256,7 +256,7 @@ mod compiled {
                     tree_mode: rule.tree_mode.or(ruleset_default_tree_mode),
                     valid_examples: rule.valid_examples,
                     invalid_examples: rule.invalid_examples,
-                    variables: std::sync::Arc::new(rule.variables),
+                    variables: rule.variables,
                     glob,
                 })
             })
@@ -312,16 +312,22 @@ pub struct Rule {
 
     /// Rule-level variables, bound as the `$rule.variables` map in this
     /// rule's XPath queries. Run-level variables are bound separately as
-    /// `$variables`.
-    pub variables: QueryVariables,
+    /// `$variables`. Carries what this rule's xpath reads, so resolution
+    /// policy is fixed here rather than re-derived at execution.
+    pub variables: EntryVariables,
 }
 
 impl Rule {
     /// Create a rule with just an id and xpath. All other fields use defaults.
     pub fn new(id: impl Into<String>, xpath: impl Into<NormalizedXpath>) -> Self {
+        let xpath = xpath.into();
+        // Built from the xpath even with no rule-level variables: the
+        // record of what this rule *reads* (including the run-level
+        // `$variables`) must exist whether or not it declares any.
+        let variables = EntryVariables::new(QueryVariables::new(), EntryKind::Rule, xpath.as_str());
         Rule {
             id: id.into(),
-            xpath: xpath.into(),
+            xpath,
             reason: None,
             severity: Severity::Error,
             message: None,
@@ -331,7 +337,7 @@ impl Rule {
             tree_mode: None,
             valid_examples: Vec::new(),
             invalid_examples: Vec::new(),
-            variables: QueryVariables::new(),
+            variables,
         }
     }
 
@@ -391,7 +397,7 @@ impl Rule {
 
     /// Set rule-level variables (bound as `$rule.variables` in queries).
     pub fn with_variables(mut self, variables: QueryVariables) -> Self {
-        self.variables = variables;
+        self.variables = EntryVariables::new(variables, EntryKind::Rule, self.xpath.as_str());
         self
     }
 

--- a/tractor/src/model/rule.rs
+++ b/tractor/src/model/rule.rs
@@ -196,8 +196,10 @@ mod compiled {
         pub invalid_examples: Vec<String>,
         /// Rule-level variables, bound as the `$rule.variables` map for this
         /// rule's queries. Run-level variables stay separate (`$variables`) —
-        /// no merging. `Arc` so `run_rules` can attach them to each parse
-        /// result without cloning the map per file.
+        /// no merging. Internally `Arc`, so `run_rules` can attach them to
+        /// each parse result without cloning the map per file, and carries
+        /// what this rule's xpath reads so the executor never re-derives
+        /// source-resolution policy from strings.
         pub variables: crate::variables::EntryVariables,
         /// Compiled glob matcher combining ruleset and rule layers.
         pub glob: GlobMatcher,

--- a/tractor/src/model/variables.rs
+++ b/tractor/src/model/variables.rs
@@ -441,6 +441,34 @@ pub struct EntryContext {
     pub id: Option<String>,
 }
 
+/// Everything user-defined that binds into a query's dynamic context: the
+/// run-level `$variables` map and the current operation entry (which
+/// supplies `$<entry>.variables` and `$rule.id`).
+///
+/// One value instead of two loose parameters, so adding a future binding
+/// changes this struct rather than every signature along the way. `Default`
+/// is "nothing bound" — every namespace an empty map.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct QueryBindings {
+    /// Run-level variables, bound as `$variables`.
+    pub variables: std::sync::Arc<QueryVariables>,
+    /// The current operation entry, or `None` outside any entry.
+    pub entry: Option<EntryContext>,
+}
+
+impl QueryBindings {
+    /// Bindings with only the run-level variables set.
+    pub fn run(variables: std::sync::Arc<QueryVariables>) -> Self {
+        Self { variables, entry: None }
+    }
+
+    /// The same bindings with `entry` as the current operation entry.
+    pub fn with_entry(mut self, entry: EntryContext) -> Self {
+        self.entry = Some(entry);
+        self
+    }
+}
+
 impl EntryContext {
     pub fn rule(variables: std::sync::Arc<QueryVariables>, id: impl Into<String>) -> Self {
         Self { kind: EntryKind::Rule, variables, id: Some(id.into()) }

--- a/tractor/src/model/variables.rs
+++ b/tractor/src/model/variables.rs
@@ -63,8 +63,30 @@
 //! `$`-prefixed keys are reserved everywhere outside `$literal`: an unknown
 //! directive or a `$`-key mixed into an ordinary map is a load error, so a
 //! typo'd directive can never silently pass through as literal data.
-//! Directives are resolved once at config load ([`QueryVariables::resolve_sources`]);
-//! everything downstream sees plain resolved data.
+//!
+//! ### When a source is read
+//!
+//! Directives are checked in two stages, because a source may name a file
+//! that an *earlier operation in the same run* has yet to write:
+//!
+//! 1. **At config load**, every directive is validated structurally
+//!    ([`QueryVariables::validate_sources`]) — unknown directives, reserved
+//!    `$query`, `$`-keys in ordinary maps, and non-string `$file` paths all
+//!    fail before any operation runs. No filesystem access happens here.
+//! 2. **At the start of each operation**, the sources that operation reads
+//!    are loaded ([`QueryVariables::resolve_sources`]). Operations run in
+//!    order, so a file written by an earlier operation (e.g. a query op's
+//!    `output:`) is read fresh by the next one, and every entry within one
+//!    operation sees a single consistent snapshot.
+//!
+//! What counts as "reads" is recorded per entry at load time by
+//! [`EntryVariables`] — not re-derived from XPath strings during execution.
+//! Resolution is therefore per entry, not per operation: one rule reading
+//! `$rule.variables` never forces resolution for a sibling rule that
+//! doesn't. A declared-but-unread source is neither resolved (so it cannot
+//! fail the run over a file that does not exist yet) nor bound raw: it
+//! binds an empty map. Downstream code therefore only ever sees plain
+//! resolved data — never an unresolved directive.
 //!
 //! ## Conversion to XPath values
 //!
@@ -346,6 +368,11 @@ fn resolve_value(
 
 /// Load a JSON/YAML/TOML document as a single [`VariableValue`]. The content
 /// is pure data — directives inside loaded files are not processed.
+///
+/// Native-only: reading a file needs a filesystem, and the YAML/TOML parsers
+/// are native-only dependencies. The wasm build has neither, so it reports
+/// the directive as unsupported instead (see the `not(native)` variant).
+#[cfg(feature = "native")]
 fn load_variables_file(
     file: &Path,
     path: &[String],
@@ -370,6 +397,24 @@ fn load_variables_file(
             ),
         )),
     }
+}
+
+/// Builds without the `native` feature (wasm) have no filesystem, so a
+/// `$file` source cannot be loaded. Directive *validation* still works —
+/// only the read is unavailable.
+#[cfg(not(feature = "native"))]
+fn load_variables_file(
+    file: &Path,
+    path: &[String],
+) -> Result<VariableValue, VariableSourceError> {
+    Err(VariableSourceError::new(
+        path,
+        format!(
+            "`$file` variable sources need a filesystem and are unavailable in this build \
+             (tried to load '{}')",
+            file.display()
+        ),
+    ))
 }
 
 /// The kind of operation entry a query runs under. Each kind owns one XPath

--- a/tractor/src/model/variables.rs
+++ b/tractor/src/model/variables.rs
@@ -503,7 +503,15 @@ pub struct EntryContext {
 /// over-approximates — a name inside a string literal counts as a read —
 /// which is the safe direction: an unread source may be resolved need-
 /// lessly, but a read source is never left unresolved.
-#[derive(Debug, Clone, Default, PartialEq)]
+///
+/// Deliberately **not** `Default`: a default value would claim "reads
+/// nothing" without having seen an expression, and a construction site that
+/// forgot to pass its xpath would silently disable resolution for the whole
+/// operation. Every value must be built from the expression it describes.
+/// Prefer the entry constructors (`SetMapping::new`, `QueryExpr::new`,
+/// `TestAssertion::new`, `Rule::with_variables`), which pass their own
+/// xpath so the two cannot disagree.
+#[derive(Debug, Clone, PartialEq)]
 pub struct EntryVariables {
     variables: std::sync::Arc<QueryVariables>,
     /// The expression reads this entry's own `$<entry>.variables`.

--- a/tractor/src/model/variables.rs
+++ b/tractor/src/model/variables.rs
@@ -1,12 +1,15 @@
 //! User-defined variables for the XPath dynamic context.
 //!
 //! Config files can declare named values that are bound into every query of
-//! the run as two well-known map-valued XPath variables, alongside the
-//! built-in `$file`:
+//! the run as well-known map-valued XPath variables, alongside the built-in
+//! `$file`:
 //!
 //! - `$variables` — the config root's `variables:` mapping
-//! - `$rule.variables` — the current check rule's `variables:` mapping
-//!   (an empty map outside a rule context)
+//! - `$rule.variables` / `$mapping.variables` / `$query.variables` /
+//!   `$assertion.variables` — the current operation entry's `variables:`
+//!   mapping, named after the config key the entry lives under (`rules:`,
+//!   `mappings:`, `queries:`, `assertions:`). Only the namespace matching
+//!   the current entry is populated; the others are empty maps.
 //!
 //! ```yaml
 //! variables:
@@ -152,6 +155,93 @@ impl QueryVariables {
 impl FromIterator<(String, VariableValue)> for QueryVariables {
     fn from_iter<I: IntoIterator<Item = (String, VariableValue)>>(iter: I) -> Self {
         Self(iter.into_iter().collect())
+    }
+}
+
+/// The kind of operation entry a query runs under. Each kind owns one XPath
+/// namespace for its `variables:` — named after the config key the entry
+/// lives under, so the XPath name mirrors the YAML right above it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    /// A check rule (`check: rules:`) — `$rule.variables`, `$rule.id`.
+    Rule,
+    /// A set mapping (`set: mappings:`) — `$mapping.variables`.
+    Mapping,
+    /// A query expression (`query: queries:`) — `$query.variables`.
+    Query,
+    /// A test assertion (`test: assertions:`) — `$assertion.variables`.
+    Assertion,
+}
+
+impl EntryKind {
+    /// Every kind, in declaration order. The engine binds one map per kind
+    /// on every query so the static context can stay constant.
+    pub const ALL: [EntryKind; 4] = [
+        EntryKind::Rule,
+        EntryKind::Mapping,
+        EntryKind::Query,
+        EntryKind::Assertion,
+    ];
+
+    /// The XPath variable name this kind's `variables:` bind to.
+    pub fn variables_name(self) -> &'static str {
+        match self {
+            EntryKind::Rule => "rule.variables",
+            EntryKind::Mapping => "mapping.variables",
+            EntryKind::Query => "query.variables",
+            EntryKind::Assertion => "assertion.variables",
+        }
+    }
+
+    /// The entry noun as it appears in config and diagnostics.
+    pub fn label(self) -> &'static str {
+        match self {
+            EntryKind::Rule => "rule",
+            EntryKind::Mapping => "mapping",
+            EntryKind::Query => "query",
+            EntryKind::Assertion => "assertion",
+        }
+    }
+
+    /// Where entries of this kind live, for "only bound in …" diagnostics.
+    pub fn config_home(self) -> &'static str {
+        match self {
+            EntryKind::Rule => "check rules",
+            EntryKind::Mapping => "set mappings",
+            EntryKind::Query => "query entries",
+            EntryKind::Assertion => "test assertions",
+        }
+    }
+}
+
+/// The operation entry a query is executing for: which kind it is, its
+/// `variables:`, and (for rules) its id. Binding is all-or-nothing — the
+/// pairing of kind, variables, and id is structural, not a set of loose
+/// fields kept in sync by convention.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EntryContext {
+    pub kind: EntryKind,
+    /// The entry's own `variables:`, bound under `kind.variables_name()`.
+    pub variables: std::sync::Arc<QueryVariables>,
+    /// The entry's id, bound as `$rule.id`. Only check rules have ids.
+    pub id: Option<String>,
+}
+
+impl EntryContext {
+    pub fn rule(variables: std::sync::Arc<QueryVariables>, id: impl Into<String>) -> Self {
+        Self { kind: EntryKind::Rule, variables, id: Some(id.into()) }
+    }
+
+    pub fn mapping(variables: std::sync::Arc<QueryVariables>) -> Self {
+        Self { kind: EntryKind::Mapping, variables, id: None }
+    }
+
+    pub fn query(variables: std::sync::Arc<QueryVariables>) -> Self {
+        Self { kind: EntryKind::Query, variables, id: None }
+    }
+
+    pub fn assertion(variables: std::sync::Arc<QueryVariables>) -> Self {
+        Self { kind: EntryKind::Assertion, variables, id: None }
     }
 }
 

--- a/tractor/src/model/variables.rs
+++ b/tractor/src/model/variables.rs
@@ -441,6 +441,122 @@ pub struct EntryContext {
     pub id: Option<String>,
 }
 
+/// An operation entry's `variables:` together with what its expression
+/// actually reads — decided once, where both are known (config load), so
+/// execution never re-derives resolution policy from XPath strings.
+///
+/// Resolving a `$`-directive source has an observable cost: it reads a file
+/// that a *later* operation in the run may not have written yet. Only an
+/// expression that reads a namespace may depend on (and fail on) its
+/// sources, and that question is per entry — one rule referencing
+/// `$rule.variables` must not force resolution for a sibling rule that
+/// doesn't.
+///
+/// The reference test is a literal substring scan, which is sound because
+/// XPath 3.1 has no dynamic variable references (no `eval`, no computed
+/// variable names): a namespace can only be read by writing its name. It
+/// over-approximates — a name inside a string literal counts as a read —
+/// which is the safe direction: an unread source may be resolved need-
+/// lessly, but a read source is never left unresolved.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct EntryVariables {
+    variables: std::sync::Arc<QueryVariables>,
+    /// The expression reads this entry's own `$<entry>.variables`.
+    reads_own: bool,
+    /// The expression reads the run-level `$variables`.
+    reads_run: bool,
+}
+
+impl EntryVariables {
+    /// Bind `variables` to an entry of `kind` whose expression is `xpath`,
+    /// recording what that expression reads.
+    pub fn new(variables: QueryVariables, kind: EntryKind, xpath: &str) -> Self {
+        Self {
+            variables: std::sync::Arc::new(variables),
+            reads_own: xpath.contains(&format!("${}", kind.variables_name())),
+            reads_run: reads_run_variables(xpath),
+        }
+    }
+
+    /// The entry's declared variables, directives unresolved.
+    pub fn declared(&self) -> &std::sync::Arc<QueryVariables> {
+        &self.variables
+    }
+
+    /// Whether the entry's expression reads the run-level `$variables`.
+    pub fn reads_run_variables(&self) -> bool {
+        self.reads_run
+    }
+
+    /// The map to bind as this entry's namespace, with `$`-directive
+    /// sources resolved against `base_dir`.
+    ///
+    /// An entry that never reads its own namespace binds an empty map: its
+    /// sources are neither resolved (so a not-yet-written file cannot fail
+    /// the run) nor bound raw (so an unresolved directive never reaches the
+    /// XPath context as data).
+    pub fn bind(&self, base_dir: &Path) -> Result<std::sync::Arc<QueryVariables>, VariableSourceError> {
+        bind_variables(&self.variables, self.reads_own, base_dir)
+    }
+
+    /// The same entry with its declared variables replaced by an already
+    /// bound (resolved) map — what the executor stores back into the plan
+    /// before running the entry.
+    pub fn with_bound(mut self, bound: std::sync::Arc<QueryVariables>) -> Self {
+        self.variables = bound;
+        self
+    }
+}
+
+impl std::ops::Deref for EntryVariables {
+    type Target = QueryVariables;
+    fn deref(&self) -> &QueryVariables {
+        &self.variables
+    }
+}
+
+/// Whether an XPath expression reads the run-level `$variables`.
+///
+/// `$rule.variables` and friends don't count: the character before
+/// `variables` there is `.`, not `$`.
+pub fn reads_run_variables(xpath: &str) -> bool {
+    xpath.match_indices("$variables").any(|(i, _)| {
+        // Reject `$variables` as a prefix of a longer name (NCNames may
+        // contain `-`, `_`, `.`, and digits).
+        !xpath[i + "$variables".len()..]
+            .starts_with(|c: char| c.is_alphanumeric() || c == '-' || c == '_' || c == '.')
+    })
+}
+
+/// Shared binding policy: resolve when read, empty when not, and never
+/// bind an unresolved directive map.
+fn bind_variables(
+    variables: &std::sync::Arc<QueryVariables>,
+    is_read: bool,
+    base_dir: &Path,
+) -> Result<std::sync::Arc<QueryVariables>, VariableSourceError> {
+    if !variables.has_sources() {
+        return Ok(std::sync::Arc::clone(variables));
+    }
+    if !is_read {
+        return Ok(std::sync::Arc::default());
+    }
+    Ok(std::sync::Arc::new(
+        (**variables).clone().resolve_sources(base_dir)?,
+    ))
+}
+
+/// Resolve the run-level `$variables` for an operation: same policy as
+/// [`EntryVariables::bind`], driven by whether any of the operation's
+/// expressions read it.
+pub fn bind_run_variables(
+    variables: &std::sync::Arc<QueryVariables>,
+    is_read: bool,
+    base_dir: &Path,
+) -> Result<std::sync::Arc<QueryVariables>, VariableSourceError> {
+    bind_variables(variables, is_read, base_dir)
+}
+
 /// Everything user-defined that binds into a query's dynamic context: the
 /// run-level `$variables` map and the current operation entry (which
 /// supplies `$<entry>.variables` and `$rule.id`).
@@ -627,6 +743,78 @@ mod tests {
         // $file expects a string path.
         let err = resolve("x:\n  $file: [a, b]\n", Path::new(".")).unwrap_err();
         assert!(err.to_string().contains("expects a path string"), "{}", err);
+    }
+
+    /// The reference scan decides resolution policy, so its edges are
+    /// pinned here: own vs run namespace, and the deliberate
+    /// over-approximation on string literals.
+    #[test]
+    fn entry_variables_records_what_the_expression_reads() {
+        let vars: QueryVariables = serde_yaml::from_str("max: 4\n").unwrap();
+
+        let reads_own = EntryVariables::new(
+            vars.clone(),
+            EntryKind::Rule,
+            "//f[count(p) > $rule.variables?max]",
+        );
+        assert!(reads_own.bind(Path::new(".")).is_ok());
+        assert!(!reads_own.reads_run_variables());
+
+        let reads_run = EntryVariables::new(vars.clone(), EntryKind::Rule, "//a[$variables?env]");
+        assert!(reads_run.reads_run_variables());
+
+        // Another entry kind's namespace is not this entry's own.
+        let other_kind = EntryVariables::new(
+            vars.clone(),
+            EntryKind::Rule,
+            "//a[$mapping.variables?max]",
+        );
+        assert!(!other_kind.reads_run_variables());
+
+        // `$variables` as a prefix of a longer name is not a read of it.
+        assert!(!EntryVariables::new(vars.clone(), EntryKind::Rule, "//a[$variables-x]")
+            .reads_run_variables());
+        // ...but `$rule.variables` never counts as `$variables` either.
+        assert!(!EntryVariables::new(vars.clone(), EntryKind::Rule, "//a[$rule.variables?max]")
+            .reads_run_variables());
+
+        // Over-approximation: a namespace name inside a string literal
+        // counts as a read. XPath has no dynamic variable references, so
+        // the scan can never MISS a real read; treating a literal as a
+        // read only resolves a source needlessly, which is the safe
+        // direction. This test pins that direction deliberately.
+        assert!(
+            EntryVariables::new(vars, EntryKind::Rule, "//a[. = '$variables?x']")
+                .reads_run_variables(),
+            "a literal occurrence must be treated as a read (conservative)"
+        );
+    }
+
+    /// An entry that never reads its own namespace neither resolves its
+    /// sources nor binds them raw — the invariant that downstream only
+    /// ever sees plain resolved data.
+    #[test]
+    fn unread_sources_bind_empty_and_never_resolve() {
+        let declared: QueryVariables =
+            serde_yaml::from_str("data:\n  $file: does-not-exist.json\n").unwrap();
+
+        // Reads its own namespace: resolution runs, and the missing file
+        // is fatal.
+        let read = EntryVariables::new(declared.clone(), EntryKind::Rule, "//a[$rule.variables?data]");
+        assert!(read.bind(Path::new(".")).is_err(), "a read source must resolve (and fail loudly)");
+
+        // Does not read it: no resolution (so a file a later operation
+        // will write cannot fail this entry) and nothing raw is bound.
+        let unread = EntryVariables::new(declared, EntryKind::Rule, "//a[@x = 1]");
+        let bound = unread.bind(Path::new(".")).expect("unread sources must not resolve");
+        assert!(bound.is_empty(), "unread sources must bind empty, not raw directives: {:?}", bound);
+        assert!(!bound.has_sources(), "a raw `$file` directive must never reach the query context");
+
+        // Plain values are bound as-is whether read or not.
+        let plain: QueryVariables = serde_yaml::from_str("env: prod\n").unwrap();
+        let unread_plain = EntryVariables::new(plain, EntryKind::Rule, "//a[@x = 1]");
+        let bound = unread_plain.bind(Path::new(".")).unwrap();
+        assert_eq!(bound.get("env"), Some(&VariableValue::String("prod".into())));
     }
 
     #[test]

--- a/tractor/src/model/variables.rs
+++ b/tractor/src/model/variables.rs
@@ -209,15 +209,50 @@ impl VariableSourceError {
 impl QueryVariables {
     /// Resolve every `$`-directive source in the tree into plain data.
     /// `base_dir` anchors relative `$file` paths (the config file's
-    /// directory). Called once at config load; downstream code only ever
-    /// sees resolved values.
+    /// directory). Called at *operation start* — not config load — so a
+    /// file written by an earlier operation in the run is read fresh.
+    /// Each operation sees one consistent snapshot.
     pub fn resolve_sources(self, base_dir: &Path) -> Result<QueryVariables, VariableSourceError> {
+        self.walk(&mut |file, path| load_variables_file(&base_dir.join(file), path))
+    }
+
+    /// Statically validate every `$`-directive in the tree without touching
+    /// the filesystem: unknown directives, reserved `$query`, `$`-keys mixed
+    /// into ordinary maps, and non-string `$file` paths all fail here.
+    /// Called at config load, so a typo'd directive fails before any
+    /// operation runs — only the file *read* is deferred to execution.
+    pub fn validate_sources(&self) -> Result<(), VariableSourceError> {
+        self.clone().walk(&mut |_, _| Ok(VariableValue::Null)).map(|_| ())
+    }
+
+    /// Whether the tree contains any `$`-directive (a resolution would
+    /// change it). Used to skip cloning when there is nothing to resolve.
+    pub fn has_sources(&self) -> bool {
+        fn scan(v: &VariableValue) -> bool {
+            match v {
+                VariableValue::Map(m) => {
+                    (m.len() == 1 && m.keys().next().unwrap().starts_with('$'))
+                        || m.values().any(scan)
+                }
+                VariableValue::Array(items) => items.iter().any(scan),
+                _ => false,
+            }
+        }
+        self.0.values().any(scan)
+    }
+
+    /// Shared walk for resolve/validate: `load` supplies a `$file`'s content
+    /// (or a placeholder during validation).
+    fn walk(
+        self,
+        load: &mut dyn FnMut(&str, &[String]) -> Result<VariableValue, VariableSourceError>,
+    ) -> Result<QueryVariables, VariableSourceError> {
         let mut path = Vec::new();
         self.0
             .into_iter()
             .map(|(name, value)| {
                 path.push(name.clone());
-                let resolved = resolve_value(value, base_dir, &mut path)?;
+                let resolved = resolve_value(value, load, &mut path)?;
                 path.pop();
                 Ok((name, resolved))
             })
@@ -229,7 +264,7 @@ impl QueryVariables {
 /// messages and is restored before returning.
 fn resolve_value(
     value: VariableValue,
-    base_dir: &Path,
+    load: &mut dyn FnMut(&str, &[String]) -> Result<VariableValue, VariableSourceError>,
     path: &mut Vec<String>,
 ) -> Result<VariableValue, VariableSourceError> {
     let VariableValue::Map(map) = value else {
@@ -240,7 +275,7 @@ fn resolve_value(
                     .enumerate()
                     .map(|(i, item)| {
                         path.push(i.to_string());
-                        let resolved = resolve_value(item, base_dir, path)?;
+                        let resolved = resolve_value(item, load, path)?;
                         path.pop();
                         Ok(resolved)
                     })
@@ -266,7 +301,7 @@ fn resolve_value(
                             "`$file` expects a path string",
                         ));
                     };
-                    load_variables_file(&base_dir.join(&rel), path)
+                    load(&rel, path)
                 }
                 "query" => Err(VariableSourceError::new(
                     path,
@@ -301,7 +336,7 @@ fn resolve_value(
         .into_iter()
         .map(|(k, v)| {
             path.push(k.clone());
-            let resolved = resolve_value(v, base_dir, path)?;
+            let resolved = resolve_value(v, load, path)?;
             path.pop();
             Ok((k, resolved))
         })

--- a/tractor/src/model/variables.rs
+++ b/tractor/src/model/variables.rs
@@ -79,14 +79,20 @@
 //!    `output:`) is read fresh by the next one, and every entry within one
 //!    operation sees a single consistent snapshot.
 //!
-//! What counts as "reads" is recorded per entry at load time by
-//! [`EntryVariables`] — not re-derived from XPath strings during execution.
-//! Resolution is therefore per entry, not per operation: one rule reading
-//! `$rule.variables` never forces resolution for a sibling rule that
-//! doesn't. A declared-but-unread source is neither resolved (so it cannot
-//! fail the run over a file that does not exist yet) nor bound raw: it
-//! binds an empty map. Downstream code therefore only ever sees plain
-//! resolved data — never an unresolved directive.
+//! What counts as "reads" is recorded at load time by [`VariableReads`],
+//! from the expression itself — not re-derived from XPath strings during
+//! execution. Resolution is scoped two ways:
+//!
+//! - **per entry**, so one rule reading `$rule.variables` never forces
+//!   resolution for a sibling rule that doesn't;
+//! - **per top-level key**, so a map holding an inline `env:` beside a
+//!   gathered `repos: {$file: ...}` resolves only what an expression looks
+//!   up. Reading `$variables?env` leaves `repos` alone.
+//!
+//! A declared-but-unread source is neither resolved (so it cannot fail the
+//! run over a file that does not exist yet) nor bound raw: its key is
+//! omitted from the bound map. Downstream code therefore only ever sees
+//! plain resolved data — never an unresolved directive.
 //!
 //! ## Conversion to XPath values
 //!
@@ -269,6 +275,55 @@ impl QueryVariables {
     /// operation runs — only the file *read* is deferred to execution.
     pub fn validate_sources(&self) -> Result<(), VariableSourceError> {
         self.clone().walk(&mut |_, _| Ok(VariableValue::Null)).map(|_| ())
+    }
+
+    /// Bind this map for a query that reads the top-level keys `reads`
+    /// accepts.
+    ///
+    /// Resolution is per key, because a map routinely holds inline settings
+    /// beside a gathered artifact:
+    ///
+    /// ```yaml
+    /// variables:
+    ///   env: production
+    ///   repos: { $file: "gathered/repos.json" }   # written later in the run
+    /// ```
+    ///
+    /// A rule reading only `$variables?env` must not be killed by `repos`
+    /// naming a file a later operation is about to write. So a key is:
+    ///
+    /// - kept as-is when it declares no sources (free, and always safe),
+    /// - resolved when it declares sources *and* is read,
+    /// - **omitted** when it declares sources and is not read — never
+    ///   resolved (it may not exist yet) and never bound raw (a directive
+    ///   map must not reach the query as data).
+    ///
+    /// An omitted key is absent rather than empty, so `map:contains` reports
+    /// it missing — the honest answer, since its value was never determined.
+    pub fn bind_for(
+        &self,
+        reads: &NamespaceReads,
+        base_dir: &Path,
+    ) -> Result<QueryVariables, VariableSourceError> {
+        if !self.has_sources() {
+            return Ok(self.clone());
+        }
+        let mut bound = BTreeMap::new();
+        for (name, value) in &self.0 {
+            let one: QueryVariables =
+                std::iter::once((name.clone(), value.clone())).collect();
+            if !one.has_sources() {
+                bound.insert(name.clone(), value.clone());
+            } else if reads.reads(name) {
+                let resolved = one
+                    .resolve_sources(base_dir)?
+                    .0
+                    .remove(name)
+                    .expect("resolution preserves top-level keys");
+                bound.insert(name.clone(), resolved);
+            }
+        }
+        Ok(QueryVariables(bound))
     }
 
     /// Whether the tree contains any `$`-directive (a resolution would
@@ -517,6 +572,111 @@ pub struct EntryContext {
     pub id: Option<String>,
 }
 
+/// What an expression reads from one variable namespace: which top-level
+/// keys by name, and whether it reaches the namespace in a way that could
+/// touch any key.
+///
+/// `all` covers the cases a key list cannot: `?*`, a computed lookup
+/// `?($expr)`, and a bare `$variables` used as a whole map. Those must
+/// resolve everything, since which key they land on is not knowable
+/// statically.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct NamespaceReads {
+    keys: std::collections::BTreeSet<String>,
+    all: bool,
+}
+
+impl NamespaceReads {
+    /// What `xpath` reads from the namespace named `$<var_name>`.
+    ///
+    /// A lexical scan, sound because XPath 3.1 has no dynamic variable
+    /// references: a namespace can only be read by writing its name. It
+    /// over-approximates (a name inside a string literal counts as a read),
+    /// which is the safe direction — a source may be resolved needlessly,
+    /// but a read source is never left unresolved.
+    pub fn of(xpath: &str, var_name: &str) -> Self {
+        let needle = format!("${}", var_name);
+        let mut reads = NamespaceReads::default();
+        for (at, _) in xpath.match_indices(&needle) {
+            let rest = &xpath[at + needle.len()..];
+            // `$variables` must not match inside a longer name such as
+            // `$variables-x`; NCNames continue with these characters.
+            if rest.starts_with(is_ncname_continuation) {
+                continue;
+            }
+            match rest.trim_start().strip_prefix('?') {
+                Some(lookup) => {
+                    let key: String = lookup
+                        .trim_start()
+                        .chars()
+                        .take_while(|c| is_ncname_continuation(*c))
+                        .collect();
+                    // `?*` and `?(...)` yield no literal key — any key may
+                    // be reached.
+                    if key.is_empty() {
+                        reads.all = true;
+                    } else {
+                        reads.keys.insert(key);
+                    }
+                }
+                // The whole map is used (passed around, counted, dumped).
+                None => reads.all = true,
+            }
+        }
+        reads
+    }
+
+    /// Whether the expression reads this namespace at all.
+    pub fn reads_any(&self) -> bool {
+        self.all || !self.keys.is_empty()
+    }
+
+    /// Whether the expression may read this top-level key.
+    pub fn reads(&self, key: &str) -> bool {
+        self.all || self.keys.contains(key)
+    }
+
+    /// Everything either side reads — for the run-level map, which one
+    /// operation's entries share.
+    pub fn union(mut self, other: &NamespaceReads) -> Self {
+        self.all |= other.all;
+        self.keys.extend(other.keys.iter().cloned());
+        self
+    }
+}
+
+fn is_ncname_continuation(c: char) -> bool {
+    c.is_alphanumeric() || c == '-' || c == '_' || c == '.'
+}
+
+/// What an expression reads from the namespaces available to it: the
+/// run-level `$variables`, and its own entry namespace.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VariableReads {
+    run: NamespaceReads,
+    own: NamespaceReads,
+}
+
+impl VariableReads {
+    /// What `xpath` reads, for an entry of `kind`.
+    pub fn of(xpath: &str, kind: EntryKind) -> Self {
+        Self {
+            run: NamespaceReads::of(xpath, "variables"),
+            own: NamespaceReads::of(xpath, kind.variables_name()),
+        }
+    }
+
+    /// Reads from the run-level `$variables`.
+    pub fn run(&self) -> &NamespaceReads {
+        &self.run
+    }
+
+    /// Reads from this entry's own `$<entry>.variables`.
+    pub fn own(&self) -> &NamespaceReads {
+        &self.own
+    }
+}
+
 /// An operation entry's `variables:` together with what its expression
 /// actually reads — decided once, where both are known (config load), so
 /// execution never re-derives resolution policy from XPath strings.
@@ -544,11 +704,11 @@ pub struct EntryContext {
 /// xpath so the two cannot disagree.
 #[derive(Debug, Clone, PartialEq)]
 pub struct EntryVariables {
-    variables: std::sync::Arc<QueryVariables>,
-    /// The expression reads this entry's own `$<entry>.variables`.
-    reads_own: bool,
-    /// The expression reads the run-level `$variables`.
-    reads_run: bool,
+    /// The entry's `variables:` as written — pure data.
+    declared: std::sync::Arc<QueryVariables>,
+    /// What the entry's expression reads — facts about a string, kept
+    /// beside the values only so the two cannot be paired wrongly.
+    reads: VariableReads,
 }
 
 impl EntryVariables {
@@ -556,89 +716,56 @@ impl EntryVariables {
     /// recording what that expression reads.
     pub fn new(variables: QueryVariables, kind: EntryKind, xpath: &str) -> Self {
         Self {
-            variables: std::sync::Arc::new(variables),
-            reads_own: xpath.contains(&format!("${}", kind.variables_name())),
-            reads_run: reads_run_variables(xpath),
+            declared: std::sync::Arc::new(variables),
+            reads: VariableReads::of(xpath, kind),
         }
     }
 
     /// The entry's declared variables, directives unresolved.
     pub fn declared(&self) -> &std::sync::Arc<QueryVariables> {
-        &self.variables
+        &self.declared
     }
 
-    /// Whether the entry's expression reads the run-level `$variables`.
-    pub fn reads_run_variables(&self) -> bool {
-        self.reads_run
+    /// What the entry's expression reads.
+    pub fn reads(&self) -> &VariableReads {
+        &self.reads
     }
 
-    /// The map to bind as this entry's namespace, with `$`-directive
-    /// sources resolved against `base_dir`.
-    ///
-    /// An entry that never reads its own namespace binds an empty map: its
-    /// sources are neither resolved (so a not-yet-written file cannot fail
-    /// the run) nor bound raw (so an unresolved directive never reaches the
-    /// XPath context as data).
+    /// Whether the declared variables contain any `$`-directive.
+    pub fn has_sources(&self) -> bool {
+        self.declared.has_sources()
+    }
+
+    /// The map to bind as this entry's namespace, resolving the sources
+    /// under the keys this entry reads (see [`QueryVariables::bind_for`]).
     pub fn bind(&self, base_dir: &Path) -> Result<std::sync::Arc<QueryVariables>, VariableSourceError> {
-        bind_variables(&self.variables, self.reads_own, base_dir)
+        Ok(std::sync::Arc::new(
+            self.declared.bind_for(self.reads.own(), base_dir)?,
+        ))
     }
 
     /// The same entry with its declared variables replaced by an already
     /// bound (resolved) map — what the executor stores back into the plan
     /// before running the entry.
     pub fn with_bound(mut self, bound: std::sync::Arc<QueryVariables>) -> Self {
-        self.variables = bound;
+        self.declared = bound;
         self
     }
 }
 
-impl std::ops::Deref for EntryVariables {
-    type Target = QueryVariables;
-    fn deref(&self) -> &QueryVariables {
-        &self.variables
-    }
-}
-
-/// Whether an XPath expression reads the run-level `$variables`.
-///
-/// `$rule.variables` and friends don't count: the character before
-/// `variables` there is `.`, not `$`.
-pub fn reads_run_variables(xpath: &str) -> bool {
-    xpath.match_indices("$variables").any(|(i, _)| {
-        // Reject `$variables` as a prefix of a longer name (NCNames may
-        // contain `-`, `_`, `.`, and digits).
-        !xpath[i + "$variables".len()..]
-            .starts_with(|c: char| c.is_alphanumeric() || c == '-' || c == '_' || c == '.')
-    })
-}
-
-/// Shared binding policy: resolve when read, empty when not, and never
-/// bind an unresolved directive map.
-fn bind_variables(
+/// Bind the run-level `$variables` for one operation, resolving the sources
+/// under the keys that operation's entries read. Same policy as
+/// [`EntryVariables::bind`], with the reads unioned across entries because
+/// one map serves them all.
+pub fn bind_run_variables(
     variables: &std::sync::Arc<QueryVariables>,
-    is_read: bool,
+    reads: &NamespaceReads,
     base_dir: &Path,
 ) -> Result<std::sync::Arc<QueryVariables>, VariableSourceError> {
     if !variables.has_sources() {
         return Ok(std::sync::Arc::clone(variables));
     }
-    if !is_read {
-        return Ok(std::sync::Arc::default());
-    }
-    Ok(std::sync::Arc::new(
-        (**variables).clone().resolve_sources(base_dir)?,
-    ))
-}
-
-/// Resolve the run-level `$variables` for an operation: same policy as
-/// [`EntryVariables::bind`], driven by whether any of the operation's
-/// expressions read it.
-pub fn bind_run_variables(
-    variables: &std::sync::Arc<QueryVariables>,
-    is_read: bool,
-    base_dir: &Path,
-) -> Result<std::sync::Arc<QueryVariables>, VariableSourceError> {
-    bind_variables(variables, is_read, base_dir)
+    Ok(std::sync::Arc::new(variables.bind_for(reads, base_dir)?))
 }
 
 /// Everything user-defined that binds into a query's dynamic context: the
@@ -842,10 +969,10 @@ mod tests {
             "//f[count(p) > $rule.variables?max]",
         );
         assert!(reads_own.bind(Path::new(".")).is_ok());
-        assert!(!reads_own.reads_run_variables());
+        assert!(!reads_own.reads().run().reads_any());
 
         let reads_run = EntryVariables::new(vars.clone(), EntryKind::Rule, "//a[$variables?env]");
-        assert!(reads_run.reads_run_variables());
+        assert!(reads_run.reads().run().reads_any());
 
         // Another entry kind's namespace is not this entry's own.
         let other_kind = EntryVariables::new(
@@ -853,14 +980,14 @@ mod tests {
             EntryKind::Rule,
             "//a[$mapping.variables?max]",
         );
-        assert!(!other_kind.reads_run_variables());
+        assert!(!other_kind.reads().run().reads_any());
 
         // `$variables` as a prefix of a longer name is not a read of it.
         assert!(!EntryVariables::new(vars.clone(), EntryKind::Rule, "//a[$variables-x]")
-            .reads_run_variables());
+            .reads().run().reads_any());
         // ...but `$rule.variables` never counts as `$variables` either.
         assert!(!EntryVariables::new(vars.clone(), EntryKind::Rule, "//a[$rule.variables?max]")
-            .reads_run_variables());
+            .reads().run().reads_any());
 
         // Over-approximation: a namespace name inside a string literal
         // counts as a read. XPath has no dynamic variable references, so
@@ -869,9 +996,68 @@ mod tests {
         // direction. This test pins that direction deliberately.
         assert!(
             EntryVariables::new(vars, EntryKind::Rule, "//a[. = '$variables?x']")
-                .reads_run_variables(),
+                .reads().run().reads_any(),
             "a literal occurrence must be treated as a read (conservative)"
         );
+    }
+
+    /// The read scan records which top-level keys an expression looks up,
+    /// and when it can reach any key at all.
+    #[test]
+    fn namespace_reads_records_keys_and_wildcards() {
+        let reads = NamespaceReads::of("//a[$variables?env = $variables?limits?max]", "variables");
+        assert!(reads.reads("env"));
+        assert!(reads.reads("limits"), "the top-level key of a nested lookup");
+        assert!(!reads.reads("other"));
+        assert!(reads.reads_any());
+
+        // A wildcard or computed lookup can land on any key.
+        for xpath in ["//a[$variables?*]", "//a[$variables?($name)]"] {
+            let reads = NamespaceReads::of(xpath, "variables");
+            assert!(reads.reads("anything"), "{}", xpath);
+        }
+
+        // The whole map used as a value — also any key.
+        assert!(NamespaceReads::of("$variables", "variables").reads("anything"));
+
+        // A longer name is a different variable.
+        let reads = NamespaceReads::of("//a[$variables-x?env]", "variables");
+        assert!(!reads.reads_any());
+
+        // Namespaces don't bleed into each other.
+        let reads = NamespaceReads::of("//a[$rule.variables?max]", "variables");
+        assert!(!reads.reads_any(), "$rule.variables is not $variables");
+        let own = NamespaceReads::of("//a[$rule.variables?max]", "rule.variables");
+        assert!(own.reads("max"));
+
+        // Nothing read at all.
+        assert!(!NamespaceReads::of("//a[@x = 1]", "variables").reads_any());
+    }
+
+    /// Resolution is per key: an unread source in the same map as a read
+    /// key must not be resolved. This is the shape the docs encourage —
+    /// inline settings beside a gathered artifact.
+    #[test]
+    fn bind_for_resolves_only_the_keys_that_are_read() {
+        let vars: QueryVariables = serde_yaml::from_str(
+            "env: production\nrepos:\n  $file: not-written-yet.json\n",
+        )
+        .unwrap();
+
+        // Reading only `env` leaves `repos` alone — no read, no failure.
+        let reads = NamespaceReads::of("//a[$variables?env = 'production']", "variables");
+        let bound = vars.bind_for(&reads, Path::new(".")).expect("unread source must not resolve");
+        assert_eq!(bound.get("env"), Some(&VariableValue::String("production".into())));
+        assert!(bound.get("repos").is_none(), "an unread source is omitted, not bound raw");
+        assert!(!bound.has_sources(), "no directive may reach the query context");
+
+        // Reading `repos` resolves it — and fails loudly when it cannot.
+        let reads = NamespaceReads::of("//a[$variables?repos?x]", "variables");
+        assert!(vars.bind_for(&reads, Path::new(".")).is_err(), "a read source must resolve");
+
+        // A wildcard reads everything, so it resolves everything.
+        let reads = NamespaceReads::of("//a[$variables?*]", "variables");
+        assert!(vars.bind_for(&reads, Path::new(".")).is_err());
     }
 
     /// An entry that never reads its own namespace neither resolves its

--- a/tractor/src/model/variables.rs
+++ b/tractor/src/model/variables.rs
@@ -1,0 +1,223 @@
+//! User-defined variables for the XPath dynamic context.
+//!
+//! Config files can declare named values that are bound into every query of
+//! the run as two well-known map-valued XPath variables, alongside the
+//! built-in `$file`:
+//!
+//! - `$variables` — the config root's `variables:` mapping
+//! - `$rule.variables` — the current check rule's `variables:` mapping
+//!   (an empty map outside a rule context)
+//!
+//! ```yaml
+//! variables:
+//!   env: production
+//! check:
+//!   rules:
+//!     - id: too-long
+//!       variables:
+//!         max-params: 4
+//!       xpath: "//function[count(parameters/parameter) > $rule.variables?max-params][$variables?env = 'production']"
+//! ```
+//!
+//! Because user values are map *keys* (not XPath variable names), any string
+//! is a legal name; keys that aren't valid NCNames are reachable via
+//! `$variables?("weird key")`.
+//!
+//! ## Data model
+//!
+//! [`VariableValue`] mirrors the JSON data model (null, bool, number, string,
+//! array, object) rather than any single config format. This is deliberate:
+//! a future `variables-file:` feature that loads a JSON or YAML document as
+//! variable context deserializes into the exact same type — merging file-based
+//! and inline variables is then a plain [`QueryVariables::merge`], with no new
+//! conversion machinery.
+//!
+//! ## Conversion to XPath values
+//!
+//! At execution time the whole map becomes a single XPath `map(*)` item
+//! (an `xee_xpath::Sequence` — the datatype the dynamic context accepts for
+//! variable bindings) by serializing to JSON and evaluating `parse-json()`.
+//! JSON semantics apply inside the map: numbers become `xs:double`, `null`
+//! becomes the empty sequence, nested arrays/objects become `array(*)` /
+//! `map(*)`.
+//!
+//! The conversion itself lives in `xpath::engine` (it needs xee internals);
+//! this module is plain `Send + Sync` data so it can cross rayon threads —
+//! xee sequences are `Rc`-based and must be built per thread.
+
+use std::collections::BTreeMap;
+use serde::Deserialize;
+
+/// A single variable value, mirroring the JSON data model.
+///
+/// Deserializes untagged, so plain YAML/TOML/JSON scalars, lists, and tables
+/// map directly: `env: production` → `String`, `port: 8080` → `Int`,
+/// `tags: [a, b]` → `Array`, nested mappings → `Map`.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum VariableValue {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    String(String),
+    Array(Vec<VariableValue>),
+    Map(BTreeMap<String, VariableValue>),
+}
+
+impl VariableValue {
+    /// Whether the value is a scalar (bindable as a single atomic item)
+    /// as opposed to a structured array/map.
+    pub fn is_scalar(&self) -> bool {
+        !matches!(self, VariableValue::Array(_) | VariableValue::Map(_))
+    }
+
+    /// Convert to a `serde_json::Value`. Structured values are bound into
+    /// the XPath context by serializing through JSON and parsing with the
+    /// engine's `parse-json` — one canonical bridge for every config format.
+    pub fn to_json(&self) -> serde_json::Value {
+        match self {
+            VariableValue::Null => serde_json::Value::Null,
+            VariableValue::Bool(b) => serde_json::Value::Bool(*b),
+            VariableValue::Int(i) => serde_json::Value::from(*i),
+            VariableValue::Float(f) => serde_json::Value::from(*f),
+            VariableValue::String(s) => serde_json::Value::String(s.clone()),
+            VariableValue::Array(items) => {
+                serde_json::Value::Array(items.iter().map(|v| v.to_json()).collect())
+            }
+            VariableValue::Map(entries) => serde_json::Value::Object(
+                entries.iter().map(|(k, v)| (k.clone(), v.to_json())).collect(),
+            ),
+        }
+    }
+}
+
+/// Named variables bound into every XPath query of a run.
+///
+/// Plain data (no xee types), so it is cheap to share across threads via
+/// `Arc` and convert per thread at query time. Backed by a `BTreeMap` for
+/// deterministic iteration order.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+#[serde(transparent)]
+pub struct QueryVariables(BTreeMap<String, VariableValue>);
+
+impl QueryVariables {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Insert a variable, replacing any existing value under the same name.
+    pub fn insert(&mut self, name: impl Into<String>, value: VariableValue) {
+        self.0.insert(name.into(), value);
+    }
+
+    pub fn get(&self, name: &str) -> Option<&VariableValue> {
+        self.0.get(name)
+    }
+
+    /// Iterate over (name, value) pairs in deterministic (sorted) order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &VariableValue)> {
+        self.0.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    /// Variable names in deterministic (sorted) order.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.0.keys().map(|k| k.as_str())
+    }
+
+    /// Overlay `other` on top of `self` — `other` wins on name clashes.
+    /// This is the extension seam for `variables-file:`: load the file into
+    /// a `QueryVariables`, then merge the inline `variables:` over it.
+    pub fn merge(&mut self, other: QueryVariables) {
+        self.0.extend(other.0);
+    }
+
+    /// The whole variable map as a JSON object — the bridge format used to
+    /// bind it into the XPath context as a `map(*)` item via `parse-json()`.
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::Value::Object(
+            self.0.iter().map(|(k, v)| (k.clone(), v.to_json())).collect(),
+        )
+    }
+}
+
+impl FromIterator<(String, VariableValue)> for QueryVariables {
+    fn from_iter<I: IntoIterator<Item = (String, VariableValue)>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_yaml_scalars() {
+        let vars: QueryVariables = serde_yaml::from_str(
+            "env: production\nport: 8080\nratio: 1.5\nstrict: true\nnothing: null\n",
+        )
+        .unwrap();
+        assert_eq!(vars.get("env"), Some(&VariableValue::String("production".into())));
+        assert_eq!(vars.get("port"), Some(&VariableValue::Int(8080)));
+        assert_eq!(vars.get("ratio"), Some(&VariableValue::Float(1.5)));
+        assert_eq!(vars.get("strict"), Some(&VariableValue::Bool(true)));
+        assert_eq!(vars.get("nothing"), Some(&VariableValue::Null));
+    }
+
+    #[test]
+    fn deserialize_yaml_structured() {
+        let vars: QueryVariables = serde_yaml::from_str(
+            "tags: [a, b]\nlimits:\n  max: 10\n",
+        )
+        .unwrap();
+        assert_eq!(
+            vars.get("tags"),
+            Some(&VariableValue::Array(vec![
+                VariableValue::String("a".into()),
+                VariableValue::String("b".into()),
+            ]))
+        );
+        match vars.get("limits") {
+            Some(VariableValue::Map(m)) => assert_eq!(m.get("max"), Some(&VariableValue::Int(10))),
+            other => panic!("expected map, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn whole_map_to_json() {
+        let vars: QueryVariables =
+            serde_yaml::from_str("env: prod\nmax: 4\n").unwrap();
+        assert_eq!(vars.to_json(), serde_json::json!({"env": "prod", "max": 4}));
+        assert_eq!(QueryVariables::new().to_json(), serde_json::json!({}));
+    }
+
+    #[test]
+    fn merge_overlays() {
+        let mut base = QueryVariables::new();
+        base.insert("a", VariableValue::Int(1));
+        base.insert("b", VariableValue::Int(2));
+        let mut over = QueryVariables::new();
+        over.insert("b", VariableValue::Int(20));
+        over.insert("c", VariableValue::Int(3));
+        base.merge(over);
+        assert_eq!(base.get("a"), Some(&VariableValue::Int(1)));
+        assert_eq!(base.get("b"), Some(&VariableValue::Int(20)));
+        assert_eq!(base.get("c"), Some(&VariableValue::Int(3)));
+    }
+
+    #[test]
+    fn to_json_roundtrip() {
+        let vars: QueryVariables =
+            serde_yaml::from_str("cfg:\n  hosts: [a, b]\n  port: 1\n").unwrap();
+        let json = vars.get("cfg").unwrap().to_json();
+        assert_eq!(json, serde_json::json!({"hosts": ["a", "b"], "port": 1}));
+    }
+}

--- a/tractor/src/model/variables.rs
+++ b/tractor/src/model/variables.rs
@@ -211,9 +211,13 @@ impl FromIterator<(String, VariableValue)> for QueryVariables {
 
 /// Error while resolving `$`-directive variable sources. Always fatal: a
 /// declared source is a promise, unlike an optional key lookup.
-#[derive(Debug, thiserror::Error)]
-#[error("in variables{path}: {message}")]
+#[derive(Debug)]
 pub struct VariableSourceError {
+    /// Which `variables:` block the source is in — `None` for the config
+    /// root, otherwise the entry that owns it (e.g. `rule 'no-console'`).
+    /// The value knows its lookup path but not its owner, so callers
+    /// attach this via [`VariableSourceError::in_scope`].
+    scope: Option<String>,
     /// Lookup path to the offending value, e.g. `?settings?db`.
     path: String,
     message: String,
@@ -222,11 +226,31 @@ pub struct VariableSourceError {
 impl VariableSourceError {
     fn new(path: &[String], message: impl Into<String>) -> Self {
         Self {
+            scope: None,
             path: path.iter().map(|p| format!("?{}", p)).collect(),
             message: message.into(),
         }
     }
+
+    /// Name the `variables:` block this error came from, so a message
+    /// points at one entry instead of at "some variables somewhere".
+    /// Only the outermost scope sticks — resolution never nests.
+    pub fn in_scope(mut self, scope: impl Into<String>) -> Self {
+        self.scope.get_or_insert_with(|| scope.into());
+        self
+    }
 }
+
+impl std::fmt::Display for VariableSourceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.scope {
+            Some(scope) => write!(f, "in {} variables{}: {}", scope, self.path, self.message),
+            None => write!(f, "in variables{}: {}", self.path, self.message),
+        }
+    }
+}
+
+impl std::error::Error for VariableSourceError {}
 
 impl QueryVariables {
     /// Resolve every `$`-directive source in the tree into plain data.
@@ -366,6 +390,13 @@ fn resolve_value(
     Ok(VariableValue::Map(resolved))
 }
 
+/// A path for messages: forward slashes on every platform. A Windows join
+/// puts a backslash before the file name, which in a message like
+/// "cannot read 'dir\nope.json'" reads as an escape sequence.
+fn display_path(p: &Path) -> String {
+    p.display().to_string().replace('\\', "/")
+}
+
 /// Load a JSON/YAML/TOML document as a single [`VariableValue`]. The content
 /// is pure data — directives inside loaded files are not processed.
 ///
@@ -378,10 +409,10 @@ fn load_variables_file(
     path: &[String],
 ) -> Result<VariableValue, VariableSourceError> {
     let content = std::fs::read_to_string(file).map_err(|e| {
-        VariableSourceError::new(path, format!("cannot read '{}': {}", file.display(), e))
+        VariableSourceError::new(path, format!("cannot read '{}': {}", display_path(file), e))
     })?;
     let parse_err = |e: String| {
-        VariableSourceError::new(path, format!("invalid variables in '{}': {}", file.display(), e))
+        VariableSourceError::new(path, format!("invalid variables in '{}': {}", display_path(file), e))
     };
     match file.extension().and_then(|e| e.to_str()) {
         Some("json") => serde_json::from_str(&content).map_err(|e| parse_err(e.to_string())),
@@ -393,7 +424,7 @@ fn load_variables_file(
             path,
             format!(
                 "unsupported variables file '{}': use .json, .yml/.yaml, or .toml",
-                file.display()
+                display_path(file)
             ),
         )),
     }
@@ -412,7 +443,7 @@ fn load_variables_file(
         format!(
             "`$file` variable sources need a filesystem and are unavailable in this build \
              (tried to load '{}')",
-            file.display()
+            display_path(file)
         ),
     ))
 }
@@ -868,6 +899,41 @@ mod tests {
         let unread_plain = EntryVariables::new(plain, EntryKind::Rule, "//a[@x = 1]");
         let bound = unread_plain.bind(Path::new(".")).unwrap();
         assert_eq!(bound.get("env"), Some(&VariableValue::String("prod".into())));
+    }
+
+    /// A source failure names the `variables:` block it came from — a
+    /// rule's sources fail mid-run, so "somewhere in variables" is not
+    /// enough to act on.
+    #[test]
+    fn source_errors_name_their_scope() {
+        let vars: QueryVariables =
+            serde_yaml::from_str("data:\n  $file: nope.json\n").unwrap();
+
+        // Unscoped (config root).
+        let err = vars.clone().resolve_sources(Path::new(".")).unwrap_err();
+        assert!(err.to_string().starts_with("in variables?data:"), "{}", err);
+
+        // Scoped by the owning entry.
+        let err = vars
+            .clone()
+            .resolve_sources(Path::new("."))
+            .unwrap_err()
+            .in_scope("rule 'needs-baseline'");
+        assert!(
+            err.to_string().starts_with("in rule 'needs-baseline' variables?data:"),
+            "{}", err,
+        );
+
+        // The outermost scope wins — an entry label is not overwritten.
+        let err = vars
+            .resolve_sources(Path::new("."))
+            .unwrap_err()
+            .in_scope("set mapping 2")
+            .in_scope("something later");
+        assert!(err.to_string().contains("set mapping 2"), "{}", err);
+
+        // Paths render with forward slashes so they don't read as escapes.
+        assert!(!err.to_string().contains('\\'), "{}", err);
     }
 
     #[test]

--- a/tractor/src/model/variables.rs
+++ b/tractor/src/model/variables.rs
@@ -30,10 +30,41 @@
 //!
 //! [`VariableValue`] mirrors the JSON data model (null, bool, number, string,
 //! array, object) rather than any single config format. This is deliberate:
-//! a future `variables-file:` feature that loads a JSON or YAML document as
-//! variable context deserializes into the exact same type — merging file-based
-//! and inline variables is then a plain [`QueryVariables::merge`], with no new
-//! conversion machinery.
+//! every variable source — inline config values, `$file` documents, future
+//! source kinds — deserializes into the exact same type, so downstream code
+//! never knows or cares where a value came from.
+//!
+//! ## Sources (`$`-directives)
+//!
+//! Any value in a `variables:` tree may be a *source directive* instead of a
+//! literal: a map with exactly one `$`-prefixed key saying where the value
+//! comes from. Each source binds under its own name — there are no merge or
+//! shadowing semantics; two sources cannot collide because they are distinct
+//! keys in one map.
+//!
+//! ```yaml
+//! variables:
+//!   env: production              # inline literal
+//!   settings:
+//!     $file: "config/vars.yml"   # whole file bound under this name
+//!   team:
+//!     prefixes:
+//!       $file: "prefixes.yml"    # directives may appear at any depth
+//! ```
+//!
+//! - **`$file`** — load a JSON/YAML/TOML document (path relative to the
+//!   config file's directory). File content is pure data: directives inside
+//!   loaded files are *not* processed.
+//! - **`$literal`** — the inner value verbatim; the escape hatch for literal
+//!   data whose keys start with `$`.
+//! - **`$query`** — reserved for binding the result of a tractor query;
+//!   errors as "not implemented yet" so it cannot silently become data.
+//!
+//! `$`-prefixed keys are reserved everywhere outside `$literal`: an unknown
+//! directive or a `$`-key mixed into an ordinary map is a load error, so a
+//! typo'd directive can never silently pass through as literal data.
+//! Directives are resolved once at config load ([`QueryVariables::resolve_sources`]);
+//! everything downstream sees plain resolved data.
 //!
 //! ## Conversion to XPath values
 //!
@@ -49,6 +80,7 @@
 //! xee sequences are `Rc`-based and must be built per thread.
 
 use std::collections::BTreeMap;
+use std::path::Path;
 use serde::Deserialize;
 
 /// A single variable value, mirroring the JSON data model.
@@ -136,13 +168,6 @@ impl QueryVariables {
         self.0.keys().map(|k| k.as_str())
     }
 
-    /// Overlay `other` on top of `self` — `other` wins on name clashes.
-    /// This is the extension seam for `variables-file:`: load the file into
-    /// a `QueryVariables`, then merge the inline `variables:` over it.
-    pub fn merge(&mut self, other: QueryVariables) {
-        self.0.extend(other.0);
-    }
-
     /// The whole variable map as a JSON object — the bridge format used to
     /// bind it into the XPath context as a `map(*)` item via `parse-json()`.
     pub fn to_json(&self) -> serde_json::Value {
@@ -155,6 +180,160 @@ impl QueryVariables {
 impl FromIterator<(String, VariableValue)> for QueryVariables {
     fn from_iter<I: IntoIterator<Item = (String, VariableValue)>>(iter: I) -> Self {
         Self(iter.into_iter().collect())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Source directives ($file, $literal, reserved $query)
+// ---------------------------------------------------------------------------
+
+/// Error while resolving `$`-directive variable sources. Always fatal: a
+/// declared source is a promise, unlike an optional key lookup.
+#[derive(Debug, thiserror::Error)]
+#[error("in variables{path}: {message}")]
+pub struct VariableSourceError {
+    /// Lookup path to the offending value, e.g. `?settings?db`.
+    path: String,
+    message: String,
+}
+
+impl VariableSourceError {
+    fn new(path: &[String], message: impl Into<String>) -> Self {
+        Self {
+            path: path.iter().map(|p| format!("?{}", p)).collect(),
+            message: message.into(),
+        }
+    }
+}
+
+impl QueryVariables {
+    /// Resolve every `$`-directive source in the tree into plain data.
+    /// `base_dir` anchors relative `$file` paths (the config file's
+    /// directory). Called once at config load; downstream code only ever
+    /// sees resolved values.
+    pub fn resolve_sources(self, base_dir: &Path) -> Result<QueryVariables, VariableSourceError> {
+        let mut path = Vec::new();
+        self.0
+            .into_iter()
+            .map(|(name, value)| {
+                path.push(name.clone());
+                let resolved = resolve_value(value, base_dir, &mut path)?;
+                path.pop();
+                Ok((name, resolved))
+            })
+            .collect()
+    }
+}
+
+/// Recursively resolve one value. `path` carries the lookup trail for error
+/// messages and is restored before returning.
+fn resolve_value(
+    value: VariableValue,
+    base_dir: &Path,
+    path: &mut Vec<String>,
+) -> Result<VariableValue, VariableSourceError> {
+    let VariableValue::Map(map) = value else {
+        return match value {
+            VariableValue::Array(items) => {
+                let resolved = items
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, item)| {
+                        path.push(i.to_string());
+                        let resolved = resolve_value(item, base_dir, path)?;
+                        path.pop();
+                        Ok(resolved)
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(VariableValue::Array(resolved))
+            }
+            scalar => Ok(scalar),
+        };
+    };
+
+    // A single-`$`-key map is a source directive.
+    if map.len() == 1 {
+        let directive = map.keys().next().unwrap().strip_prefix('$').map(str::to_owned);
+        if let Some(directive) = directive {
+            let inner = map.into_values().next().unwrap();
+            return match directive.as_str() {
+                // Verbatim escape hatch — no directive processing inside.
+                "literal" => Ok(inner),
+                "file" => {
+                    let VariableValue::String(rel) = inner else {
+                        return Err(VariableSourceError::new(
+                            path,
+                            "`$file` expects a path string",
+                        ));
+                    };
+                    load_variables_file(&base_dir.join(&rel), path)
+                }
+                "query" => Err(VariableSourceError::new(
+                    path,
+                    "`$query` variable sources are not implemented yet",
+                )),
+                other => Err(VariableSourceError::new(
+                    path,
+                    format!(
+                        "unknown variable source directive `${}` (known: $file, $literal; \
+                         wrap literal data in `$literal:` if the `$` key is intentional)",
+                        other
+                    ),
+                )),
+            };
+        }
+    }
+
+    // Ordinary map: `$`-keys are reserved here, so a typo'd or misplaced
+    // directive fails loudly instead of passing through as data.
+    if let Some(stray) = map.keys().find(|k| k.starts_with('$')) {
+        return Err(VariableSourceError::new(
+            path,
+            format!(
+                "`{}` is a reserved directive key inside a map with other keys; \
+                 wrap the map in `$literal:` if it is literal data",
+                stray
+            ),
+        ));
+    }
+
+    let resolved = map
+        .into_iter()
+        .map(|(k, v)| {
+            path.push(k.clone());
+            let resolved = resolve_value(v, base_dir, path)?;
+            path.pop();
+            Ok((k, resolved))
+        })
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    Ok(VariableValue::Map(resolved))
+}
+
+/// Load a JSON/YAML/TOML document as a single [`VariableValue`]. The content
+/// is pure data — directives inside loaded files are not processed.
+fn load_variables_file(
+    file: &Path,
+    path: &[String],
+) -> Result<VariableValue, VariableSourceError> {
+    let content = std::fs::read_to_string(file).map_err(|e| {
+        VariableSourceError::new(path, format!("cannot read '{}': {}", file.display(), e))
+    })?;
+    let parse_err = |e: String| {
+        VariableSourceError::new(path, format!("invalid variables in '{}': {}", file.display(), e))
+    };
+    match file.extension().and_then(|e| e.to_str()) {
+        Some("json") => serde_json::from_str(&content).map_err(|e| parse_err(e.to_string())),
+        Some("yml") | Some("yaml") => {
+            serde_yaml::from_str(&content).map_err(|e| parse_err(e.to_string()))
+        }
+        Some("toml") => toml::from_str(&content).map_err(|e| parse_err(e.to_string())),
+        _ => Err(VariableSourceError::new(
+            path,
+            format!(
+                "unsupported variables file '{}': use .json, .yml/.yaml, or .toml",
+                file.display()
+            ),
+        )),
     }
 }
 
@@ -289,18 +468,102 @@ mod tests {
         assert_eq!(QueryVariables::new().to_json(), serde_json::json!({}));
     }
 
+    fn resolve(yaml: &str, base_dir: &Path) -> Result<QueryVariables, VariableSourceError> {
+        let vars: QueryVariables = serde_yaml::from_str(yaml).unwrap();
+        vars.resolve_sources(base_dir)
+    }
+
     #[test]
-    fn merge_overlays() {
-        let mut base = QueryVariables::new();
-        base.insert("a", VariableValue::Int(1));
-        base.insert("b", VariableValue::Int(2));
-        let mut over = QueryVariables::new();
-        over.insert("b", VariableValue::Int(20));
-        over.insert("c", VariableValue::Int(3));
-        base.merge(over);
-        assert_eq!(base.get("a"), Some(&VariableValue::Int(1)));
-        assert_eq!(base.get("b"), Some(&VariableValue::Int(20)));
-        assert_eq!(base.get("c"), Some(&VariableValue::Int(3)));
+    fn resolve_sources_passes_literals_through() {
+        let vars = resolve("env: prod\nlimits:\n  max: 4\n", Path::new(".")).unwrap();
+        assert_eq!(vars.get("env"), Some(&VariableValue::String("prod".into())));
+        match vars.get("limits") {
+            Some(VariableValue::Map(m)) => assert_eq!(m.get("max"), Some(&VariableValue::Int(4))),
+            other => panic!("expected map, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resolve_sources_loads_files_at_any_depth() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("vars.yml"), "db:\n  host: localhost\n").unwrap();
+        std::fs::write(dir.path().join("list.json"), r#"["a", "b"]"#).unwrap();
+        std::fs::write(dir.path().join("vars.toml"), "port = 8080\n").unwrap();
+
+        let vars = resolve(
+            "settings:\n  $file: vars.yml\nteam:\n  prefixes:\n    $file: list.json\nnet:\n  $file: vars.toml\n",
+            dir.path(),
+        )
+        .unwrap();
+
+        // Whole YAML document bound under its name
+        match vars.get("settings") {
+            Some(VariableValue::Map(m)) => match m.get("db") {
+                Some(VariableValue::Map(db)) => {
+                    assert_eq!(db.get("host"), Some(&VariableValue::String("localhost".into())));
+                }
+                other => panic!("expected db map, got {:?}", other),
+            },
+            other => panic!("expected settings map, got {:?}", other),
+        }
+        // Directive nested below the top level
+        match vars.get("team") {
+            Some(VariableValue::Map(m)) => assert_eq!(
+                m.get("prefixes"),
+                Some(&VariableValue::Array(vec![
+                    VariableValue::String("a".into()),
+                    VariableValue::String("b".into()),
+                ]))
+            ),
+            other => panic!("expected team map, got {:?}", other),
+        }
+        // TOML file
+        match vars.get("net") {
+            Some(VariableValue::Map(m)) => assert_eq!(m.get("port"), Some(&VariableValue::Int(8080))),
+            other => panic!("expected net map, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resolve_sources_literal_escape_hatch() {
+        // $literal keeps its content verbatim — including `$` keys inside.
+        let vars = resolve(
+            "schema:\n  $literal:\n    $file: not-a-directive\n    $ref: kept\n",
+            Path::new("."),
+        )
+        .unwrap();
+        match vars.get("schema") {
+            Some(VariableValue::Map(m)) => {
+                assert_eq!(m.get("$file"), Some(&VariableValue::String("not-a-directive".into())));
+                assert_eq!(m.get("$ref"), Some(&VariableValue::String("kept".into())));
+            }
+            other => panic!("expected map, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resolve_sources_fails_loudly() {
+        // Unknown directive (e.g. a typo) never passes through as data.
+        let err = resolve("x:\n  $fiel: vars.yml\n", Path::new(".")).unwrap_err();
+        assert!(err.to_string().contains("unknown variable source directive `$fiel`"), "{}", err);
+        assert!(err.to_string().contains("variables?x"), "{}", err);
+
+        // $query is reserved, not silently data.
+        let err = resolve("x:\n  $query:\n    xpath: //a\n", Path::new(".")).unwrap_err();
+        assert!(err.to_string().contains("not implemented"), "{}", err);
+
+        // A `$` key mixed into an ordinary map is reserved.
+        let err = resolve("x:\n  $file: vars.yml\n  other: 1\n", Path::new(".")).unwrap_err();
+        assert!(err.to_string().contains("reserved directive key"), "{}", err);
+
+        // Missing file is fatal, with the lookup path in the message.
+        let err = resolve("deep:\n  nested:\n    $file: nope.yml\n", Path::new(".")).unwrap_err();
+        assert!(err.to_string().contains("variables?deep?nested"), "{}", err);
+        assert!(err.to_string().contains("cannot read"), "{}", err);
+
+        // $file expects a string path.
+        let err = resolve("x:\n  $file: [a, b]\n", Path::new(".")).unwrap_err();
+        assert!(err.to_string().contains("expects a path string"), "{}", err);
     }
 
     #[test]

--- a/tractor/src/mutation/declarative_set.rs
+++ b/tractor/src/mutation/declarative_set.rs
@@ -125,6 +125,7 @@ pub fn declarative_set(
         let result = upsert_typed(
             &current_source, lang, &op.xpath,
             op.value.text(), None, Some(op.value.kind()),
+            Default::default(),
         )?;
         if result.source != current_source {
             ops_applied += 1;

--- a/tractor/src/mutation/xpath_upsert.rs
+++ b/tractor/src/mutation/xpath_upsert.rs
@@ -21,7 +21,7 @@
 use crate::parser::{parse, ParseInput, ParseOptions, XeeParseResult};
 use crate::render::{self, RenderOptions};
 use crate::tree_mode::TreeMode;
-use crate::variables::{EntryContext, QueryVariables};
+use crate::variables::QueryBindings;
 use crate::xpath::xot_node_to_xml_node;
 pub use crate::xpath::Match;
 use crate::xot_transform::helpers::*;
@@ -76,21 +76,7 @@ pub fn update_only(
     xpath: &str,
     value: &str,
     limit: Option<usize>,
-) -> Result<UpsertResult, UpsertError> {
-    update_only_with_variables(source, lang, xpath, value, limit, &Default::default(), None)
-}
-
-/// Like [`update_only`], but with user-defined variables bound in the
-/// query's dynamic context: `run_variables` becomes `$variables` and `entry`
-/// (if any) provides the `$<entry>.variables` namespace.
-pub fn update_only_with_variables(
-    source: &str,
-    lang: &str,
-    xpath: &str,
-    value: &str,
-    limit: Option<usize>,
-    run_variables: &std::sync::Arc<QueryVariables>,
-    entry: Option<&EntryContext>,
+    bindings: QueryBindings,
 ) -> Result<UpsertResult, UpsertError> {
     // Verify the language has a renderer that supports data mode
     let test_render = render::render(
@@ -121,8 +107,7 @@ pub fn update_only_with_variables(
         },
     )
     .map_err(|e| UpsertError::Parse(e.to_string()))?;
-    result.variables = std::sync::Arc::clone(run_variables);
-    result.entry = entry.cloned();
+    result.bindings = bindings;
 
     // Query with XPath
     let existing = result.query(xpath)
@@ -163,7 +148,7 @@ pub fn upsert(
     value: &str,
     limit: Option<usize>,
 ) -> Result<UpsertResult, UpsertError> {
-    upsert_typed(source, lang, xpath, value, limit, Some("string"))
+    upsert_typed(source, lang, xpath, value, limit, Some("string"), QueryBindings::default())
 }
 
 /// Like [`upsert`] but with explicit control over the value kind annotation.
@@ -172,6 +157,7 @@ pub fn upsert(
 ///   - `Some("string")` — force string (default for `--value`)
 ///   - `Some("null")` / `Some("number")` etc. — force that kind
 ///   - `None` — let the renderer auto-detect from the value text
+#[allow(clippy::too_many_arguments)]
 pub fn upsert_typed(
     source: &str,
     lang: &str,
@@ -179,23 +165,7 @@ pub fn upsert_typed(
     value: &str,
     limit: Option<usize>,
     value_kind: Option<&str>,
-) -> Result<UpsertResult, UpsertError> {
-    upsert_typed_with_variables(source, lang, xpath, value, limit, value_kind, &Default::default(), None)
-}
-
-/// Like [`upsert_typed`], but with user-defined variables bound in the
-/// query's dynamic context: `run_variables` becomes `$variables` and `entry`
-/// (if any) provides the `$<entry>.variables` namespace.
-#[allow(clippy::too_many_arguments)]
-pub fn upsert_typed_with_variables(
-    source: &str,
-    lang: &str,
-    xpath: &str,
-    value: &str,
-    limit: Option<usize>,
-    value_kind: Option<&str>,
-    run_variables: &std::sync::Arc<QueryVariables>,
-    entry: Option<&EntryContext>,
+    bindings: QueryBindings,
 ) -> Result<UpsertResult, UpsertError> {
     // Verify the language has a renderer that supports data mode
     let test_render = render::render(
@@ -226,8 +196,7 @@ pub fn upsert_typed_with_variables(
         },
     )
     .map_err(|e| UpsertError::Parse(e.to_string()))?;
-    result.variables = std::sync::Arc::clone(run_variables);
-    result.entry = entry.cloned();
+    result.bindings = bindings;
 
     // Query with XPath to determine update vs insert
     let existing = result.query(xpath)
@@ -1086,7 +1055,7 @@ mod tests {
     #[test]
     fn update_only_existing_string() {
         let source = r#"{"name": "Alice", "age": 30}"#;
-        let result = update_only(source, "json", "//name", "Bob", None).unwrap();
+        let result = update_only(source, "json", "//name", "Bob", None, Default::default()).unwrap();
         assert!(!result.inserted);
         assert_eq!(result.matches_updated, 1);
         assert!(result.source.contains("Bob"));
@@ -1096,7 +1065,7 @@ mod tests {
     #[test]
     fn update_only_no_match_returns_unchanged() {
         let source = r#"{"name": "Alice"}"#;
-        let result = update_only(source, "json", "//nonexistent", "value", None).unwrap();
+        let result = update_only(source, "json", "//nonexistent", "value", None, Default::default()).unwrap();
         assert!(!result.inserted);
         assert_eq!(result.matches_updated, 0);
         assert_eq!(result.source, source, "source should be unchanged when no match");
@@ -1105,7 +1074,7 @@ mod tests {
     #[test]
     fn update_only_does_not_create_missing_path() {
         let source = r#"{"name": "Alice"}"#;
-        let result = update_only(source, "json", "//db/host", "localhost", None).unwrap();
+        let result = update_only(source, "json", "//db/host", "localhost", None, Default::default()).unwrap();
         assert!(!result.inserted);
         assert_eq!(result.matches_updated, 0);
         assert_eq!(result.source, source, "should not create //db/host");
@@ -1117,7 +1086,7 @@ mod tests {
     #[test]
     fn update_only_multiple_matches() {
         let source = r#"{"items": [{"val": 1}, {"val": 2}, {"val": 3}]}"#;
-        let result = update_only(source, "json", "//items/val", "99", None).unwrap();
+        let result = update_only(source, "json", "//items/val", "99", None, Default::default()).unwrap();
         assert!(!result.inserted);
         assert_eq!(result.matches_updated, 3);
         let parsed: serde_json::Value = serde_json::from_str(&result.source).unwrap();
@@ -1129,7 +1098,7 @@ mod tests {
     #[test]
     fn update_only_respects_limit() {
         let source = r#"{"items": [{"val": 1}, {"val": 2}, {"val": 3}]}"#;
-        let result = update_only(source, "json", "//items/val", "99", Some(1)).unwrap();
+        let result = update_only(source, "json", "//items/val", "99", Some(1), Default::default()).unwrap();
         assert!(!result.inserted);
         assert_eq!(result.matches_updated, 1);
         let parsed: serde_json::Value = serde_json::from_str(&result.source).unwrap();
@@ -1142,14 +1111,14 @@ mod tests {
 
     #[test]
     fn update_only_unsupported_language() {
-        let result = update_only("{}", "brainfuck", "//x", "1", None);
+        let result = update_only("{}", "brainfuck", "//x", "1", None, Default::default());
         assert!(matches!(result.unwrap_err(), UpsertError::UnsupportedLanguage(_)));
     }
 
     #[test]
     fn yaml_update_only_existing() {
         let source = "name: Alice\nage: 30\n";
-        let result = update_only(source, "yaml", "//name", "Bob", None).unwrap();
+        let result = update_only(source, "yaml", "//name", "Bob", None, Default::default()).unwrap();
         assert!(!result.inserted);
         assert_eq!(result.matches_updated, 1);
         assert!(result.source.contains("Bob"));
@@ -1159,7 +1128,7 @@ mod tests {
     #[test]
     fn yaml_update_only_no_match() {
         let source = "name: Alice\n";
-        let result = update_only(source, "yaml", "//nonexistent", "value", None).unwrap();
+        let result = update_only(source, "yaml", "//nonexistent", "value", None, Default::default()).unwrap();
         assert_eq!(result.matches_updated, 0);
         assert_eq!(result.source, source);
     }
@@ -1167,7 +1136,7 @@ mod tests {
     #[test]
     fn yaml_update_only_does_not_create_missing_path() {
         let source = "name: Alice\n";
-        let result = update_only(source, "yaml", "//db/host", "localhost", None).unwrap();
+        let result = update_only(source, "yaml", "//db/host", "localhost", None, Default::default()).unwrap();
         assert_eq!(result.matches_updated, 0);
         assert_eq!(result.source, source, "should not create //db/host");
         assert!(!result.source.contains("db"), "db key should not be created");
@@ -1177,7 +1146,7 @@ mod tests {
     #[test]
     fn yaml_update_only_nested_existing() {
         let source = "db:\n  host: localhost\n  port: 5432\n";
-        let result = update_only(source, "yaml", "//db/host", "db.example.com", None).unwrap();
+        let result = update_only(source, "yaml", "//db/host", "db.example.com", None, Default::default()).unwrap();
         assert_eq!(result.matches_updated, 1);
         assert!(result.source.contains("db.example.com"));
         assert!(result.source.contains("port: 5432"));
@@ -1187,7 +1156,7 @@ mod tests {
     fn yaml_update_only_partial_path_no_create() {
         // db exists but port doesn't — update_only should NOT create port
         let source = "db:\n  host: localhost\n";
-        let result = update_only(source, "yaml", "//db/port", "5432", None).unwrap();
+        let result = update_only(source, "yaml", "//db/port", "5432", None, Default::default()).unwrap();
         assert_eq!(result.matches_updated, 0);
         assert_eq!(result.source, source, "should not create missing port under existing db");
     }

--- a/tractor/src/mutation/xpath_upsert.rs
+++ b/tractor/src/mutation/xpath_upsert.rs
@@ -21,6 +21,7 @@
 use crate::parser::{parse, ParseInput, ParseOptions, XeeParseResult};
 use crate::render::{self, RenderOptions};
 use crate::tree_mode::TreeMode;
+use crate::variables::{EntryContext, QueryVariables};
 use crate::xpath::xot_node_to_xml_node;
 pub use crate::xpath::Match;
 use crate::xot_transform::helpers::*;
@@ -76,6 +77,21 @@ pub fn update_only(
     value: &str,
     limit: Option<usize>,
 ) -> Result<UpsertResult, UpsertError> {
+    update_only_with_variables(source, lang, xpath, value, limit, &Default::default(), None)
+}
+
+/// Like [`update_only`], but with user-defined variables bound in the
+/// query's dynamic context: `run_variables` becomes `$variables` and `entry`
+/// (if any) provides the `$<entry>.variables` namespace.
+pub fn update_only_with_variables(
+    source: &str,
+    lang: &str,
+    xpath: &str,
+    value: &str,
+    limit: Option<usize>,
+    run_variables: &std::sync::Arc<QueryVariables>,
+    entry: Option<&EntryContext>,
+) -> Result<UpsertResult, UpsertError> {
     // Verify the language has a renderer that supports data mode
     let test_render = render::render(
         &crate::xpath::XmlNode::Element {
@@ -105,6 +121,8 @@ pub fn update_only(
         },
     )
     .map_err(|e| UpsertError::Parse(e.to_string()))?;
+    result.variables = std::sync::Arc::clone(run_variables);
+    result.entry = entry.cloned();
 
     // Query with XPath
     let existing = result.query(xpath)
@@ -162,6 +180,23 @@ pub fn upsert_typed(
     limit: Option<usize>,
     value_kind: Option<&str>,
 ) -> Result<UpsertResult, UpsertError> {
+    upsert_typed_with_variables(source, lang, xpath, value, limit, value_kind, &Default::default(), None)
+}
+
+/// Like [`upsert_typed`], but with user-defined variables bound in the
+/// query's dynamic context: `run_variables` becomes `$variables` and `entry`
+/// (if any) provides the `$<entry>.variables` namespace.
+#[allow(clippy::too_many_arguments)]
+pub fn upsert_typed_with_variables(
+    source: &str,
+    lang: &str,
+    xpath: &str,
+    value: &str,
+    limit: Option<usize>,
+    value_kind: Option<&str>,
+    run_variables: &std::sync::Arc<QueryVariables>,
+    entry: Option<&EntryContext>,
+) -> Result<UpsertResult, UpsertError> {
     // Verify the language has a renderer that supports data mode
     let test_render = render::render(
         &crate::xpath::XmlNode::Element {
@@ -191,6 +226,8 @@ pub fn upsert_typed(
         },
     )
     .map_err(|e| UpsertError::Parse(e.to_string()))?;
+    result.variables = std::sync::Arc::clone(run_variables);
+    result.entry = entry.cloned();
 
     // Query with XPath to determine update vs insert
     let existing = result.query(xpath)

--- a/tractor/src/parser/mod.rs
+++ b/tractor/src/parser/mod.rs
@@ -396,35 +396,27 @@ pub struct XeeParseResult {
     pub file_path: String,
     /// Language used for parsing
     pub language: String,
-    /// Run-level user variables, bound as the `$variables` map in every
-    /// query on this result. Defaults to empty; callers that run
-    /// config-declared variables (the executor) assign this after parsing.
-    pub variables: std::sync::Arc<crate::variables::QueryVariables>,
-    /// The current operation entry (rule / mapping / query / assertion),
-    /// providing its `variables:` under the matching `$<entry>.variables`
-    /// namespace and (for rules) `$rule.id`. `None` (the default) binds
-    /// empty maps everywhere; executors reassign it per entry while
-    /// iterating a parsed file's entries.
-    pub entry: Option<crate::variables::EntryContext>,
+    /// User-defined variables bound into every query on this result: the
+    /// run-level `$variables` map plus the current operation entry.
+    /// Defaults to nothing bound; executors assign it after parsing and
+    /// reassign the entry while iterating a file's rules/mappings.
+    pub bindings: crate::variables::QueryBindings,
 }
 
 impl XeeParseResult {
     /// Execute an XPath query on the parsed document.
     ///
     /// This is a convenience method that creates an XPathEngine and calls
-    /// `query_documents_with_variables`, avoiding the need to destructure
-    /// the parse result. `$variables` comes from `self.variables`; the
-    /// entry namespaces and `$rule.id` come from `self.entry`.
+    /// `query_documents`, avoiding the need to destructure the parse
+    /// result. The engine is bound with `self.bindings`.
     pub fn query(&mut self, xpath: &str) -> Result<Vec<crate::xpath::Match>, crate::xpath::XPathError> {
-        let engine = crate::xpath::XPathEngine::new();
-        engine.query_documents_with_variables(
+        let engine = crate::xpath::XPathEngine::new().with_bindings(self.bindings.clone());
+        engine.query_documents(
             &mut self.documents,
             self.doc_handle,
             xpath,
             self.source_lines.clone(),
             &self.file_path,
-            &self.variables,
-            self.entry.as_ref(),
         )
     }
 }
@@ -528,8 +520,7 @@ pub fn parse_string_to_xee_with_options(
         source_lines,
         file_path,
         language: lang.to_string(),
-        variables: Default::default(),
-        entry: None,
+        bindings: Default::default(),
     })
 }
 
@@ -579,8 +570,7 @@ pub fn load_xml_string_to_documents(xml: &str, file_path: String) -> Result<XeeP
         source_lines: std::sync::Arc::new(Vec::new()), // XML passthrough doesn't have source lines
         file_path,
         language: "xml".to_string(),
-        variables: Default::default(),
-        entry: None,
+        bindings: Default::default(),
     })
 }
 

--- a/tractor/src/parser/mod.rs
+++ b/tractor/src/parser/mod.rs
@@ -396,21 +396,38 @@ pub struct XeeParseResult {
     pub file_path: String,
     /// Language used for parsing
     pub language: String,
+    /// Run-level user variables, bound as the `$variables` map in every
+    /// query on this result. Defaults to empty; callers that run
+    /// config-declared variables (the executor) assign this after parsing.
+    pub variables: std::sync::Arc<crate::variables::QueryVariables>,
+    /// Rule-level user variables, bound as the `$rule.variables` map.
+    /// Defaults to empty; the check executor reassigns this per rule while
+    /// iterating a parsed file's applicable rules.
+    pub rule_variables: std::sync::Arc<crate::variables::QueryVariables>,
+    /// The current rule's id, bound as `$rule.id`. `None` (the default)
+    /// binds the empty sequence; the check executor sets it per rule.
+    pub rule_id: Option<String>,
 }
 
 impl XeeParseResult {
     /// Execute an XPath query on the parsed document.
     ///
     /// This is a convenience method that creates an XPathEngine and calls
-    /// `query_documents`, avoiding the need to destructure the parse result.
+    /// `query_documents_with_variables`, avoiding the need to destructure
+    /// the parse result. `$variables` comes from `self.variables`,
+    /// `$rule.variables` from `self.rule_variables`, `$rule.id` from
+    /// `self.rule_id`.
     pub fn query(&mut self, xpath: &str) -> Result<Vec<crate::xpath::Match>, crate::xpath::XPathError> {
         let engine = crate::xpath::XPathEngine::new();
-        engine.query_documents(
+        engine.query_documents_with_variables(
             &mut self.documents,
             self.doc_handle,
             xpath,
             self.source_lines.clone(),
             &self.file_path,
+            &self.variables,
+            &self.rule_variables,
+            self.rule_id.as_deref(),
         )
     }
 }
@@ -514,6 +531,9 @@ pub fn parse_string_to_xee_with_options(
         source_lines,
         file_path,
         language: lang.to_string(),
+        variables: Default::default(),
+        rule_variables: Default::default(),
+        rule_id: None,
     })
 }
 
@@ -563,6 +583,9 @@ pub fn load_xml_string_to_documents(xml: &str, file_path: String) -> Result<XeeP
         source_lines: std::sync::Arc::new(Vec::new()), // XML passthrough doesn't have source lines
         file_path,
         language: "xml".to_string(),
+        variables: Default::default(),
+        rule_variables: Default::default(),
+        rule_id: None,
     })
 }
 

--- a/tractor/src/parser/mod.rs
+++ b/tractor/src/parser/mod.rs
@@ -400,13 +400,12 @@ pub struct XeeParseResult {
     /// query on this result. Defaults to empty; callers that run
     /// config-declared variables (the executor) assign this after parsing.
     pub variables: std::sync::Arc<crate::variables::QueryVariables>,
-    /// Rule-level user variables, bound as the `$rule.variables` map.
-    /// Defaults to empty; the check executor reassigns this per rule while
-    /// iterating a parsed file's applicable rules.
-    pub rule_variables: std::sync::Arc<crate::variables::QueryVariables>,
-    /// The current rule's id, bound as `$rule.id`. `None` (the default)
-    /// binds the empty sequence; the check executor sets it per rule.
-    pub rule_id: Option<String>,
+    /// The current operation entry (rule / mapping / query / assertion),
+    /// providing its `variables:` under the matching `$<entry>.variables`
+    /// namespace and (for rules) `$rule.id`. `None` (the default) binds
+    /// empty maps everywhere; executors reassign it per entry while
+    /// iterating a parsed file's entries.
+    pub entry: Option<crate::variables::EntryContext>,
 }
 
 impl XeeParseResult {
@@ -414,9 +413,8 @@ impl XeeParseResult {
     ///
     /// This is a convenience method that creates an XPathEngine and calls
     /// `query_documents_with_variables`, avoiding the need to destructure
-    /// the parse result. `$variables` comes from `self.variables`,
-    /// `$rule.variables` from `self.rule_variables`, `$rule.id` from
-    /// `self.rule_id`.
+    /// the parse result. `$variables` comes from `self.variables`; the
+    /// entry namespaces and `$rule.id` come from `self.entry`.
     pub fn query(&mut self, xpath: &str) -> Result<Vec<crate::xpath::Match>, crate::xpath::XPathError> {
         let engine = crate::xpath::XPathEngine::new();
         engine.query_documents_with_variables(
@@ -426,8 +424,7 @@ impl XeeParseResult {
             self.source_lines.clone(),
             &self.file_path,
             &self.variables,
-            &self.rule_variables,
-            self.rule_id.as_deref(),
+            self.entry.as_ref(),
         )
     }
 }
@@ -532,8 +529,7 @@ pub fn parse_string_to_xee_with_options(
         file_path,
         language: lang.to_string(),
         variables: Default::default(),
-        rule_variables: Default::default(),
-        rule_id: None,
+        entry: None,
     })
 }
 
@@ -584,8 +580,7 @@ pub fn load_xml_string_to_documents(xml: &str, file_path: String) -> Result<XeeP
         file_path,
         language: "xml".to_string(),
         variables: Default::default(),
-        rule_variables: Default::default(),
-        rule_id: None,
+        entry: None,
     })
 }
 

--- a/tractor/src/tractor_config.rs
+++ b/tractor/src/tractor_config.rs
@@ -596,13 +596,13 @@ fn convert_set(config: SetConfig, scope: &RootScope) -> Result<ConfigOperation, 
 
     let mut mappings = config.mappings.into_iter().map(|m| {
         Ok(SetMapping {
+            variables: {
+                m.variables.validate_sources()?;
+                tractor::EntryVariables::new(m.variables, tractor::EntryKind::Mapping, &m.xpath)
+            },
             xpath: m.xpath,
             value: m.value,
             value_kind: m.value_kind,
-            variables: {
-                m.variables.validate_sources()?;
-                std::sync::Arc::new(m.variables)
-            },
         })
     }).collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;
 
@@ -669,11 +669,11 @@ fn convert_query(config: QueryConfig, scope: &RootScope) -> Result<ConfigOperati
 
     let queries = config.queries.into_iter().map(|q| {
         Ok(QueryExpr {
-            xpath: q.xpath,
             variables: {
                 q.variables.validate_sources()?;
-                std::sync::Arc::new(q.variables)
+                tractor::EntryVariables::new(q.variables, tractor::EntryKind::Query, q.xpath.as_str())
             },
+            xpath: q.xpath,
         })
     }).collect::<Result<_, Box<dyn std::error::Error>>>()?;
 
@@ -721,12 +721,12 @@ fn convert_test(config: TestConfig, scope: &RootScope) -> Result<ConfigOperation
 
     let assertions = config.assertions.into_iter().map(|a| {
         Ok(TestAssertion {
-            xpath: a.xpath,
-            expect: a.expect,
             variables: {
                 a.variables.validate_sources()?;
-                std::sync::Arc::new(a.variables)
+                tractor::EntryVariables::new(a.variables, tractor::EntryKind::Assertion, a.xpath.as_str())
             },
+            xpath: a.xpath,
+            expect: a.expect,
         })
     }).collect::<Result<_, Box<dyn std::error::Error>>>()?;
 

--- a/tractor/src/tractor_config.rs
+++ b/tractor/src/tractor_config.rs
@@ -684,6 +684,18 @@ fn convert_query(config: QueryConfig, scope: &RootScope) -> Result<ConfigOperati
             QueryOutputConfig::Path(file) => (file, None),
             QueryOutputConfig::Full(full) => (full.file, full.view),
         };
+        // The path is a static property of the config, so it is checked here
+        // rather than after the query has run: `..` or an absolute path would
+        // let a config write outside its own directory.
+        let path = Path::new(&file);
+        if path.is_absolute()
+            || path.components().any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(format!(
+                "query output '{}' must be a relative path inside the config directory",
+                file
+            ).into());
+        }
         let view = match view {
             None => vec![QueryOutputField::Value],
             Some(fields) => fields
@@ -1659,6 +1671,20 @@ check:
         let yaml = "query:\n  queries:\n    - xpath: \"//name\"\n  output:\n    file: \"names.json\"\n    view: [severity]\n";
         let err = parse_config_yaml(yaml).unwrap_err();
         assert!(err.to_string().contains("invalid query output view field"), "{}", err);
+
+        // The path is knowable at load, so an escaping one fails here —
+        // before any file is parsed, let alone queried.
+        for escaping in ["../outside.json", "a/../../outside.json"] {
+            let yaml = format!(
+                "query:\n  queries:\n    - xpath: \"//name\"\n  output: \"{}\"\n",
+                escaping
+            );
+            let err = parse_config_yaml(&yaml).unwrap_err();
+            assert!(
+                err.to_string().contains("must be a relative path inside the config directory"),
+                "{} should be rejected at load: {}", escaping, err,
+            );
+        }
     }
 
     #[test]

--- a/tractor/src/tractor_config.rs
+++ b/tractor/src/tractor_config.rs
@@ -688,7 +688,7 @@ fn convert_query(config: QueryConfig, scope: &RootScope) -> Result<ConfigOperati
             None => vec![QueryOutputField::Value],
             Some(fields) => fields
                 .iter()
-                .map(|f| QueryOutputField::from_str(f))
+                .map(|f| f.parse::<QueryOutputField>())
                 .collect::<Result<Vec<_>, _>>()?,
         };
         Ok(QueryOutput { file, view })

--- a/tractor/src/tractor_config.rs
+++ b/tractor/src/tractor_config.rs
@@ -1560,8 +1560,8 @@ check:
 "#;
         let loaded = parse_config_yaml(yaml).unwrap();
         let (_, c) = as_check(&loaded.operations[0]);
-        assert_eq!(c.rules[0].variables.get("max"), Some(&VariableValue::Int(4)));
-        assert!(c.rules[1].variables.is_empty());
+        assert_eq!(c.rules[0].variables.declared().get("max"), Some(&VariableValue::Int(4)));
+        assert!(c.rules[1].variables.declared().is_empty());
         // Root-level variables stay at the config level, not copied per rule
         assert_eq!(loaded.variables.get("env"), Some(&VariableValue::String("production".into())));
     }
@@ -1592,11 +1592,11 @@ test:
         // variables for later operations), then check/set/test.
         let loaded = parse_config_yaml(yaml).unwrap();
         let (_, q) = as_query(&loaded.operations[0]);
-        assert_eq!(q.queries[0].variables.get("role"), Some(&VariableValue::String("admin".into())));
+        assert_eq!(q.queries[0].variables.declared().get("role"), Some(&VariableValue::String("admin".into())));
         let (_, s) = as_set(&loaded.operations[1]);
-        assert_eq!(s.mappings[0].variables.get("from"), Some(&VariableValue::Int(8080)));
+        assert_eq!(s.mappings[0].variables.declared().get("from"), Some(&VariableValue::Int(8080)));
         let (_, t) = as_test(&loaded.operations[2]);
-        assert_eq!(t.assertions[0].variables.get("max"), Some(&VariableValue::Int(100)));
+        assert_eq!(t.assertions[0].variables.declared().get("max"), Some(&VariableValue::Int(100)));
     }
 
     #[test]

--- a/tractor/src/tractor_config.rs
+++ b/tractor/src/tractor_config.rs
@@ -529,7 +529,8 @@ fn convert_check(config: CheckConfig, scope: &RootScope) -> Result<ConfigOperati
             rule = rule.with_invalid_examples(invalid_examples);
         }
         if !r.variables.is_empty() {
-            r.variables.validate_sources()?;
+            r.variables.validate_sources()
+                .map_err(|e| e.in_scope(format!("rule '{}'", rule.id)))?;
             rule = rule.with_variables(r.variables);
         }
         Ok::<Rule, Box<dyn std::error::Error>>(rule)
@@ -594,8 +595,9 @@ fn normalize_set_expression(
 fn convert_set(config: SetConfig, scope: &RootScope) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
-    let mut mappings = config.mappings.into_iter().map(|m| {
-        m.variables.validate_sources()?;
+    let mut mappings = config.mappings.into_iter().enumerate().map(|(i, m)| {
+        m.variables.validate_sources()
+            .map_err(|e| e.in_scope(format!("set mapping {}", i + 1)))?;
         Ok(SetMapping::new(m.xpath, m.value, m.value_kind, m.variables))
     }).collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;
 
@@ -660,8 +662,9 @@ fn convert_set(config: SetConfig, scope: &RootScope) -> Result<ConfigOperation, 
 fn convert_query(config: QueryConfig, scope: &RootScope) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
-    let queries = config.queries.into_iter().map(|q| {
-        q.variables.validate_sources()?;
+    let queries = config.queries.into_iter().enumerate().map(|(i, q)| {
+        q.variables.validate_sources()
+            .map_err(|e| e.in_scope(format!("query {}", i + 1)))?;
         Ok(QueryExpr::new(q.xpath, q.variables))
     }).collect::<Result<_, Box<dyn std::error::Error>>>()?;
 
@@ -707,8 +710,9 @@ fn convert_query(config: QueryConfig, scope: &RootScope) -> Result<ConfigOperati
 fn convert_test(config: TestConfig, scope: &RootScope) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
-    let assertions = config.assertions.into_iter().map(|a| {
-        a.variables.validate_sources()?;
+    let assertions = config.assertions.into_iter().enumerate().map(|(i, a)| {
+        a.variables.validate_sources()
+            .map_err(|e| e.in_scope(format!("test assertion {}", i + 1)))?;
         Ok(TestAssertion::new(a.xpath, a.expect, a.variables))
     }).collect::<Result<_, Box<dyn std::error::Error>>>()?;
 

--- a/tractor/src/tractor_config.rs
+++ b/tractor/src/tractor_config.rs
@@ -474,7 +474,7 @@ pub enum ConfigOperationKind {
     Test,
 }
 
-fn convert_check(config: CheckConfig, scope: &RootScope) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
+fn convert_check(config: CheckConfig, scope: &RootScope, base_dir: &Path) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let rules: Vec<Rule> = config.rules.into_iter().map(|r| {
@@ -508,7 +508,7 @@ fn convert_check(config: CheckConfig, scope: &RootScope) -> Result<ConfigOperati
             rule = rule.with_invalid_examples(invalid_examples);
         }
         if !r.variables.is_empty() {
-            rule = rule.with_variables(r.variables);
+            rule = rule.with_variables(r.variables.resolve_sources(base_dir)?);
         }
         Ok::<Rule, Box<dyn std::error::Error>>(rule)
     }).collect::<Result<_, _>>()?;
@@ -569,17 +569,17 @@ fn normalize_set_expression(
     }).collect())
 }
 
-fn convert_set(config: SetConfig, scope: &RootScope) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
+fn convert_set(config: SetConfig, scope: &RootScope, base_dir: &Path) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let mut mappings = config.mappings.into_iter().map(|m| {
-        SetMapping {
+        Ok(SetMapping {
             xpath: m.xpath,
             value: m.value,
             value_kind: m.value_kind,
-            variables: std::sync::Arc::new(m.variables),
-        }
-    }).collect::<Vec<_>>();
+            variables: std::sync::Arc::new(m.variables.resolve_sources(base_dir)?),
+        })
+    }).collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;
 
     if let Some(ref expr) = config.expression {
         mappings.extend(normalize_set_expression(expr, config.value.as_deref())?);
@@ -639,15 +639,15 @@ fn convert_set(config: SetConfig, scope: &RootScope) -> Result<ConfigOperation, 
     Ok(ConfigOperation::Set { inputs, op })
 }
 
-fn convert_query(config: QueryConfig, scope: &RootScope) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
+fn convert_query(config: QueryConfig, scope: &RootScope, base_dir: &Path) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let queries = config.queries.into_iter().map(|q| {
-        QueryExpr {
+        Ok(QueryExpr {
             xpath: q.xpath,
-            variables: std::sync::Arc::new(q.variables),
-        }
-    }).collect();
+            variables: std::sync::Arc::new(q.variables.resolve_sources(base_dir)?),
+        })
+    }).collect::<Result<_, Box<dyn std::error::Error>>>()?;
 
     let (files, exclude, diff_files, diff_lines) = merge_scope(scope, config.files, config.exclude, config.diff_files, config.diff_lines);
 
@@ -672,16 +672,16 @@ fn convert_query(config: QueryConfig, scope: &RootScope) -> Result<ConfigOperati
     Ok(ConfigOperation::Query { inputs, op })
 }
 
-fn convert_test(config: TestConfig, scope: &RootScope) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
+fn convert_test(config: TestConfig, scope: &RootScope, base_dir: &Path) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let assertions = config.assertions.into_iter().map(|a| {
-        TestAssertion {
+        Ok(TestAssertion {
             xpath: a.xpath,
             expect: a.expect,
-            variables: std::sync::Arc::new(a.variables),
-        }
-    }).collect();
+            variables: std::sync::Arc::new(a.variables.resolve_sources(base_dir)?),
+        })
+    }).collect::<Result<_, Box<dyn std::error::Error>>>()?;
 
     let (files, exclude, diff_files, diff_lines) = merge_scope(scope, config.files, config.exclude, config.diff_files, config.diff_lines);
 
@@ -741,7 +741,7 @@ fn merge_scope(
     (op_files, exclude, diff_files, diff_lines)
 }
 
-fn config_to_operations(config: ConfigFile) -> Result<LoadedConfig, Box<dyn std::error::Error>> {
+fn config_to_operations(config: ConfigFile, base_dir: &Path) -> Result<LoadedConfig, Box<dyn std::error::Error>> {
     let root_files = config.files;
 
     let scope = RootScope {
@@ -754,37 +754,37 @@ fn config_to_operations(config: ConfigFile) -> Result<LoadedConfig, Box<dyn std:
 
     // Root-level shorthand keys first
     if let Some(check) = config.check {
-        ops.push(convert_check(check, &scope)?);
+        ops.push(convert_check(check, &scope, base_dir)?);
     }
     if let Some(set) = config.set {
-        ops.push(convert_set(set, &scope)?);
+        ops.push(convert_set(set, &scope, base_dir)?);
     }
     if let Some(query) = config.query {
-        ops.push(convert_query(query, &scope)?);
+        ops.push(convert_query(query, &scope, base_dir)?);
     }
     if let Some(test) = config.test {
-        ops.push(convert_test(test, &scope)?);
+        ops.push(convert_test(test, &scope, base_dir)?);
     }
 
     // Then explicit operations list
     for entry in config.operations {
         if let Some(c) = entry.check {
-            ops.push(convert_check(c, &scope)?);
+            ops.push(convert_check(c, &scope, base_dir)?);
         }
         if let Some(s) = entry.set {
-            ops.push(convert_set(s, &scope)?);
+            ops.push(convert_set(s, &scope, base_dir)?);
         }
         if let Some(q) = entry.query {
-            ops.push(convert_query(q, &scope)?);
+            ops.push(convert_query(q, &scope, base_dir)?);
         }
         if let Some(t) = entry.test {
-            ops.push(convert_test(t, &scope)?);
+            ops.push(convert_test(t, &scope, base_dir)?);
         }
     }
 
     Ok(LoadedConfig {
         root_files,
-        variables: config.variables,
+        variables: config.variables.resolve_sources(base_dir)?,
         operations: ops,
     })
 }
@@ -803,8 +803,9 @@ pub struct LoadedConfig {
     /// explicitly empty.
     pub root_files: Option<Vec<String>>,
     /// User-defined variables from the root-level `variables:` key, bound
-    /// as `$variables` in every query of the run. A future `variables-file:`
-    /// key merges into this same map (inline wins).
+    /// as `$variables` in every query of the run. `$`-directive sources
+    /// (`$file`, `$literal`) are already resolved — each source's data
+    /// lives under its own name, never merged.
     pub variables: QueryVariables,
     /// Parsed operations paired with their per-op input-resolution data.
     /// Sources/filters are filled in by the runner once the shared
@@ -828,9 +829,15 @@ pub fn load_tractor_config(path: &Path) -> Result<LoadedConfig, Box<dyn std::err
     let content = std::fs::read_to_string(path)
         .map_err(|e| format!("cannot read '{}': {}", path.display(), e))?;
 
+    // `$file` variable sources resolve relative to the config file's
+    // directory, same as globs.
+    let base_dir = path.parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+
     match path.extension().and_then(|e| e.to_str()) {
-        Some("yml") | Some("yaml") => parse_config_yaml(&content),
-        Some("toml") => parse_config_toml(&content),
+        Some("yml") | Some("yaml") => parse_config_yaml_at(&content, base_dir),
+        Some("toml") => parse_config_toml_at(&content, base_dir),
         Some(ext) => Err(format!(
             "unsupported config file extension '.{}': use .yaml, .yml, or .toml",
             ext
@@ -839,18 +846,36 @@ pub fn load_tractor_config(path: &Path) -> Result<LoadedConfig, Box<dyn std::err
     }
 }
 
-/// Parse a tractor config from a YAML string.
+/// Parse a tractor config from a YAML string. `$file` variable sources
+/// resolve relative to the current directory; prefer [`parse_config_yaml_at`]
+/// when the config's own directory is known.
+#[cfg(test)]
 pub fn parse_config_yaml(content: &str) -> Result<LoadedConfig, Box<dyn std::error::Error>> {
-    let config: ConfigFile = serde_yaml::from_str(content)
-        .map_err(|e| format!("invalid tractor config YAML: {}", e))?;
-    config_to_operations(config)
+    parse_config_yaml_at(content, Path::new("."))
 }
 
-/// Parse a tractor config from a TOML string.
+/// Parse a tractor config from a YAML string, resolving `$file` variable
+/// sources against `base_dir`.
+pub fn parse_config_yaml_at(content: &str, base_dir: &Path) -> Result<LoadedConfig, Box<dyn std::error::Error>> {
+    let config: ConfigFile = serde_yaml::from_str(content)
+        .map_err(|e| format!("invalid tractor config YAML: {}", e))?;
+    config_to_operations(config, base_dir)
+}
+
+/// Parse a tractor config from a TOML string. `$file` variable sources
+/// resolve relative to the current directory; prefer [`parse_config_toml_at`]
+/// when the config's own directory is known.
+#[cfg(test)]
 pub fn parse_config_toml(content: &str) -> Result<LoadedConfig, Box<dyn std::error::Error>> {
+    parse_config_toml_at(content, Path::new("."))
+}
+
+/// Parse a tractor config from a TOML string, resolving `$file` variable
+/// sources against `base_dir`.
+pub fn parse_config_toml_at(content: &str, base_dir: &Path) -> Result<LoadedConfig, Box<dyn std::error::Error>> {
     let config: ConfigFile = toml::from_str(content)
         .map_err(|e| format!("invalid tractor config TOML: {}", e))?;
-    config_to_operations(config)
+    config_to_operations(config, base_dir)
 }
 
 // ---------------------------------------------------------------------------
@@ -1549,6 +1574,58 @@ test:
         assert_eq!(q.queries[0].variables.get("role"), Some(&VariableValue::String("admin".into())));
         let (_, t) = as_test(&loaded.operations[2]);
         assert_eq!(t.assertions[0].variables.get("max"), Some(&VariableValue::Int(100)));
+    }
+
+    #[test]
+    fn parse_yaml_variable_file_sources() {
+        use tractor::variables::VariableValue;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("settings.yml"), "db:\n  host: localhost\n").unwrap();
+        std::fs::write(dir.path().join("prefixes.json"), r#"["Assert", "Should"]"#).unwrap();
+
+        let yaml = r#"
+variables:
+  env: production
+  settings:
+    $file: settings.yml
+check:
+  rules:
+    - id: r
+      xpath: "//x"
+      variables:
+        prefixes:
+          $file: prefixes.json
+"#;
+        let loaded = parse_config_yaml_at(yaml, dir.path()).unwrap();
+
+        // Root: inline and file-sourced names coexist, each under its own key.
+        assert_eq!(loaded.variables.get("env"), Some(&VariableValue::String("production".into())));
+        match loaded.variables.get("settings") {
+            Some(VariableValue::Map(m)) => assert!(matches!(m.get("db"), Some(VariableValue::Map(_)))),
+            other => panic!("expected settings map, got {:?}", other),
+        }
+
+        // Entry-level variables resolve sources too.
+        let (_, c) = as_check(&loaded.operations[0]);
+        assert_eq!(
+            c.rules[0].variables.get("prefixes"),
+            Some(&VariableValue::Array(vec![
+                VariableValue::String("Assert".into()),
+                VariableValue::String("Should".into()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn parse_yaml_variable_source_errors_are_fatal() {
+        let yaml = "variables:\n  x:\n    $file: does-not-exist.yml\n";
+        let err = parse_config_yaml(yaml).unwrap_err();
+        assert!(err.to_string().contains("cannot read"), "{}", err);
+
+        let yaml = "variables:\n  x:\n    $query:\n      xpath: //a\n";
+        let err = parse_config_yaml(yaml).unwrap_err();
+        assert!(err.to_string().contains("not implemented"), "{}", err);
     }
 
     #[test]

--- a/tractor/src/tractor_config.rs
+++ b/tractor/src/tractor_config.rs
@@ -575,35 +575,28 @@ fn normalize_set_expression(
     explicit_value: Option<&str>,
 ) -> Result<Vec<SetMapping>, Box<dyn std::error::Error>> {
     if let Some(value) = explicit_value {
-        return Ok(vec![SetMapping {
-            xpath: selector_xpath(expr),
-            value: value.to_string(),
-            value_kind: Some("string".to_string()),
-            variables: Default::default(),
-        }]);
+        return Ok(vec![SetMapping::new(
+            selector_xpath(expr),
+            value,
+            Some("string".to_string()),
+            QueryVariables::new(),
+        )]);
     }
 
-    Ok(parse_set_expr(expr)?.into_iter().map(|op| SetMapping {
-        xpath: op.xpath,
-        value: op.value.text().to_string(),
-        value_kind: Some(op.value.kind().to_string()),
-        variables: Default::default(),
-    }).collect())
+    Ok(parse_set_expr(expr)?.into_iter().map(|op| SetMapping::new(
+        op.xpath,
+        op.value.text(),
+        Some(op.value.kind().to_string()),
+        QueryVariables::new(),
+    )).collect())
 }
 
 fn convert_set(config: SetConfig, scope: &RootScope) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let mut mappings = config.mappings.into_iter().map(|m| {
-        Ok(SetMapping {
-            variables: {
-                m.variables.validate_sources()?;
-                tractor::EntryVariables::new(m.variables, tractor::EntryKind::Mapping, &m.xpath)
-            },
-            xpath: m.xpath,
-            value: m.value,
-            value_kind: m.value_kind,
-        })
+        m.variables.validate_sources()?;
+        Ok(SetMapping::new(m.xpath, m.value, m.value_kind, m.variables))
     }).collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;
 
     if let Some(ref expr) = config.expression {
@@ -668,13 +661,8 @@ fn convert_query(config: QueryConfig, scope: &RootScope) -> Result<ConfigOperati
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let queries = config.queries.into_iter().map(|q| {
-        Ok(QueryExpr {
-            variables: {
-                q.variables.validate_sources()?;
-                tractor::EntryVariables::new(q.variables, tractor::EntryKind::Query, q.xpath.as_str())
-            },
-            xpath: q.xpath,
-        })
+        q.variables.validate_sources()?;
+        Ok(QueryExpr::new(q.xpath, q.variables))
     }).collect::<Result<_, Box<dyn std::error::Error>>>()?;
 
     let (files, exclude, diff_files, diff_lines) = merge_scope(scope, config.files, config.exclude, config.diff_files, config.diff_lines);
@@ -720,14 +708,8 @@ fn convert_test(config: TestConfig, scope: &RootScope) -> Result<ConfigOperation
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let assertions = config.assertions.into_iter().map(|a| {
-        Ok(TestAssertion {
-            variables: {
-                a.variables.validate_sources()?;
-                tractor::EntryVariables::new(a.variables, tractor::EntryKind::Assertion, a.xpath.as_str())
-            },
-            xpath: a.xpath,
-            expect: a.expect,
-        })
+        a.variables.validate_sources()?;
+        Ok(TestAssertion::new(a.xpath, a.expect, a.variables))
     }).collect::<Result<_, Box<dyn std::error::Error>>>()?;
 
     let (files, exclude, diff_files, diff_lines) = merge_scope(scope, config.files, config.exclude, config.diff_files, config.diff_lines);

--- a/tractor/src/tractor_config.rs
+++ b/tractor/src/tractor_config.rs
@@ -37,8 +37,8 @@ use tractor::rule::Rule;
 use tractor::tree_mode::TreeMode;
 
 use crate::executor::{
-    QueryExpr, QueryOperation, SetMapping, SetOperation, SetReportMode, SetWriteMode,
-    TestAssertion, TestOperation,
+    QueryExpr, QueryOperation, QueryOutput, QueryOutputField, SetMapping, SetOperation,
+    SetReportMode, SetWriteMode, TestAssertion, TestOperation,
 };
 use crate::input::Source;
 
@@ -250,6 +250,10 @@ struct QueryConfig {
     language: Option<String>,
     #[serde(default)]
     limit: Option<usize>,
+    /// Materialize results into a JSON index keyed by source file, for
+    /// later operations to consume via a `$file` variable source.
+    #[serde(default)]
+    output: Option<QueryOutputConfig>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -260,6 +264,23 @@ struct QueryExprConfig {
     /// expression.
     #[serde(default)]
     variables: QueryVariables,
+}
+
+/// Query output settings: a bare path string, or `{file, view}`.
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+enum QueryOutputConfig {
+    Path(String),
+    Full(QueryOutputFullConfig),
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+struct QueryOutputFullConfig {
+    file: String,
+    /// Fields stored per entry (default: `[value]`, written as bare strings).
+    #[serde(default)]
+    view: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -474,7 +495,7 @@ pub enum ConfigOperationKind {
     Test,
 }
 
-fn convert_check(config: CheckConfig, scope: &RootScope, base_dir: &Path) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
+fn convert_check(config: CheckConfig, scope: &RootScope) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let rules: Vec<Rule> = config.rules.into_iter().map(|r| {
@@ -508,7 +529,8 @@ fn convert_check(config: CheckConfig, scope: &RootScope, base_dir: &Path) -> Res
             rule = rule.with_invalid_examples(invalid_examples);
         }
         if !r.variables.is_empty() {
-            rule = rule.with_variables(r.variables.resolve_sources(base_dir)?);
+            r.variables.validate_sources()?;
+            rule = rule.with_variables(r.variables);
         }
         Ok::<Rule, Box<dyn std::error::Error>>(rule)
     }).collect::<Result<_, _>>()?;
@@ -569,7 +591,7 @@ fn normalize_set_expression(
     }).collect())
 }
 
-fn convert_set(config: SetConfig, scope: &RootScope, base_dir: &Path) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
+fn convert_set(config: SetConfig, scope: &RootScope) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let mut mappings = config.mappings.into_iter().map(|m| {
@@ -577,7 +599,10 @@ fn convert_set(config: SetConfig, scope: &RootScope, base_dir: &Path) -> Result<
             xpath: m.xpath,
             value: m.value,
             value_kind: m.value_kind,
-            variables: std::sync::Arc::new(m.variables.resolve_sources(base_dir)?),
+            variables: {
+                m.variables.validate_sources()?;
+                std::sync::Arc::new(m.variables)
+            },
         })
     }).collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;
 
@@ -639,13 +664,16 @@ fn convert_set(config: SetConfig, scope: &RootScope, base_dir: &Path) -> Result<
     Ok(ConfigOperation::Set { inputs, op })
 }
 
-fn convert_query(config: QueryConfig, scope: &RootScope, base_dir: &Path) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
+fn convert_query(config: QueryConfig, scope: &RootScope) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let queries = config.queries.into_iter().map(|q| {
         Ok(QueryExpr {
             xpath: q.xpath,
-            variables: std::sync::Arc::new(q.variables.resolve_sources(base_dir)?),
+            variables: {
+                q.variables.validate_sources()?;
+                std::sync::Arc::new(q.variables)
+            },
         })
     }).collect::<Result<_, Box<dyn std::error::Error>>>()?;
 
@@ -660,6 +688,21 @@ fn convert_query(config: QueryConfig, scope: &RootScope, base_dir: &Path) -> Res
         inline_source: None,
     };
 
+    let output = config.output.map(|o| -> Result<QueryOutput, Box<dyn std::error::Error>> {
+        let (file, view) = match o {
+            QueryOutputConfig::Path(file) => (file, None),
+            QueryOutputConfig::Full(full) => (full.file, full.view),
+        };
+        let view = match view {
+            None => vec![QueryOutputField::Value],
+            Some(fields) => fields
+                .iter()
+                .map(|f| QueryOutputField::from_str(f))
+                .collect::<Result<Vec<_>, _>>()?,
+        };
+        Ok(QueryOutput { file, view })
+    }).transpose()?;
+
     let op = QueryOperation {
         queries,
         tree_mode,
@@ -667,19 +710,23 @@ fn convert_query(config: QueryConfig, scope: &RootScope, base_dir: &Path) -> Res
         limit: config.limit,
         ignore_whitespace: false,
         parse_depth: None,
+        output,
     };
 
     Ok(ConfigOperation::Query { inputs, op })
 }
 
-fn convert_test(config: TestConfig, scope: &RootScope, base_dir: &Path) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
+fn convert_test(config: TestConfig, scope: &RootScope) -> Result<ConfigOperation, Box<dyn std::error::Error>> {
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let assertions = config.assertions.into_iter().map(|a| {
         Ok(TestAssertion {
             xpath: a.xpath,
             expect: a.expect,
-            variables: std::sync::Arc::new(a.variables.resolve_sources(base_dir)?),
+            variables: {
+                a.variables.validate_sources()?;
+                std::sync::Arc::new(a.variables)
+            },
         })
     }).collect::<Result<_, Box<dyn std::error::Error>>>()?;
 
@@ -741,7 +788,7 @@ fn merge_scope(
     (op_files, exclude, diff_files, diff_lines)
 }
 
-fn config_to_operations(config: ConfigFile, base_dir: &Path) -> Result<LoadedConfig, Box<dyn std::error::Error>> {
+fn config_to_operations(config: ConfigFile) -> Result<LoadedConfig, Box<dyn std::error::Error>> {
     let root_files = config.files;
 
     let scope = RootScope {
@@ -752,39 +799,47 @@ fn config_to_operations(config: ConfigFile, base_dir: &Path) -> Result<LoadedCon
 
     let mut ops = Vec::new();
 
-    // Root-level shorthand keys first
+    // Root-level shorthand keys first. Query goes ahead of the others: a
+    // query op can materialize variables (`output:`) that later operations
+    // consume, and variable sources resolve at each op's start — gathering
+    // before checking is the sane default. Order-dependent flows beyond
+    // that use the explicit `operations:` list, which runs exactly in
+    // written order.
+    if let Some(query) = config.query {
+        ops.push(convert_query(query, &scope)?);
+    }
     if let Some(check) = config.check {
-        ops.push(convert_check(check, &scope, base_dir)?);
+        ops.push(convert_check(check, &scope)?);
     }
     if let Some(set) = config.set {
-        ops.push(convert_set(set, &scope, base_dir)?);
-    }
-    if let Some(query) = config.query {
-        ops.push(convert_query(query, &scope, base_dir)?);
+        ops.push(convert_set(set, &scope)?);
     }
     if let Some(test) = config.test {
-        ops.push(convert_test(test, &scope, base_dir)?);
+        ops.push(convert_test(test, &scope)?);
     }
 
     // Then explicit operations list
     for entry in config.operations {
         if let Some(c) = entry.check {
-            ops.push(convert_check(c, &scope, base_dir)?);
+            ops.push(convert_check(c, &scope)?);
         }
         if let Some(s) = entry.set {
-            ops.push(convert_set(s, &scope, base_dir)?);
+            ops.push(convert_set(s, &scope)?);
         }
         if let Some(q) = entry.query {
-            ops.push(convert_query(q, &scope, base_dir)?);
+            ops.push(convert_query(q, &scope)?);
         }
         if let Some(t) = entry.test {
-            ops.push(convert_test(t, &scope, base_dir)?);
+            ops.push(convert_test(t, &scope)?);
         }
     }
 
     Ok(LoadedConfig {
         root_files,
-        variables: config.variables.resolve_sources(base_dir)?,
+        variables: {
+            config.variables.validate_sources()?;
+            config.variables
+        },
         operations: ops,
     })
 }
@@ -829,15 +884,9 @@ pub fn load_tractor_config(path: &Path) -> Result<LoadedConfig, Box<dyn std::err
     let content = std::fs::read_to_string(path)
         .map_err(|e| format!("cannot read '{}': {}", path.display(), e))?;
 
-    // `$file` variable sources resolve relative to the config file's
-    // directory, same as globs.
-    let base_dir = path.parent()
-        .filter(|p| !p.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-
     match path.extension().and_then(|e| e.to_str()) {
-        Some("yml") | Some("yaml") => parse_config_yaml_at(&content, base_dir),
-        Some("toml") => parse_config_toml_at(&content, base_dir),
+        Some("yml") | Some("yaml") => parse_config_yaml(&content),
+        Some("toml") => parse_config_toml(&content),
         Some(ext) => Err(format!(
             "unsupported config file extension '.{}': use .yaml, .yml, or .toml",
             ext
@@ -846,36 +895,22 @@ pub fn load_tractor_config(path: &Path) -> Result<LoadedConfig, Box<dyn std::err
     }
 }
 
-/// Parse a tractor config from a YAML string. `$file` variable sources
-/// resolve relative to the current directory; prefer [`parse_config_yaml_at`]
-/// when the config's own directory is known.
-#[cfg(test)]
+/// Parse a tractor config from a YAML string. `$`-directive variable
+/// sources are validated statically here; the file reads happen at each
+/// operation's start (against the run's base dir).
 pub fn parse_config_yaml(content: &str) -> Result<LoadedConfig, Box<dyn std::error::Error>> {
-    parse_config_yaml_at(content, Path::new("."))
-}
-
-/// Parse a tractor config from a YAML string, resolving `$file` variable
-/// sources against `base_dir`.
-pub fn parse_config_yaml_at(content: &str, base_dir: &Path) -> Result<LoadedConfig, Box<dyn std::error::Error>> {
     let config: ConfigFile = serde_yaml::from_str(content)
         .map_err(|e| format!("invalid tractor config YAML: {}", e))?;
-    config_to_operations(config, base_dir)
+    config_to_operations(config)
 }
 
-/// Parse a tractor config from a TOML string. `$file` variable sources
-/// resolve relative to the current directory; prefer [`parse_config_toml_at`]
-/// when the config's own directory is known.
-#[cfg(test)]
+/// Parse a tractor config from a TOML string. `$`-directive variable
+/// sources are validated statically here; the file reads happen at each
+/// operation's start (against the run's base dir).
 pub fn parse_config_toml(content: &str) -> Result<LoadedConfig, Box<dyn std::error::Error>> {
-    parse_config_toml_at(content, Path::new("."))
-}
-
-/// Parse a tractor config from a TOML string, resolving `$file` variable
-/// sources against `base_dir`.
-pub fn parse_config_toml_at(content: &str, base_dir: &Path) -> Result<LoadedConfig, Box<dyn std::error::Error>> {
     let config: ConfigFile = toml::from_str(content)
         .map_err(|e| format!("invalid tractor config TOML: {}", e))?;
-    config_to_operations(config, base_dir)
+    config_to_operations(config)
 }
 
 // ---------------------------------------------------------------------------
@@ -1567,23 +1602,24 @@ test:
       variables:
         max: 100
 "#;
+        // Shorthand normalization puts query first (it can materialize
+        // variables for later operations), then check/set/test.
         let loaded = parse_config_yaml(yaml).unwrap();
-        let (_, s) = as_set(&loaded.operations[0]);
-        assert_eq!(s.mappings[0].variables.get("from"), Some(&VariableValue::Int(8080)));
-        let (_, q) = as_query(&loaded.operations[1]);
+        let (_, q) = as_query(&loaded.operations[0]);
         assert_eq!(q.queries[0].variables.get("role"), Some(&VariableValue::String("admin".into())));
+        let (_, s) = as_set(&loaded.operations[1]);
+        assert_eq!(s.mappings[0].variables.get("from"), Some(&VariableValue::Int(8080)));
         let (_, t) = as_test(&loaded.operations[2]);
         assert_eq!(t.assertions[0].variables.get("max"), Some(&VariableValue::Int(100)));
     }
 
     #[test]
-    fn parse_yaml_variable_file_sources() {
+    fn parse_yaml_variable_file_sources_stay_raw_until_execution() {
         use tractor::variables::VariableValue;
 
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("settings.yml"), "db:\n  host: localhost\n").unwrap();
-        std::fs::write(dir.path().join("prefixes.json"), r#"["Assert", "Should"]"#).unwrap();
-
+        // The referenced files deliberately do NOT exist: parse only
+        // validates directives statically — reads happen at op start, so a
+        // file produced by an earlier operation in the run can be consumed.
         let yaml = r#"
 variables:
   env: production
@@ -1597,35 +1633,64 @@ check:
         prefixes:
           $file: prefixes.json
 "#;
-        let loaded = parse_config_yaml_at(yaml, dir.path()).unwrap();
+        let loaded = parse_config_yaml(yaml).unwrap();
 
-        // Root: inline and file-sourced names coexist, each under its own key.
         assert_eq!(loaded.variables.get("env"), Some(&VariableValue::String("production".into())));
+        // The directive is preserved raw for execution-time resolution.
+        assert!(loaded.variables.has_sources());
         match loaded.variables.get("settings") {
-            Some(VariableValue::Map(m)) => assert!(matches!(m.get("db"), Some(VariableValue::Map(_)))),
-            other => panic!("expected settings map, got {:?}", other),
+            Some(VariableValue::Map(m)) => {
+                assert_eq!(m.get("$file"), Some(&VariableValue::String("settings.yml".into())));
+            }
+            other => panic!("expected raw directive map, got {:?}", other),
         }
-
-        // Entry-level variables resolve sources too.
         let (_, c) = as_check(&loaded.operations[0]);
-        assert_eq!(
-            c.rules[0].variables.get("prefixes"),
-            Some(&VariableValue::Array(vec![
-                VariableValue::String("Assert".into()),
-                VariableValue::String("Should".into()),
-            ]))
-        );
+        assert!(c.rules[0].variables.has_sources());
     }
 
     #[test]
-    fn parse_yaml_variable_source_errors_are_fatal() {
-        let yaml = "variables:\n  x:\n    $file: does-not-exist.yml\n";
-        let err = parse_config_yaml(yaml).unwrap_err();
-        assert!(err.to_string().contains("cannot read"), "{}", err);
+    fn parse_yaml_query_output() {
+        // Shorthand: bare path, default view ([value] → bare strings).
+        let yaml = "query:\n  queries:\n    - xpath: \"//name\"\n  output: \"gathered/names.json\"\n";
+        let (_, q) = match &parse_config_yaml(yaml).unwrap().operations[0] {
+            ConfigOperation::Query { inputs, op } => (inputs, op.clone()),
+            other => panic!("expected query, got {:?}", other),
+        };
+        let output = q.output.unwrap();
+        assert_eq!(output.file, "gathered/names.json");
+        assert_eq!(output.view, vec![QueryOutputField::Value]);
 
+        // Full form with an explicit view.
+        let yaml = "query:\n  queries:\n    - xpath: \"//name\"\n  output:\n    file: \"names.json\"\n    view: [value, line]\n";
+        let (_, q) = match &parse_config_yaml(yaml).unwrap().operations[0] {
+            ConfigOperation::Query { inputs, op } => (inputs, op.clone()),
+            other => panic!("expected query, got {:?}", other),
+        };
+        let output = q.output.unwrap();
+        assert_eq!(output.view, vec![QueryOutputField::Value, QueryOutputField::Line]);
+
+        // Unknown view field fails loudly.
+        let yaml = "query:\n  queries:\n    - xpath: \"//name\"\n  output:\n    file: \"names.json\"\n    view: [severity]\n";
+        let err = parse_config_yaml(yaml).unwrap_err();
+        assert!(err.to_string().contains("invalid query output view field"), "{}", err);
+    }
+
+    #[test]
+    fn parse_yaml_variable_source_static_errors_are_fatal() {
+        // Static directive problems fail at load — before any operation
+        // runs. (A missing file is a *runtime* error, since the file may be
+        // produced mid-run by an earlier operation.)
         let yaml = "variables:\n  x:\n    $query:\n      xpath: //a\n";
         let err = parse_config_yaml(yaml).unwrap_err();
         assert!(err.to_string().contains("not implemented"), "{}", err);
+
+        let yaml = "variables:\n  x:\n    $fiel: vars.yml\n";
+        let err = parse_config_yaml(yaml).unwrap_err();
+        assert!(err.to_string().contains("unknown variable source directive"), "{}", err);
+
+        let yaml = "check:\n  rules:\n    - id: r\n      xpath: \"//x\"\n      variables:\n        x:\n          $file: [not, a, string]\n";
+        let err = parse_config_yaml(yaml).unwrap_err();
+        assert!(err.to_string().contains("expects a path string"), "{}", err);
     }
 
     #[test]

--- a/tractor/src/tractor_config.rs
+++ b/tractor/src/tractor_config.rs
@@ -31,6 +31,7 @@ use std::path::Path;
 use serde::Deserialize;
 use tractor::declarative_set::parse_set_expr;
 use tractor::normalized_xpath::NormalizedXpath;
+use tractor::variables::QueryVariables;
 use tractor::report::Severity;
 use tractor::rule::Rule;
 use tractor::tree_mode::TreeMode;
@@ -67,6 +68,13 @@ struct ConfigFile {
     /// Root-level git diff spec: only include matches in changed hunks.
     #[serde(default, rename = "diff-lines")]
     diff_lines: Option<String>,
+
+    /// User-defined variables, bound as the `$variables` map in the XPath
+    /// dynamic context of every query in this config run (e.g.
+    /// `$variables?env`). Values may be scalars, lists, or nested mappings
+    /// (bound as XPath arrays/maps with JSON semantics).
+    #[serde(default)]
+    variables: QueryVariables,
 
     /// Root-level check shorthand (single check operation).
     #[serde(default)]
@@ -152,6 +160,11 @@ struct CheckRuleConfig {
     tree_mode: Option<String>,
     #[serde(default)]
     expect: Vec<CheckExpectEntry>,
+    /// Rule-level variables, bound as the `$rule.variables` map in this
+    /// rule's queries (e.g. `$rule.variables?max`). The root-level
+    /// `variables:` stay separately reachable as `$variables`.
+    #[serde(default)]
+    variables: QueryVariables,
 }
 
 /// A single expectation entry for check rules in tractor config files.
@@ -482,6 +495,9 @@ fn convert_check(config: CheckConfig, scope: &RootScope) -> Result<ConfigOperati
         if !invalid_examples.is_empty() {
             rule = rule.with_invalid_examples(invalid_examples);
         }
+        if !r.variables.is_empty() {
+            rule = rule.with_variables(r.variables);
+        }
         Ok::<Rule, Box<dyn std::error::Error>>(rule)
     }).collect::<Result<_, _>>()?;
 
@@ -749,6 +765,7 @@ fn config_to_operations(config: ConfigFile) -> Result<LoadedConfig, Box<dyn std:
 
     Ok(LoadedConfig {
         root_files,
+        variables: config.variables,
         operations: ops,
     })
 }
@@ -766,6 +783,10 @@ pub struct LoadedConfig {
     /// `None` when the key is missing (unrestricted); `Some(vec![])` when
     /// explicitly empty.
     pub root_files: Option<Vec<String>>,
+    /// User-defined variables from the root-level `variables:` key, bound
+    /// as `$variables` in every query of the run. A future `variables-file:`
+    /// key merges into this same map (inline wins).
+    pub variables: QueryVariables,
     /// Parsed operations paired with their per-op input-resolution data.
     /// Sources/filters are filled in by the runner once the shared
     /// `FileResolver` has resolved each operation's file set.
@@ -776,6 +797,7 @@ impl std::fmt::Debug for LoadedConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LoadedConfig")
             .field("root_files", &self.root_files)
+            .field("variables", &self.variables)
             .field("operations", &self.operations)
             .finish()
     }
@@ -1419,6 +1441,83 @@ check:
         let (_, c) = as_check(&ops[0]);
         assert_eq!(c.rules[0].valid_examples, vec!["fn main() {}"]);
         assert_eq!(c.rules[0].invalid_examples, vec!["// TODO: fix"]);
+    }
+
+    // -- Variables --
+
+    #[test]
+    fn parse_yaml_variables() {
+        use tractor::variables::VariableValue;
+        let yaml = r#"
+variables:
+  env: production
+  max-lines: 500
+  strict: true
+  allowed: [a, b]
+check:
+  rules:
+    - id: env-gate
+      xpath: "//comment[$variables?env = 'production']"
+"#;
+        let loaded = parse_config_yaml(yaml).unwrap();
+        assert_eq!(loaded.variables.get("env"), Some(&VariableValue::String("production".into())));
+        assert_eq!(loaded.variables.get("max-lines"), Some(&VariableValue::Int(500)));
+        assert_eq!(loaded.variables.get("strict"), Some(&VariableValue::Bool(true)));
+        assert!(matches!(loaded.variables.get("allowed"), Some(VariableValue::Array(_))));
+    }
+
+    #[test]
+    fn parse_yaml_variables_absent_is_empty() {
+        let yaml = r#"
+check:
+  rules:
+    - id: r
+      xpath: "//x"
+"#;
+        let loaded = parse_config_yaml(yaml).unwrap();
+        assert!(loaded.variables.is_empty());
+    }
+
+    #[test]
+    fn parse_yaml_rule_level_variables() {
+        use tractor::variables::VariableValue;
+        let yaml = r#"
+variables:
+  env: production
+check:
+  rules:
+    - id: with-vars
+      xpath: "//function[count(param) > $rule.variables?max]"
+      variables:
+        max: 4
+    - id: without-vars
+      xpath: "//x"
+"#;
+        let loaded = parse_config_yaml(yaml).unwrap();
+        let (_, c) = as_check(&loaded.operations[0]);
+        assert_eq!(c.rules[0].variables.get("max"), Some(&VariableValue::Int(4)));
+        assert!(c.rules[1].variables.is_empty());
+        // Root-level variables stay at the config level, not copied per rule
+        assert_eq!(loaded.variables.get("env"), Some(&VariableValue::String("production".into())));
+    }
+
+    #[test]
+    fn parse_toml_variables() {
+        use tractor::variables::VariableValue;
+        let toml = r#"
+[variables]
+env = "production"
+max = 10
+
+[query]
+files = ["*.json"]
+
+[[query.queries]]
+xpath = "//name"
+"#;
+        let loaded = parse_config_toml(toml).unwrap();
+        assert_eq!(loaded.variables.get("env"), Some(&VariableValue::String("production".into())));
+        assert_eq!(loaded.variables.get("max"), Some(&VariableValue::Int(10)));
     }
 
     // -- XPath normalization (implicit // prefix) --

--- a/tractor/src/tractor_config.rs
+++ b/tractor/src/tractor_config.rs
@@ -225,6 +225,10 @@ struct SetMappingConfig {
     value: String,
     #[serde(default, rename = "value-kind", alias = "kind", alias = "type")]
     value_kind: Option<String>,
+    /// Mapping-level variables, bound as the `$mapping.variables` map in
+    /// this mapping's xpath.
+    #[serde(default)]
+    variables: QueryVariables,
 }
 
 #[derive(Deserialize, Debug)]
@@ -252,6 +256,10 @@ struct QueryConfig {
 #[serde(deny_unknown_fields)]
 struct QueryExprConfig {
     xpath: NormalizedXpath,
+    /// Query-level variables, bound as the `$query.variables` map in this
+    /// expression.
+    #[serde(default)]
+    variables: QueryVariables,
 }
 
 #[derive(Deserialize, Debug)]
@@ -281,6 +289,10 @@ struct TestAssertionConfig {
     xpath: NormalizedXpath,
     #[serde(default = "default_expect")]
     expect: String,
+    /// Assertion-level variables, bound as the `$assertion.variables` map
+    /// in this assertion.
+    #[serde(default)]
+    variables: QueryVariables,
 }
 
 fn default_expect() -> String {
@@ -545,6 +557,7 @@ fn normalize_set_expression(
             xpath: selector_xpath(expr),
             value: value.to_string(),
             value_kind: Some("string".to_string()),
+            variables: Default::default(),
         }]);
     }
 
@@ -552,6 +565,7 @@ fn normalize_set_expression(
         xpath: op.xpath,
         value: op.value.text().to_string(),
         value_kind: Some(op.value.kind().to_string()),
+        variables: Default::default(),
     }).collect())
 }
 
@@ -563,6 +577,7 @@ fn convert_set(config: SetConfig, scope: &RootScope) -> Result<ConfigOperation, 
             xpath: m.xpath,
             value: m.value,
             value_kind: m.value_kind,
+            variables: std::sync::Arc::new(m.variables),
         }
     }).collect::<Vec<_>>();
 
@@ -628,7 +643,10 @@ fn convert_query(config: QueryConfig, scope: &RootScope) -> Result<ConfigOperati
     let tree_mode = config.tree_mode.as_deref().map(parse_tree_mode).transpose()?;
 
     let queries = config.queries.into_iter().map(|q| {
-        QueryExpr { xpath: q.xpath }
+        QueryExpr {
+            xpath: q.xpath,
+            variables: std::sync::Arc::new(q.variables),
+        }
     }).collect();
 
     let (files, exclude, diff_files, diff_lines) = merge_scope(scope, config.files, config.exclude, config.diff_files, config.diff_lines);
@@ -661,6 +679,7 @@ fn convert_test(config: TestConfig, scope: &RootScope) -> Result<ConfigOperation
         TestAssertion {
             xpath: a.xpath,
             expect: a.expect,
+            variables: std::sync::Arc::new(a.variables),
         }
     }).collect();
 
@@ -1499,6 +1518,37 @@ check:
         assert!(c.rules[1].variables.is_empty());
         // Root-level variables stay at the config level, not copied per rule
         assert_eq!(loaded.variables.get("env"), Some(&VariableValue::String("production".into())));
+    }
+
+    #[test]
+    fn parse_yaml_entry_level_variables() {
+        use tractor::variables::VariableValue;
+        let yaml = r#"
+set:
+  mappings:
+    - xpath: "//port[. = $mapping.variables?from]"
+      value: "3000"
+      variables:
+        from: 8080
+query:
+  queries:
+    - xpath: "//user[@role = $query.variables?role]"
+      variables:
+        role: admin
+test:
+  assertions:
+    - xpath: "count(//user) <= $assertion.variables?max"
+      expect: some
+      variables:
+        max: 100
+"#;
+        let loaded = parse_config_yaml(yaml).unwrap();
+        let (_, s) = as_set(&loaded.operations[0]);
+        assert_eq!(s.mappings[0].variables.get("from"), Some(&VariableValue::Int(8080)));
+        let (_, q) = as_query(&loaded.operations[1]);
+        assert_eq!(q.queries[0].variables.get("role"), Some(&VariableValue::String("admin".into())));
+        let (_, t) = as_test(&loaded.operations[2]);
+        assert_eq!(t.assertions[0].variables.get("max"), Some(&VariableValue::Int(100)));
     }
 
     #[test]

--- a/tractor/src/tractor_config.rs
+++ b/tractor/src/tractor_config.rs
@@ -685,17 +685,8 @@ fn convert_query(config: QueryConfig, scope: &RootScope) -> Result<ConfigOperati
             QueryOutputConfig::Full(full) => (full.file, full.view),
         };
         // The path is a static property of the config, so it is checked here
-        // rather than after the query has run: `..` or an absolute path would
-        // let a config write outside its own directory.
-        let path = Path::new(&file);
-        if path.is_absolute()
-            || path.components().any(|c| matches!(c, std::path::Component::ParentDir))
-        {
-            return Err(format!(
-                "query output '{}' must be a relative path inside the config directory",
-                file
-            ).into());
-        }
+        // rather than after the query has run.
+        QueryOutput::validate_path(&file)?;
         let view = match view {
             None => vec![QueryOutputField::Value],
             Some(fields) => fields

--- a/tractor/src/xpath/engine.rs
+++ b/tractor/src/xpath/engine.rs
@@ -3,7 +3,7 @@
 use super::{Match, XPathError};
 use super::map_normalize::{try_normalize_and_serialize_map, extract_map_value_expr};
 use super::match_result::XmlNode;
-use crate::variables::{EntryContext, EntryKind, QueryVariables};
+use crate::variables::{EntryContext, EntryKind, QueryBindings, QueryVariables};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::cell::RefCell;
@@ -342,12 +342,11 @@ fn execute_direct_query(
     doc_handle: DocumentHandle,
     source_lines: Arc<Vec<String>>,
     file_path: &str,
-    run_variables: &QueryVariables,
-    entry: Option<&EntryContext>,
+    bindings: &QueryBindings,
 ) -> Result<Vec<Match>, XPathError> {
     // Bind $file / $variables / the entry namespaces / $rule.id up front —
     // the map bindings execute a small `parse-json` query against `documents`.
-    let vars = tractor_variables(file_path, run_variables, entry, documents)?;
+    let vars = tractor_variables(file_path, &bindings.variables, bindings.entry.as_ref(), documents)?;
 
     QUERY_CACHE.with(|cache| {
         let mut cache = cache.borrow_mut();
@@ -482,12 +481,28 @@ fn execute_direct_query(
 pub struct XPathEngine {
     verbose: bool,
     ignore_whitespace: bool,
+    /// User-defined bindings for every query this engine runs. Default is
+    /// "nothing bound" — `$variables` and the entry namespaces are empty
+    /// maps, `$rule.id` the empty sequence.
+    bindings: QueryBindings,
 }
 
 impl XPathEngine {
     /// Create a new XPath engine
     pub fn new() -> Self {
-        XPathEngine { verbose: false, ignore_whitespace: false }
+        XPathEngine {
+            verbose: false,
+            ignore_whitespace: false,
+            bindings: QueryBindings::default(),
+        }
+    }
+
+    /// Bind user-defined variables into every query this engine runs:
+    /// `$variables` from the run-level map, and `$<entry>.variables` /
+    /// `$rule.id` from the current operation entry.
+    pub fn with_bindings(mut self, bindings: QueryBindings) -> Self {
+        self.bindings = bindings;
+        self
     }
 
     /// Enable verbose mode for debugging
@@ -509,6 +524,10 @@ impl XPathEngine {
     /// directly on the Documents instance. Use this when you've built the AST
     /// directly into Documents using XeeBuilder.
     ///
+    /// The built-in `$file` is always bound; user-defined variables come from
+    /// the engine's [`with_bindings`](Self::with_bindings) (nothing bound by
+    /// default).
+    ///
     /// source_lines is wrapped in Arc to avoid cloning for each match.
     pub fn query_documents(
         &self,
@@ -520,29 +539,7 @@ impl XPathEngine {
     ) -> Result<Vec<Match>, XPathError> {
         execute_direct_query(
             xpath, documents, doc_handle, source_lines, file_path,
-            &QueryVariables::new(), None,
-        )
-    }
-
-    /// Execute an XPath query on Documents with user-defined variables bound
-    /// in the dynamic context alongside the built-in `$file`:
-    /// `run_variables` becomes `$variables`, and `entry` (the current
-    /// operation entry, if any) provides `$rule.variables` /
-    /// `$mapping.variables` / `$query.variables` / `$assertion.variables`
-    /// plus `$rule.id`.
-    pub fn query_documents_with_variables(
-        &self,
-        documents: &mut Documents,
-        doc_handle: DocumentHandle,
-        xpath: &str,
-        source_lines: Arc<Vec<String>>,
-        file_path: &str,
-        run_variables: &QueryVariables,
-        entry: Option<&EntryContext>,
-    ) -> Result<Vec<Match>, XPathError> {
-        execute_direct_query(
-            xpath, documents, doc_handle, source_lines, file_path,
-            run_variables, entry,
+            &self.bindings,
         )
     }
 
@@ -561,6 +558,14 @@ impl Default for XPathEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An engine bound to the given run-level variables and optional entry.
+    fn bound_engine(variables: &QueryVariables, entry: Option<&EntryContext>) -> XPathEngine {
+        XPathEngine::new().with_bindings(QueryBindings {
+            variables: Arc::new(variables.clone()),
+            entry: entry.cloned(),
+        })
+    }
 
     #[test]
     fn test_strip_location_metadata() {
@@ -943,25 +948,23 @@ mod tests {
 
         let xml = r#"<root><item level="3">a</item><item level="7">b</item></root>"#;
         let mut result = load_xml_string_to_documents(xml, "test.xml".to_string()).unwrap();
-        let engine = XPathEngine::new();
 
         let mut vars = QueryVariables::new();
         vars.insert("min-level", VariableValue::Int(5));
         vars.insert("env", VariableValue::String("prod".into()));
         vars.insert("strict", VariableValue::Bool(true));
 
-        let matches = engine.query_documents_with_variables(
+        let matches = bound_engine(&vars, None).query_documents(
             &mut result.documents, result.doc_handle,
             "//item[number(@level) > $variables?min-level]", Arc::new(vec![]), "test.xml",
-            &vars, None,
         ).unwrap();
         assert_eq!(matches.len(), 1, "only level 7 exceeds min-level=5");
         assert_eq!(matches[0].value, "b");
 
-        let matches = engine.query_documents_with_variables(
+        let matches = bound_engine(&vars, None).query_documents(
             &mut result.documents, result.doc_handle,
             r#"if ($variables?strict and $variables?env = 'prod') then //item else ()"#,
-            Arc::new(vec![]), "test.xml", &vars, None,
+            Arc::new(vec![]), "test.xml",
         ).unwrap();
         assert_eq!(matches.len(), 2, "strict/env condition should hold");
     }
@@ -974,7 +977,6 @@ mod tests {
 
         let xml = r#"<root><name>alpha</name><name>gamma</name></root>"#;
         let mut result = load_xml_string_to_documents(xml, "test.xml".to_string()).unwrap();
-        let engine = XPathEngine::new();
 
         let vars: QueryVariables = serde_yaml::from_str(
             "allowed: [alpha, beta]\nlimits:\n  max: 1\n",
@@ -982,19 +984,17 @@ mod tests {
         assert!(matches!(vars.get("allowed"), Some(VariableValue::Array(_))));
 
         // Array membership test via the general comparison over the array items
-        let matches = engine.query_documents_with_variables(
+        let matches = bound_engine(&vars, None).query_documents(
             &mut result.documents, result.doc_handle,
             "//name[not(. = $variables?allowed?*)]", Arc::new(vec![]), "test.xml",
-            &vars, None,
         ).unwrap();
         assert_eq!(matches.len(), 1, "only 'gamma' is outside the allowed list");
         assert_eq!(matches[0].value, "gamma");
 
         // Nested map lookup
-        let matches = engine.query_documents_with_variables(
+        let matches = bound_engine(&vars, None).query_documents(
             &mut result.documents, result.doc_handle,
             "//name[count(//name) > $variables?limits?max]", Arc::new(vec![]), "test.xml",
-            &vars, None,
         ).unwrap();
         assert_eq!(matches.len(), 2, "count(2) > limits.max(1)");
     }
@@ -1007,16 +1007,14 @@ mod tests {
         use crate::parser::load_xml_string_to_documents;
         use crate::variables::{QueryVariables, VariableValue};
 
-        let engine = XPathEngine::new();
         let mut vars = QueryVariables::new();
         vars.insert("want", VariableValue::String("x".into()));
 
         for xml in [r#"<root><a>x</a></root>"#, r#"<root><a>y</a><a>x</a></root>"#] {
             let mut result = load_xml_string_to_documents(xml, "test.xml".to_string()).unwrap();
-            let matches = engine.query_documents_with_variables(
+            let matches = bound_engine(&vars, None).query_documents(
                 &mut result.documents, result.doc_handle,
                 "//a[. = $variables?want]", Arc::new(vec![]), "test.xml",
-                &vars, None,
             ).unwrap();
             assert_eq!(matches.len(), 1, "lookup must work on every document: {}", xml);
             assert_eq!(matches[0].value, "x");
@@ -1031,15 +1029,14 @@ mod tests {
 
         let xml = r#"<root><a>1</a></root>"#;
         let mut result = load_xml_string_to_documents(xml, "test.xml".to_string()).unwrap();
-        let engine = XPathEngine::new();
 
         let mut vars = QueryVariables::new();
         vars.insert("nothing", VariableValue::Null);
 
-        let matches = engine.query_documents_with_variables(
+        let matches = bound_engine(&vars, None).query_documents(
             &mut result.documents, result.doc_handle,
             "//a[empty($variables?nothing) and empty($variables?not-configured)]",
-            Arc::new(vec![]), "test.xml", &vars, None,
+            Arc::new(vec![]), "test.xml",
         ).unwrap();
         assert_eq!(matches.len(), 1);
     }
@@ -1060,10 +1057,10 @@ mod tests {
         rule_vars.insert("v", VariableValue::String("rule".into()));
         let entry = EntryContext::rule(Arc::new(rule_vars), "r");
 
-        let matches = engine.query_documents_with_variables(
+        let matches = bound_engine(&run_vars, Some(&entry)).query_documents(
             &mut result.documents, result.doc_handle,
             "//a[$variables?v = 'global' and $rule.variables?v = 'rule']",
-            Arc::new(vec![]), "test.xml", &run_vars, Some(&entry),
+            Arc::new(vec![]), "test.xml",
         ).unwrap();
         assert_eq!(matches.len(), 1, "same key resolves per namespace");
 
@@ -1088,18 +1085,18 @@ mod tests {
 
         // The canonical escape-hatch pattern: marker derived from $rule.id
         let my_rule = EntryContext::rule(Arc::default(), "my-rule");
-        let matches = engine.query_documents_with_variables(
+        let matches = bound_engine(&none, Some(&my_rule)).query_documents(
             &mut result.documents, result.doc_handle,
             "//a[not(//comment[contains(., concat('tractor:allow(', $rule.id, ')'))])]",
-            Arc::new(vec![]), "test.xml", &none, Some(&my_rule),
+            Arc::new(vec![]), "test.xml",
         ).unwrap();
         assert_eq!(matches.len(), 0, "allow-marker for my-rule suppresses the match");
 
         let other_rule = EntryContext::rule(Arc::default(), "other-rule");
-        let matches = engine.query_documents_with_variables(
+        let matches = bound_engine(&none, Some(&other_rule)).query_documents(
             &mut result.documents, result.doc_handle,
             "//a[not(//comment[contains(., concat('tractor:allow(', $rule.id, ')'))])]",
-            Arc::new(vec![]), "test.xml", &none, Some(&other_rule),
+            Arc::new(vec![]), "test.xml",
         ).unwrap();
         assert_eq!(matches.len(), 1, "marker for a different rule does not suppress");
 
@@ -1135,7 +1132,6 @@ mod tests {
 
         let xml = r#"<root><a>x</a></root>"#;
         let mut result = load_xml_string_to_documents(xml, "test.xml".to_string()).unwrap();
-        let engine = XPathEngine::new();
         let none = QueryVariables::new();
 
         let mut entry_vars = QueryVariables::new();
@@ -1160,9 +1156,9 @@ mod tests {
             ),
         ] {
             let xpath = format!("//a[{} and {}]", own, others);
-            let matches = engine.query_documents_with_variables(
+            let matches = bound_engine(&none, Some(&entry)).query_documents(
                 &mut result.documents, result.doc_handle,
-                &xpath, Arc::new(vec![]), "test.xml", &none, Some(&entry),
+                &xpath, Arc::new(vec![]), "test.xml",
             ).unwrap();
             assert_eq!(matches.len(), 1, "{:?} should bind only its own namespace", entry.kind);
         }

--- a/tractor/src/xpath/engine.rs
+++ b/tractor/src/xpath/engine.rs
@@ -210,7 +210,19 @@ thread_local! {
     // Compiled helper query used to bind user-variable maps — see
     // `variables_map_sequence`.
     static PARSE_JSON_QUERY: RefCell<Option<SequenceQuery>> = const { RefCell::new(None) };
+    // Converted variable-map sequences, keyed by their JSON serialization.
+    // The values are pure data items (maps/arrays/atomics from `parse-json`,
+    // never nodes), so a converted sequence is valid across documents and
+    // queries within the thread. Content keying is ABA-safe where pointer
+    // keying (`Arc::as_ptr`) would not be. A run touches only a handful of
+    // distinct variable sets (run-level + one per operation entry), so the
+    // map stays tiny; the cap is a safety valve, not an eviction policy.
+    static VARIABLES_SEQ_CACHE: RefCell<std::collections::HashMap<String, Sequence>> =
+        RefCell::new(std::collections::HashMap::new());
 }
+
+/// Upper bound for `VARIABLES_SEQ_CACHE` before it is cleared wholesale.
+const VARIABLES_SEQ_CACHE_CAP: usize = 64;
 
 /// Build a StaticContextBuilder that declares the built-in tractor variables:
 /// `$file` (current file path), `$variables` (config-level user variables as
@@ -242,7 +254,10 @@ fn variables_map_sequence(
     documents: &mut Documents,
 ) -> Result<Sequence, XPathError> {
     let json = variables.to_json().to_string();
-    PARSE_JSON_QUERY.with(|cell| {
+    if let Some(cached) = VARIABLES_SEQ_CACHE.with(|c| c.borrow().get(&json).cloned()) {
+        return Ok(cached);
+    }
+    let sequence = PARSE_JSON_QUERY.with(|cell| {
         let mut cell = cell.borrow_mut();
         if cell.is_none() {
             let mut scb = StaticContextBuilder::default();
@@ -256,13 +271,21 @@ fn variables_map_sequence(
         }
         let query = cell.as_ref().unwrap();
         let mut vars = Variables::default();
-        vars.insert(OwnedName::name("json"), Sequence::from(json));
+        vars.insert(OwnedName::name("json"), Sequence::from(json.clone()));
         query
             .execute_build_context(documents, |builder| {
                 builder.variables(vars);
             })
             .map_err(|e| XPathError::Execute(format!("invalid variable value: {}", e)))
-    })
+    })?;
+    VARIABLES_SEQ_CACHE.with(|c| {
+        let mut cache = c.borrow_mut();
+        if cache.len() >= VARIABLES_SEQ_CACHE_CAP {
+            cache.clear();
+        }
+        cache.insert(json, sequence.clone());
+    });
+    Ok(sequence)
 }
 
 /// Build a Variables map binding the built-in tractor variables: `$file`,
@@ -974,6 +997,30 @@ mod tests {
             &vars, None,
         ).unwrap();
         assert_eq!(matches.len(), 2, "count(2) > limits.max(1)");
+    }
+
+    /// Converted variable maps are cached per thread by content and reused
+    /// across documents: the same variables queried against two different
+    /// documents (cache hit on the second) must resolve identically.
+    #[test]
+    fn test_variables_sequence_cached_across_documents() {
+        use crate::parser::load_xml_string_to_documents;
+        use crate::variables::{QueryVariables, VariableValue};
+
+        let engine = XPathEngine::new();
+        let mut vars = QueryVariables::new();
+        vars.insert("want", VariableValue::String("x".into()));
+
+        for xml in [r#"<root><a>x</a></root>"#, r#"<root><a>y</a><a>x</a></root>"#] {
+            let mut result = load_xml_string_to_documents(xml, "test.xml".to_string()).unwrap();
+            let matches = engine.query_documents_with_variables(
+                &mut result.documents, result.doc_handle,
+                "//a[. = $variables?want]", Arc::new(vec![]), "test.xml",
+                &vars, None,
+            ).unwrap();
+            assert_eq!(matches.len(), 1, "lookup must work on every document: {}", xml);
+            assert_eq!(matches[0].value, "x");
+        }
     }
 
     /// Null values and missing keys both yield the empty sequence.

--- a/tractor/src/xpath/engine.rs
+++ b/tractor/src/xpath/engine.rs
@@ -3,7 +3,7 @@
 use super::{Match, XPathError};
 use super::map_normalize::{try_normalize_and_serialize_map, extract_map_value_expr};
 use super::match_result::XmlNode;
-use crate::variables::QueryVariables;
+use crate::variables::{EntryContext, EntryKind, QueryVariables};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::cell::RefCell;
@@ -214,17 +214,17 @@ thread_local! {
 
 /// Build a StaticContextBuilder that declares the built-in tractor variables:
 /// `$file` (current file path), `$variables` (config-level user variables as
-/// a map), `$rule.variables` (rule-level user variables as a map; empty
-/// outside a rule context), and `$rule.id` (the current rule's id string;
-/// empty sequence outside a rule context).
+/// a map), one `$<entry>.variables` map per operation-entry kind
+/// (`$rule.variables`, `$mapping.variables`, `$query.variables`,
+/// `$assertion.variables` — only the current entry's is populated, the rest
+/// are empty maps), and `$rule.id` (the current rule's id string; empty
+/// sequence outside a rule context).
 pub fn tractor_static_context() -> StaticContextBuilder<'static> {
     let mut scb = StaticContextBuilder::default();
-    scb.variable_names([
-        OwnedName::name("file"),
-        OwnedName::name("variables"),
-        OwnedName::name("rule.variables"),
-        OwnedName::name("rule.id"),
-    ]);
+    let mut names = vec![OwnedName::name("file"), OwnedName::name("variables")];
+    names.extend(EntryKind::ALL.iter().map(|k| OwnedName::name(k.variables_name())));
+    names.push(OwnedName::name("rule.id"));
+    scb.variable_names(names);
     scb
 }
 
@@ -265,8 +265,11 @@ fn variables_map_sequence(
     })
 }
 
-/// Build a Variables map binding the built-in tractor variables:
-/// `$file`, `$variables`, `$rule.variables`, and `$rule.id`.
+/// Build a Variables map binding the built-in tractor variables: `$file`,
+/// `$variables`, one `$<entry>.variables` map per [`EntryKind`], and
+/// `$rule.id`. The current entry's namespace gets its `variables:`; every
+/// other entry namespace is an empty map, so a lookup there yields the
+/// empty sequence — the same semantics as an undefined key.
 ///
 /// Rebuilt per query execution: xee sequences are `Rc`-based and cannot cross
 /// threads, and $file changes per file anyway. The map conversions each run
@@ -274,8 +277,7 @@ fn variables_map_sequence(
 fn tractor_variables(
     file_path: &str,
     run_variables: &QueryVariables,
-    rule_variables: &QueryVariables,
-    rule_id: Option<&str>,
+    entry: Option<&EntryContext>,
     documents: &mut Documents,
 ) -> Result<Variables, XPathError> {
     let mut vars = Variables::default();
@@ -284,15 +286,22 @@ fn tractor_variables(
         OwnedName::name("variables"),
         variables_map_sequence(run_variables, documents)?,
     );
-    vars.insert(
-        OwnedName::name("rule.variables"),
-        variables_map_sequence(rule_variables, documents)?,
-    );
+    let empty = QueryVariables::new();
+    for kind in EntryKind::ALL {
+        let entry_variables = match entry {
+            Some(e) if e.kind == kind => &*e.variables,
+            _ => &empty,
+        };
+        vars.insert(
+            OwnedName::name(kind.variables_name()),
+            variables_map_sequence(entry_variables, documents)?,
+        );
+    }
     // $rule.id: the current rule's id, or the empty sequence outside a rule
     // context (so predicates like `contains(., $rule.id)` simply don't match).
     vars.insert(
         OwnedName::name("rule.id"),
-        match rule_id {
+        match entry.and_then(|e| e.id.as_deref()) {
             Some(id) => Sequence::from(id.to_string()),
             None => Sequence::default(),
         },
@@ -311,12 +320,11 @@ fn execute_direct_query(
     source_lines: Arc<Vec<String>>,
     file_path: &str,
     run_variables: &QueryVariables,
-    rule_variables: &QueryVariables,
-    rule_id: Option<&str>,
+    entry: Option<&EntryContext>,
 ) -> Result<Vec<Match>, XPathError> {
-    // Bind $file / $variables / $rule.variables / $rule.id up front — the
-    // map bindings execute a small `parse-json` query against `documents`.
-    let vars = tractor_variables(file_path, run_variables, rule_variables, rule_id, documents)?;
+    // Bind $file / $variables / the entry namespaces / $rule.id up front —
+    // the map bindings execute a small `parse-json` query against `documents`.
+    let vars = tractor_variables(file_path, run_variables, entry, documents)?;
 
     QUERY_CACHE.with(|cache| {
         let mut cache = cache.borrow_mut();
@@ -489,16 +497,16 @@ impl XPathEngine {
     ) -> Result<Vec<Match>, XPathError> {
         execute_direct_query(
             xpath, documents, doc_handle, source_lines, file_path,
-            &QueryVariables::new(), &QueryVariables::new(), None,
+            &QueryVariables::new(), None,
         )
     }
 
     /// Execute an XPath query on Documents with user-defined variables bound
     /// in the dynamic context alongside the built-in `$file`:
-    /// `run_variables` becomes `$variables`, `rule_variables` becomes
-    /// `$rule.variables`, and `rule_id` becomes `$rule.id` (pass empty/None
-    /// outside a rule context).
-    #[allow(clippy::too_many_arguments)] // mirrors query_documents + the rule context
+    /// `run_variables` becomes `$variables`, and `entry` (the current
+    /// operation entry, if any) provides `$rule.variables` /
+    /// `$mapping.variables` / `$query.variables` / `$assertion.variables`
+    /// plus `$rule.id`.
     pub fn query_documents_with_variables(
         &self,
         documents: &mut Documents,
@@ -507,12 +515,11 @@ impl XPathEngine {
         source_lines: Arc<Vec<String>>,
         file_path: &str,
         run_variables: &QueryVariables,
-        rule_variables: &QueryVariables,
-        rule_id: Option<&str>,
+        entry: Option<&EntryContext>,
     ) -> Result<Vec<Match>, XPathError> {
         execute_direct_query(
             xpath, documents, doc_handle, source_lines, file_path,
-            run_variables, rule_variables, rule_id,
+            run_variables, entry,
         )
     }
 
@@ -919,12 +926,11 @@ mod tests {
         vars.insert("min-level", VariableValue::Int(5));
         vars.insert("env", VariableValue::String("prod".into()));
         vars.insert("strict", VariableValue::Bool(true));
-        let none = QueryVariables::new();
 
         let matches = engine.query_documents_with_variables(
             &mut result.documents, result.doc_handle,
             "//item[number(@level) > $variables?min-level]", Arc::new(vec![]), "test.xml",
-            &vars, &none, None,
+            &vars, None,
         ).unwrap();
         assert_eq!(matches.len(), 1, "only level 7 exceeds min-level=5");
         assert_eq!(matches[0].value, "b");
@@ -932,7 +938,7 @@ mod tests {
         let matches = engine.query_documents_with_variables(
             &mut result.documents, result.doc_handle,
             r#"if ($variables?strict and $variables?env = 'prod') then //item else ()"#,
-            Arc::new(vec![]), "test.xml", &vars, &none, None,
+            Arc::new(vec![]), "test.xml", &vars, None,
         ).unwrap();
         assert_eq!(matches.len(), 2, "strict/env condition should hold");
     }
@@ -951,13 +957,12 @@ mod tests {
             "allowed: [alpha, beta]\nlimits:\n  max: 1\n",
         ).unwrap();
         assert!(matches!(vars.get("allowed"), Some(VariableValue::Array(_))));
-        let none = QueryVariables::new();
 
         // Array membership test via the general comparison over the array items
         let matches = engine.query_documents_with_variables(
             &mut result.documents, result.doc_handle,
             "//name[not(. = $variables?allowed?*)]", Arc::new(vec![]), "test.xml",
-            &vars, &none, None,
+            &vars, None,
         ).unwrap();
         assert_eq!(matches.len(), 1, "only 'gamma' is outside the allowed list");
         assert_eq!(matches[0].value, "gamma");
@@ -966,7 +971,7 @@ mod tests {
         let matches = engine.query_documents_with_variables(
             &mut result.documents, result.doc_handle,
             "//name[count(//name) > $variables?limits?max]", Arc::new(vec![]), "test.xml",
-            &vars, &none, None,
+            &vars, None,
         ).unwrap();
         assert_eq!(matches.len(), 2, "count(2) > limits.max(1)");
     }
@@ -983,12 +988,11 @@ mod tests {
 
         let mut vars = QueryVariables::new();
         vars.insert("nothing", VariableValue::Null);
-        let none = QueryVariables::new();
 
         let matches = engine.query_documents_with_variables(
             &mut result.documents, result.doc_handle,
             "//a[empty($variables?nothing) and empty($variables?not-configured)]",
-            Arc::new(vec![]), "test.xml", &vars, &none, None,
+            Arc::new(vec![]), "test.xml", &vars, None,
         ).unwrap();
         assert_eq!(matches.len(), 1);
     }
@@ -1007,11 +1011,12 @@ mod tests {
         run_vars.insert("v", VariableValue::String("global".into()));
         let mut rule_vars = QueryVariables::new();
         rule_vars.insert("v", VariableValue::String("rule".into()));
+        let entry = EntryContext::rule(Arc::new(rule_vars), "r");
 
         let matches = engine.query_documents_with_variables(
             &mut result.documents, result.doc_handle,
             "//a[$variables?v = 'global' and $rule.variables?v = 'rule']",
-            Arc::new(vec![]), "test.xml", &run_vars, &rule_vars, None,
+            Arc::new(vec![]), "test.xml", &run_vars, Some(&entry),
         ).unwrap();
         assert_eq!(matches.len(), 1, "same key resolves per namespace");
 
@@ -1035,17 +1040,19 @@ mod tests {
         let none = QueryVariables::new();
 
         // The canonical escape-hatch pattern: marker derived from $rule.id
+        let my_rule = EntryContext::rule(Arc::default(), "my-rule");
         let matches = engine.query_documents_with_variables(
             &mut result.documents, result.doc_handle,
             "//a[not(//comment[contains(., concat('tractor:allow(', $rule.id, ')'))])]",
-            Arc::new(vec![]), "test.xml", &none, &none, Some("my-rule"),
+            Arc::new(vec![]), "test.xml", &none, Some(&my_rule),
         ).unwrap();
         assert_eq!(matches.len(), 0, "allow-marker for my-rule suppresses the match");
 
+        let other_rule = EntryContext::rule(Arc::default(), "other-rule");
         let matches = engine.query_documents_with_variables(
             &mut result.documents, result.doc_handle,
             "//a[not(//comment[contains(., concat('tractor:allow(', $rule.id, ')'))])]",
-            Arc::new(vec![]), "test.xml", &none, &none, Some("other-rule"),
+            Arc::new(vec![]), "test.xml", &none, Some(&other_rule),
         ).unwrap();
         assert_eq!(matches.len(), 1, "marker for a different rule does not suppress");
 
@@ -1064,9 +1071,54 @@ mod tests {
 
         assert!(validate_xpath("//a[$variables?env = 'prod']").valid);
         assert!(validate_xpath("//a[$rule.variables?max > 1]").valid);
+        assert!(validate_xpath("//a[$mapping.variables?max > 1]").valid);
+        assert!(validate_xpath("//a[$query.variables?max > 1]").valid);
+        assert!(validate_xpath("//a[$assertion.variables?max > 1]").valid);
         assert!(validate_xpath("//a[$rule.id]").valid);
         assert!(validate_xpath("//a[$file]").valid);
         assert!(!validate_xpath("//a[. = $undeclared]").valid);
+    }
+
+    /// Each entry kind binds its own namespace; the other namespaces are
+    /// empty maps regardless of which entry is current.
+    #[test]
+    fn test_entry_kind_namespaces() {
+        use crate::parser::load_xml_string_to_documents;
+        use crate::variables::{QueryVariables, VariableValue};
+
+        let xml = r#"<root><a>x</a></root>"#;
+        let mut result = load_xml_string_to_documents(xml, "test.xml".to_string()).unwrap();
+        let engine = XPathEngine::new();
+        let none = QueryVariables::new();
+
+        let mut entry_vars = QueryVariables::new();
+        entry_vars.insert("max", VariableValue::Int(3));
+        let entry_vars = Arc::new(entry_vars);
+
+        for (entry, own, others) in [
+            (
+                EntryContext::mapping(Arc::clone(&entry_vars)),
+                "$mapping.variables?max = 3",
+                "empty($rule.variables?max) and empty($query.variables?max) and empty($assertion.variables?max)",
+            ),
+            (
+                EntryContext::query(Arc::clone(&entry_vars)),
+                "$query.variables?max = 3",
+                "empty($rule.variables?max) and empty($mapping.variables?max) and empty($assertion.variables?max)",
+            ),
+            (
+                EntryContext::assertion(Arc::clone(&entry_vars)),
+                "$assertion.variables?max = 3",
+                "empty($rule.variables?max) and empty($mapping.variables?max) and empty($query.variables?max)",
+            ),
+        ] {
+            let xpath = format!("//a[{} and {}]", own, others);
+            let matches = engine.query_documents_with_variables(
+                &mut result.documents, result.doc_handle,
+                &xpath, Arc::new(vec![]), "test.xml", &none, Some(&entry),
+            ).unwrap();
+            assert_eq!(matches.len(), 1, "{:?} should bind only its own namespace", entry.kind);
+        }
     }
 
     #[test]

--- a/tractor/src/xpath/engine.rs
+++ b/tractor/src/xpath/engine.rs
@@ -3,6 +3,7 @@
 use super::{Match, XPathError};
 use super::map_normalize::{try_normalize_and_serialize_map, extract_map_value_expr};
 use super::match_result::XmlNode;
+use crate::variables::QueryVariables;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::cell::RefCell;
@@ -206,20 +207,97 @@ fn json_value_to_xml_node(val: &serde_json::Value) -> XmlNode {
 // Each thread gets its own compiled query to avoid RefCell conflicts
 thread_local! {
     static QUERY_CACHE: RefCell<Option<(String, SequenceQuery)>> = const { RefCell::new(None) };
+    // Compiled helper query used to bind user-variable maps — see
+    // `variables_map_sequence`.
+    static PARSE_JSON_QUERY: RefCell<Option<SequenceQuery>> = const { RefCell::new(None) };
 }
 
-/// Build a StaticContextBuilder that declares the built-in tractor variables ($file).
+/// Build a StaticContextBuilder that declares the built-in tractor variables:
+/// `$file` (current file path), `$variables` (config-level user variables as
+/// a map), `$rule.variables` (rule-level user variables as a map; empty
+/// outside a rule context), and `$rule.id` (the current rule's id string;
+/// empty sequence outside a rule context).
 pub fn tractor_static_context() -> StaticContextBuilder<'static> {
     let mut scb = StaticContextBuilder::default();
-    scb.variable_names([OwnedName::name("file")]);
+    scb.variable_names([
+        OwnedName::name("file"),
+        OwnedName::name("variables"),
+        OwnedName::name("rule.variables"),
+        OwnedName::name("rule.id"),
+    ]);
     scb
 }
 
-/// Build a Variables map binding $file to the given path.
-fn tractor_variables(file_path: &str) -> Variables {
+/// Convert a user-variable map into a single XPath `map(*)` item by
+/// serializing it to JSON and evaluating `parse-json($json)`.
+///
+/// This is the only public-API bridge xee offers for constructing `map(*)` /
+/// `array(*)` items from Rust data — their constructors are crate-private.
+/// The resulting sequence contains only atomics/maps/arrays (never nodes),
+/// so it is safe to bind into queries over any document. JSON semantics
+/// apply to the values: numbers become `xs:double`, `null` becomes the
+/// empty sequence.
+fn variables_map_sequence(
+    variables: &QueryVariables,
+    documents: &mut Documents,
+) -> Result<Sequence, XPathError> {
+    let json = variables.to_json().to_string();
+    PARSE_JSON_QUERY.with(|cell| {
+        let mut cell = cell.borrow_mut();
+        if cell.is_none() {
+            let mut scb = StaticContextBuilder::default();
+            scb.variable_names([OwnedName::name("json")]);
+            let queries = Queries::new(scb);
+            *cell = Some(
+                queries
+                    .sequence("parse-json($json)")
+                    .map_err(|e| XPathError::Compile(e.to_string()))?,
+            );
+        }
+        let query = cell.as_ref().unwrap();
+        let mut vars = Variables::default();
+        vars.insert(OwnedName::name("json"), Sequence::from(json));
+        query
+            .execute_build_context(documents, |builder| {
+                builder.variables(vars);
+            })
+            .map_err(|e| XPathError::Execute(format!("invalid variable value: {}", e)))
+    })
+}
+
+/// Build a Variables map binding the built-in tractor variables:
+/// `$file`, `$variables`, `$rule.variables`, and `$rule.id`.
+///
+/// Rebuilt per query execution: xee sequences are `Rc`-based and cannot cross
+/// threads, and $file changes per file anyway. The map conversions each run
+/// one small `parse-json` evaluation — microseconds for typical configs.
+fn tractor_variables(
+    file_path: &str,
+    run_variables: &QueryVariables,
+    rule_variables: &QueryVariables,
+    rule_id: Option<&str>,
+    documents: &mut Documents,
+) -> Result<Variables, XPathError> {
     let mut vars = Variables::default();
     vars.insert(OwnedName::name("file"), Sequence::from(file_path.to_string()));
-    vars
+    vars.insert(
+        OwnedName::name("variables"),
+        variables_map_sequence(run_variables, documents)?,
+    );
+    vars.insert(
+        OwnedName::name("rule.variables"),
+        variables_map_sequence(rule_variables, documents)?,
+    );
+    // $rule.id: the current rule's id, or the empty sequence outside a rule
+    // context (so predicates like `contains(., $rule.id)` simply don't match).
+    vars.insert(
+        OwnedName::name("rule.id"),
+        match rule_id {
+            Some(id) => Sequence::from(id.to_string()),
+            None => Sequence::default(),
+        },
+    );
+    Ok(vars)
 }
 
 /// Execute a query directly on Documents (no XML parsing needed)
@@ -232,36 +310,34 @@ fn execute_direct_query(
     doc_handle: DocumentHandle,
     source_lines: Arc<Vec<String>>,
     file_path: &str,
+    run_variables: &QueryVariables,
+    rule_variables: &QueryVariables,
+    rule_id: Option<&str>,
 ) -> Result<Vec<Match>, XPathError> {
+    // Bind $file / $variables / $rule.variables / $rule.id up front — the
+    // map bindings execute a small `parse-json` query against `documents`.
+    let vars = tractor_variables(file_path, run_variables, rule_variables, rule_id, documents)?;
+
     QUERY_CACHE.with(|cache| {
         let mut cache = cache.borrow_mut();
 
         // Check if we have a cached query for this XPath
-        let query = if let Some((cached_xpath, cached_query)) = cache.as_ref() {
-            if cached_xpath == xpath {
-                cached_query
-            } else {
-                // Different XPath, need to recompile
-                let queries = Queries::new(tractor_static_context());
-                let new_query = queries
-                    .sequence(xpath)
-                    .map_err(|e| XPathError::Compile(e.to_string()))?;
-                *cache = Some((xpath.to_string(), new_query));
-                &cache.as_ref().unwrap().1
-            }
-        } else {
-            // No cached query, compile it
+        let cache_hit = matches!(
+            cache.as_ref(),
+            Some((cached_xpath, _)) if cached_xpath == xpath
+        );
+        if !cache_hit {
+            // Different XPath, need to recompile
             let queries = Queries::new(tractor_static_context());
             let new_query = queries
                 .sequence(xpath)
                 .map_err(|e| XPathError::Compile(e.to_string()))?;
             *cache = Some((xpath.to_string(), new_query));
-            &cache.as_ref().unwrap().1
-        };
+        }
+        let query = &cache.as_ref().unwrap().1;
 
-        // Execute the query with $file variable bound
+        // Execute the query with the tractor variables bound
         let t1 = Instant::now();
-        let vars = tractor_variables(file_path);
         let context_item = doc_handle.to_item(documents)
             .map_err(|e| XPathError::Execute(e.to_string()))?;
         let results = query
@@ -411,7 +487,33 @@ impl XPathEngine {
         source_lines: Arc<Vec<String>>,
         file_path: &str,
     ) -> Result<Vec<Match>, XPathError> {
-        execute_direct_query(xpath, documents, doc_handle, source_lines, file_path)
+        execute_direct_query(
+            xpath, documents, doc_handle, source_lines, file_path,
+            &QueryVariables::new(), &QueryVariables::new(), None,
+        )
+    }
+
+    /// Execute an XPath query on Documents with user-defined variables bound
+    /// in the dynamic context alongside the built-in `$file`:
+    /// `run_variables` becomes `$variables`, `rule_variables` becomes
+    /// `$rule.variables`, and `rule_id` becomes `$rule.id` (pass empty/None
+    /// outside a rule context).
+    #[allow(clippy::too_many_arguments)] // mirrors query_documents + the rule context
+    pub fn query_documents_with_variables(
+        &self,
+        documents: &mut Documents,
+        doc_handle: DocumentHandle,
+        xpath: &str,
+        source_lines: Arc<Vec<String>>,
+        file_path: &str,
+        run_variables: &QueryVariables,
+        rule_variables: &QueryVariables,
+        rule_id: Option<&str>,
+    ) -> Result<Vec<Match>, XPathError> {
+        execute_direct_query(
+            xpath, documents, doc_handle, source_lines, file_path,
+            run_variables, rule_variables, rule_id,
+        )
     }
 
     /// Strip location metadata from XML
@@ -801,6 +903,170 @@ mod tests {
             }
             other => panic!("Expected XmlNode::Map, got: {:?}", other),
         }
+    }
+
+    /// User-defined variables are reachable through the `$variables` map.
+    #[test]
+    fn test_query_with_scalar_variables() {
+        use crate::parser::load_xml_string_to_documents;
+        use crate::variables::{QueryVariables, VariableValue};
+
+        let xml = r#"<root><item level="3">a</item><item level="7">b</item></root>"#;
+        let mut result = load_xml_string_to_documents(xml, "test.xml".to_string()).unwrap();
+        let engine = XPathEngine::new();
+
+        let mut vars = QueryVariables::new();
+        vars.insert("min-level", VariableValue::Int(5));
+        vars.insert("env", VariableValue::String("prod".into()));
+        vars.insert("strict", VariableValue::Bool(true));
+        let none = QueryVariables::new();
+
+        let matches = engine.query_documents_with_variables(
+            &mut result.documents, result.doc_handle,
+            "//item[number(@level) > $variables?min-level]", Arc::new(vec![]), "test.xml",
+            &vars, &none, None,
+        ).unwrap();
+        assert_eq!(matches.len(), 1, "only level 7 exceeds min-level=5");
+        assert_eq!(matches[0].value, "b");
+
+        let matches = engine.query_documents_with_variables(
+            &mut result.documents, result.doc_handle,
+            r#"if ($variables?strict and $variables?env = 'prod') then //item else ()"#,
+            Arc::new(vec![]), "test.xml", &vars, &none, None,
+        ).unwrap();
+        assert_eq!(matches.len(), 2, "strict/env condition should hold");
+    }
+
+    /// Structured variables (lists / nested maps) bind as XPath arrays and maps.
+    #[test]
+    fn test_query_with_structured_variables() {
+        use crate::parser::load_xml_string_to_documents;
+        use crate::variables::{QueryVariables, VariableValue};
+
+        let xml = r#"<root><name>alpha</name><name>gamma</name></root>"#;
+        let mut result = load_xml_string_to_documents(xml, "test.xml".to_string()).unwrap();
+        let engine = XPathEngine::new();
+
+        let vars: QueryVariables = serde_yaml::from_str(
+            "allowed: [alpha, beta]\nlimits:\n  max: 1\n",
+        ).unwrap();
+        assert!(matches!(vars.get("allowed"), Some(VariableValue::Array(_))));
+        let none = QueryVariables::new();
+
+        // Array membership test via the general comparison over the array items
+        let matches = engine.query_documents_with_variables(
+            &mut result.documents, result.doc_handle,
+            "//name[not(. = $variables?allowed?*)]", Arc::new(vec![]), "test.xml",
+            &vars, &none, None,
+        ).unwrap();
+        assert_eq!(matches.len(), 1, "only 'gamma' is outside the allowed list");
+        assert_eq!(matches[0].value, "gamma");
+
+        // Nested map lookup
+        let matches = engine.query_documents_with_variables(
+            &mut result.documents, result.doc_handle,
+            "//name[count(//name) > $variables?limits?max]", Arc::new(vec![]), "test.xml",
+            &vars, &none, None,
+        ).unwrap();
+        assert_eq!(matches.len(), 2, "count(2) > limits.max(1)");
+    }
+
+    /// Null values and missing keys both yield the empty sequence.
+    #[test]
+    fn test_query_with_null_and_missing_keys() {
+        use crate::parser::load_xml_string_to_documents;
+        use crate::variables::{QueryVariables, VariableValue};
+
+        let xml = r#"<root><a>1</a></root>"#;
+        let mut result = load_xml_string_to_documents(xml, "test.xml".to_string()).unwrap();
+        let engine = XPathEngine::new();
+
+        let mut vars = QueryVariables::new();
+        vars.insert("nothing", VariableValue::Null);
+        let none = QueryVariables::new();
+
+        let matches = engine.query_documents_with_variables(
+            &mut result.documents, result.doc_handle,
+            "//a[empty($variables?nothing) and empty($variables?not-configured)]",
+            Arc::new(vec![]), "test.xml", &vars, &none, None,
+        ).unwrap();
+        assert_eq!(matches.len(), 1);
+    }
+
+    /// $variables and $rule.variables are independent namespaces.
+    #[test]
+    fn test_rule_variables_separate_from_run_variables() {
+        use crate::parser::load_xml_string_to_documents;
+        use crate::variables::{QueryVariables, VariableValue};
+
+        let xml = r#"<root><a>x</a></root>"#;
+        let mut result = load_xml_string_to_documents(xml, "test.xml".to_string()).unwrap();
+        let engine = XPathEngine::new();
+
+        let mut run_vars = QueryVariables::new();
+        run_vars.insert("v", VariableValue::String("global".into()));
+        let mut rule_vars = QueryVariables::new();
+        rule_vars.insert("v", VariableValue::String("rule".into()));
+
+        let matches = engine.query_documents_with_variables(
+            &mut result.documents, result.doc_handle,
+            "//a[$variables?v = 'global' and $rule.variables?v = 'rule']",
+            Arc::new(vec![]), "test.xml", &run_vars, &rule_vars, None,
+        ).unwrap();
+        assert_eq!(matches.len(), 1, "same key resolves per namespace");
+
+        // Without rule variables, $rule.variables is an empty map
+        let matches = engine.query_documents(
+            &mut result.documents, result.doc_handle,
+            "//a[empty($rule.variables?v)]", Arc::new(vec![]), "test.xml",
+        ).unwrap();
+        assert_eq!(matches.len(), 1, "$rule.variables lookup is empty outside a rule");
+    }
+
+    /// $rule.id binds the current rule's id; empty sequence outside a rule.
+    #[test]
+    fn test_rule_id_binding() {
+        use crate::parser::load_xml_string_to_documents;
+        use crate::variables::QueryVariables;
+
+        let xml = r#"<root><comment>tractor:allow(my-rule)</comment><a>x</a></root>"#;
+        let mut result = load_xml_string_to_documents(xml, "test.xml".to_string()).unwrap();
+        let engine = XPathEngine::new();
+        let none = QueryVariables::new();
+
+        // The canonical escape-hatch pattern: marker derived from $rule.id
+        let matches = engine.query_documents_with_variables(
+            &mut result.documents, result.doc_handle,
+            "//a[not(//comment[contains(., concat('tractor:allow(', $rule.id, ')'))])]",
+            Arc::new(vec![]), "test.xml", &none, &none, Some("my-rule"),
+        ).unwrap();
+        assert_eq!(matches.len(), 0, "allow-marker for my-rule suppresses the match");
+
+        let matches = engine.query_documents_with_variables(
+            &mut result.documents, result.doc_handle,
+            "//a[not(//comment[contains(., concat('tractor:allow(', $rule.id, ')'))])]",
+            Arc::new(vec![]), "test.xml", &none, &none, Some("other-rule"),
+        ).unwrap();
+        assert_eq!(matches.len(), 1, "marker for a different rule does not suppress");
+
+        // Outside a rule context $rule.id is the empty sequence
+        let matches = engine.query_documents(
+            &mut result.documents, result.doc_handle,
+            "//a[empty($rule.id)]", Arc::new(vec![]), "test.xml",
+        ).unwrap();
+        assert_eq!(matches.len(), 1);
+    }
+
+    /// The built-in variables always validate; undeclared ones never do.
+    #[test]
+    fn test_validate_builtin_variables() {
+        use crate::xpath::validate_xpath;
+
+        assert!(validate_xpath("//a[$variables?env = 'prod']").valid);
+        assert!(validate_xpath("//a[$rule.variables?max > 1]").valid);
+        assert!(validate_xpath("//a[$rule.id]").valid);
+        assert!(validate_xpath("//a[$file]").valid);
+        assert!(!validate_xpath("//a[. = $undeclared]").valid);
     }
 
     #[test]

--- a/tractor/src/xpath/engine.rs
+++ b/tractor/src/xpath/engine.rs
@@ -413,7 +413,17 @@ fn execute_direct_query(
                     matches.push(m);
                 }
                 xee_xpath::Item::Atomic(atomic) => {
-                    let value = atomic.xpath_representation();
+                    // A match's value is text, not an XPath literal: a
+                    // computed string like `concat(name, ':', len)` must land
+                    // as `Name:256`, not `"Name:256"`. Quoting leaks into
+                    // every consumer — reports, `-v value`, and the JSON a
+                    // query op's `output:` writes, where the quotes end up
+                    // inside the JSON string. `string_value` is the XPath
+                    // string value (what `string(...)` would yield), so every
+                    // atomic type renders the same way node matches do.
+                    let value = xee_xpath::Item::Atomic(atomic.clone())
+                        .string_value(documents.xot())
+                        .unwrap_or_else(|_| atomic.xpath_representation());
                     matches.push(Match::new(file_path.to_string(), value));
                 }
                 xee_xpath::Item::Function(func) => {
@@ -997,6 +1007,38 @@ mod tests {
             "//name[count(//name) > $variables?limits?max]", Arc::new(vec![]), "test.xml",
         ).unwrap();
         assert_eq!(matches.len(), 2, "count(2) > limits.max(1)");
+    }
+
+    /// A match's value is the XPath *string value*, never an XPath literal:
+    /// computed strings must not arrive quoted, or the quotes end up inside
+    /// consumers (reports, `-v value`, a query op's materialized JSON).
+    #[test]
+    fn test_atomic_values_are_string_values_not_xpath_literals() {
+        use crate::parser::load_xml_string_to_documents;
+
+        let xml = r#"<root><name>Alpha</name></root>"#;
+        let mut result = load_xml_string_to_documents(xml, "test.xml".to_string()).unwrap();
+        let engine = XPathEngine::new();
+
+        for (xpath, expected) in [
+            // The motivating case: a composite key built with concat().
+            (r#"concat(//name, ':', 256)"#, "Alpha:256"),
+            // string() of a node, and a bare string literal.
+            ("//name/string()", "Alpha"),
+            ("'plain'", "plain"),
+            // Other atomic types keep canonical (unquoted) forms.
+            ("1 + 1", "2"),
+            ("true()", "true"),
+            ("2.5", "2.5"),
+        ] {
+            let matches = engine.query_documents(
+                &mut result.documents, result.doc_handle,
+                xpath, Arc::new(vec![]), "test.xml",
+            ).unwrap();
+            assert_eq!(matches.len(), 1, "{}", xpath);
+            assert_eq!(matches[0].value, expected, "{} should yield {}", xpath, expected);
+            assert!(!matches[0].value.starts_with('"'), "{} must not be quoted", xpath);
+        }
     }
 
     /// Converted variable maps are cached per thread by content and reused

--- a/tractor/src/xpath/mod.rs
+++ b/tractor/src/xpath/mod.rs
@@ -85,7 +85,8 @@ pub fn validate_xpath(xpath: &str) -> ValidationResult {
         return ValidationResult::err("XPath expression is empty".to_string());
     }
 
-    // Try to compile the query (with tractor's built-in variables like $file)
+    // Try to compile the query (with tractor's built-in variables:
+    // $file, $variables, $rule.variables)
     let queries = Queries::new(tractor_static_context());
     match queries.sequence(xpath) {
         Ok(_) => ValidationResult::ok(),

--- a/tractor/tests/cli.rs
+++ b/tractor/tests/cli.rs
@@ -1796,11 +1796,13 @@ fn set_inline_with_path_plus_diff_lines_is_accepted_at_plan_time() {
 }
 
 // ---------------------------------------------------------------------------
-// Config variables (`variables:` root and rule keys)
+// Config variables (`variables:` root and per-entry keys)
 //
 // Root-level `variables:` in tractor.yml are bound as the `$variables` map
-// in every query of the run; a check rule's own `variables:` are bound as
-// `$rule.variables`. Both live alongside the built-in `$file`.
+// in every query of the run; an operation entry's own `variables:` are
+// bound under the namespace matching its config key ($rule.variables,
+// $mapping.variables, $query.variables, $assertion.variables). All live
+// alongside the built-in `$file`.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -1953,4 +1955,81 @@ console.log('bye');
         "allowed call must be suppressed: {}",
         result.stdout
     );
+}
+
+#[test]
+fn config_mapping_variables_bound_in_set() {
+    // A set mapping's own `variables:` bind as $mapping.variables in its
+    // xpath — including through the upsert mutation path. The mapping only
+    // selects //port when $mapping.variables?from binds to 8080; the test
+    // operation then verifies the rewritten value on disk.
+    let config = "set:
+  files: [\"data.json\"]
+  mappings:
+    - xpath: \"//port[. = $mapping.variables?from]\"
+      value: \"3000\"
+      variables:
+        from: 8080
+test:
+  files: [\"data.json\"]
+  assertions:
+    - xpath: \"//port[number(.) = 3000]\"
+      expect: 1
+";
+    cli_case!({
+        tractor run --config "tractor.yml";
+        expect => exit 0;
+    })
+    .in_fixture("replace")
+    .temp_fixture()
+    .seed_file("tractor.yml", config)
+    .seed_file("data.json", "{\"port\": 8080, \"backup\": 9090}")
+    .run();
+}
+
+#[test]
+fn config_query_variables_bound_per_query() {
+    // A query entry's own `variables:` bind as $query.variables in that
+    // expression only.
+    let config = "query:
+  files: [\"data.json\"]
+  queries:
+    - xpath: \"//role[. = $query.variables?role]\"
+      variables:
+        role: admin
+";
+    let result = command(["run", "--config", "tractor.yml"])
+        .in_fixture("replace")
+        .temp_fixture()
+        .seed_file("tractor.yml", config)
+        .seed_file("data.json", "{\"users\": [{\"role\": \"admin\"}, {\"role\": \"guest\"}]}")
+        .capture();
+
+    assert_eq!(0, result.status, "query run should succeed: {}{}", result.stdout, result.stderr);
+    assert!(result.stdout.contains("admin"), "admin role should match: {}", result.stdout);
+    assert!(!result.stdout.contains("guest"), "guest role must not match: {}", result.stdout);
+}
+
+#[test]
+fn config_assertion_variables_bound_in_test() {
+    // A test assertion's own `variables:` bind as $assertion.variables:
+    // among leaf values only b(3) exceeds max(2), so `expect: 1` passes
+    // iff the assertion-level variable binds.
+    let config = "test:
+  files: [\"data.json\"]
+  assertions:
+    - xpath: \"//*[not(*)][number(.) > $assertion.variables?max]\"
+      expect: 1
+      variables:
+        max: 2
+";
+    cli_case!({
+        tractor run --config "tractor.yml";
+        expect => exit 0;
+    })
+    .in_fixture("replace")
+    .temp_fixture()
+    .seed_file("tractor.yml", config)
+    .seed_file("data.json", "{\"a\": 1, \"b\": 3}")
+    .run();
 }

--- a/tractor/tests/cli.rs
+++ b/tractor/tests/cli.rs
@@ -2043,6 +2043,38 @@ set:
         "the run variables must be bound, not empty: {}{}",
         result.stdout, result.stderr
     );
+    // Pin the semantics, not just the diagnostic surface: the predicate has
+    // to have matched, which only happens if $variables?settings resolved.
+    assert!(
+        result.stdout.contains("updated") || result.stderr.contains("updated"),
+        "the mapping should have rewritten the value: {}{}",
+        result.stdout, result.stderr
+    );
+}
+
+#[test]
+fn config_query_output_cannot_escape_the_config_directory() {
+    // The path is joined to the config's directory; `..` would let a config
+    // write anywhere. Refused rather than normalized, so the author sees it.
+    let config = "query:
+  files: [\"data.json\"]
+  queries: [{ xpath: \"//port\" }]
+  output: \"../escaped.json\"
+";
+    let result = command(["run", "--config", "tractor.yml"])
+        .in_fixture("replace")
+        .temp_fixture()
+        .seed_file("tractor.yml", config)
+        .seed_file("data.json", "{\"port\": 8080}")
+        .capture();
+
+    assert_ne!(0, result.status, "an escaping output path must fail: {}{}", result.stdout, result.stderr);
+    let combined = format!("{}{}", result.stdout, result.stderr);
+    assert!(
+        combined.contains("must be a relative path inside the config directory"),
+        "error should name the constraint: {}",
+        combined
+    );
 }
 
 #[test]

--- a/tractor/tests/cli.rs
+++ b/tractor/tests/cli.rs
@@ -1794,3 +1794,163 @@ fn set_inline_with_path_plus_diff_lines_is_accepted_at_plan_time() {
     let on_disk = std::fs::read_to_string(src_dir.join("x.yaml")).expect("read baseline");
     assert_eq!(on_disk, baseline, "working tree must be untouched");
 }
+
+// ---------------------------------------------------------------------------
+// Config variables (`variables:` root and rule keys)
+//
+// Root-level `variables:` in tractor.yml are bound as the `$variables` map
+// in every query of the run; a check rule's own `variables:` are bound as
+// `$rule.variables`. Both live alongside the built-in `$file`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_variables_bound_in_check_rules() {
+    // $variables?env = 'production' -> the predicate holds and the rule fires.
+    let config = "variables:
+  env: production
+check:
+  files: [\"app.js\"]
+  rules:
+    - id: no-console-in-prod
+      xpath: \"//call//object[.='console'][$variables?env = 'production']\"
+      severity: error
+      reason: \"no console in production\"
+";
+    cli_case!({
+        tractor check --config "tractor.yml";
+        expect => exit 1;
+    })
+    .in_fixture("replace")
+    .temp_fixture()
+    .seed_file("tractor.yml", config)
+    .seed_file("app.js", "console.log('hi');
+")
+    .run();
+}
+
+#[test]
+fn config_variables_different_value_disables_rule() {
+    // Same rule, env = 'dev' -> predicate is false, no violations.
+    let config = "variables:
+  env: dev
+check:
+  files: [\"app.js\"]
+  rules:
+    - id: no-console-in-prod
+      xpath: \"//call//object[.='console'][$variables?env = 'production']\"
+      severity: error
+      reason: \"no console in production\"
+";
+    cli_case!({
+        tractor check --config "tractor.yml";
+        expect => exit 0;
+    })
+    .in_fixture("replace")
+    .temp_fixture()
+    .seed_file("tractor.yml", config)
+    .seed_file("app.js", "console.log('hi');
+")
+    .run();
+}
+
+#[test]
+fn config_rule_variables_bound_per_rule() {
+    // Two rules sharing one config: each sees its own $rule.variables while
+    // $variables stays global. Rule A's flag matches an element name in the
+    // file, rule B's does not -> exactly rule A fires (exit 1 with one match).
+    let config = "variables:
+  env: production
+check:
+  files: [\"data.json\"]
+  rules:
+    - id: rule-a
+      xpath: \"//*[local-name() = $rule.variables?flag][$variables?env = 'production']\"
+      variables:
+        flag: debug
+    - id: rule-b
+      xpath: \"//*[local-name() = $rule.variables?flag]\"
+      variables:
+        flag: nonexistent
+";
+    let result = command(["check", "--config", "tractor.yml"])
+        .in_fixture("replace")
+        .temp_fixture()
+        .seed_file("tractor.yml", config)
+        .seed_file("data.json", "{\"debug\": true}")
+        .capture();
+
+    assert_eq!(1, result.status, "rule-a should fire: {}{}", result.stdout, result.stderr);
+    assert!(
+        result.stdout.contains("rule-a"),
+        "rule-a should be reported: {}",
+        result.stdout
+    );
+    assert!(
+        !result.stdout.contains("rule-b"),
+        "rule-b must not fire (its flag matches nothing): {}",
+        result.stdout
+    );
+}
+
+#[test]
+fn config_variables_numeric_comparison_in_test_assertion() {
+    // Numeric variable used in a test assertion with an exact expected count:
+    // among leaf values only b(3) exceeds min(2), so `expect: 1` passes iff
+    // $variables?min binds. (Leaf-only: container elements' concatenated
+    // string values would also parse as numbers.)
+    let config = "variables:
+  min: 2
+test:
+  files: [\"data.json\"]
+  assertions:
+    - xpath: \"//*[not(*)][number(.) > $variables?min]\"
+      expect: 1
+";
+    cli_case!({
+        tractor run --config "tractor.yml";
+        expect => exit 0;
+    })
+    .in_fixture("replace")
+    .temp_fixture()
+    .seed_file("tractor.yml", config)
+    .seed_file("data.json", "{\"a\": 1, \"b\": 3}")
+    .run();
+}
+
+#[test]
+fn config_rule_id_bound_for_allow_markers() {
+    // $rule.id lets one shared predicate implement per-rule escape hatches:
+    // a comment `tractor:allow(<rule-id>)` inside the enclosing function
+    // suppresses that rule only. First console.log is allowed, second fires.
+    let config = "check:
+  files: [\"app.js\"]
+  rules:
+    - id: no-console
+      reason: \"no console\"
+      xpath: \"//call//object[.='console'][not(ancestor::function[.//comment[contains(., concat('tractor:allow(', $rule.id, ')'))]])]\"
+";
+    let source = "function ok() {
+  // tractor:allow(no-console)
+  console.log('hi');
+}
+console.log('bye');
+";
+    let result = command(["check", "--config", "tractor.yml"])
+        .in_fixture("replace")
+        .temp_fixture()
+        .seed_file("tractor.yml", config)
+        .seed_file("app.js", source)
+        .capture();
+
+    assert_eq!(1, result.status, "unallowed console.log should fire: {}{}", result.stdout, result.stderr);
+    assert!(
+        result.stdout.contains("5"),
+        "only the line-5 console.log should be reported: {}",
+        result.stdout
+    );
+    assert!(
+        !result.stdout.contains("console.log('hi')"),
+        "allowed call must be suppressed: {}",
+        result.stdout
+    );
+}

--- a/tractor/tests/cli.rs
+++ b/tractor/tests/cli.rs
@@ -2046,6 +2046,48 @@ set:
 }
 
 #[test]
+fn config_unread_source_in_a_mixed_variables_map_does_not_block_a_run() {
+    // Inline settings and a gathered artifact commonly share one map. A
+    // rule reading only the inline key must not be killed by the artifact
+    // naming a file a later operation is about to write — resolution is
+    // per key, not per map.
+    let config = "variables:
+  env: production
+  repos:
+    $file: \"gathered/repos.json\"
+operations:
+  - check:
+      files: [\"data.json\"]
+      rules:
+        - id: reads-only-env
+          reason: \"port present in production\"
+          xpath: \"//port[$variables?env = 'production']\"
+  - query:
+      files: [\"data.json\"]
+      queries: [{ xpath: \"//port\" }]
+      output: \"gathered/repos.json\"
+";
+    let result = command(["run", "--config", "tractor.yml"])
+        .in_fixture("replace")
+        .temp_fixture()
+        .seed_file("tractor.yml", config)
+        .seed_file("data.json", "{\"port\": 8080}")
+        .capture();
+
+    let combined = format!("{}{}", result.stdout, result.stderr);
+    assert!(
+        !combined.contains("cannot read"),
+        "an unread source must not be resolved: {}",
+        combined
+    );
+    assert!(
+        combined.contains("port present in production"),
+        "the rule reading the inline key should still fire: {}",
+        combined
+    );
+}
+
+#[test]
 fn config_query_output_feeds_check_in_one_run() {
     // The multi-query pipeline in a single run: the query op materializes
     // repository class names to a JSON index, and the check op — whose

--- a/tractor/tests/cli.rs
+++ b/tractor/tests/cli.rs
@@ -1988,6 +1988,59 @@ test:
 }
 
 #[test]
+fn config_variable_file_source_bound_in_check() {
+    // A `$file` variable source loads a document under its own name:
+    // $variables?settings?forbidden drives the rule, while inline
+    // variables coexist untouched. Paths resolve against the config dir.
+    let config = "variables:
+  env: production
+  settings:
+    $file: \"vars/settings.yml\"
+check:
+  files: [\"app.js\"]
+  rules:
+    - id: no-forbidden-call
+      xpath: \"//call/function[. = $variables?settings?forbidden?*][$variables?env = 'production']\"
+      severity: error
+      reason: \"forbidden call\"
+";
+    cli_case!({
+        tractor check --config "tractor.yml";
+        expect => exit 1;
+    })
+    .in_fixture("replace")
+    .temp_fixture()
+    .seed_file("tractor.yml", config)
+    .seed_file("vars/settings.yml", "forbidden: [alert, eval]\n")
+    .seed_file("app.js", "alert('hi');\n")
+    .run();
+}
+
+#[test]
+fn config_variable_file_source_missing_is_fatal() {
+    let config = "variables:
+  settings:
+    $file: \"nope.yml\"
+check:
+  files: [\"app.js\"]
+  rules:
+    - id: r
+      xpath: \"//x\"
+";
+    let result = command(["check", "--config", "tractor.yml"])
+        .in_fixture("replace")
+        .temp_fixture()
+        .seed_file("tractor.yml", config)
+        .seed_file("app.js", "let x = 1;\n")
+        .capture();
+
+    assert_ne!(0, result.status, "missing variables file must fail: {}{}", result.stdout, result.stderr);
+    let combined = format!("{}{}", result.stdout, result.stderr);
+    assert!(combined.contains("cannot read"), "error should name the failure: {}", combined);
+    assert!(combined.contains("variables?settings"), "error should name the variable: {}", combined);
+}
+
+#[test]
 fn config_set_error_still_renders_advisory_warnings() {
     // $rule.variables in a set mapping is an empty map, so the xpath matches
     // nothing and the upsert insert path errors on the predicate. The

--- a/tractor/tests/cli.rs
+++ b/tractor/tests/cli.rs
@@ -2061,7 +2061,7 @@ fn config_query_output_feeds_check_in_one_run() {
       files: [\"src/*.cs\"]
       rules:
         - id: entity-needs-repository
-          xpath: \"//class/name[not(contains(., 'Repository'))][not(concat(., 'Repository') = $variables?repos?files?*?*)]\"
+          xpath: \"//class/name[not(contains(., 'Repository'))][not(concat(., 'Repository') = $variables?repos?files?*?*?value)]\"
           severity: error
           reason: \"entity class has no matching repository\"
 variables:

--- a/tractor/tests/cli.rs
+++ b/tractor/tests/cli.rs
@@ -2017,6 +2017,35 @@ check:
 }
 
 #[test]
+fn config_set_expression_shorthand_reads_run_variables() {
+    // Regression: `expression:` builds its mapping through a different path
+    // than `mappings:`. Both must record that the xpath reads $variables,
+    // or the run-level map binds empty and the predicate silently misses.
+    let config = "variables:
+  settings:
+    $file: \"vars.yml\"
+set:
+  files: [\"data.json\"]
+  expression: \"port[$variables?settings?enable = 'yes']\"
+  value: \"3000\"
+";
+    let result = command(["run", "--config", "tractor.yml"])
+        .in_fixture("replace")
+        .temp_fixture()
+        .seed_file("tractor.yml", config)
+        .seed_file("vars.yml", "enable: yes\n")
+        .seed_file("data.json", "{\"port\": 8080}")
+        .capture();
+
+    assert_eq!(0, result.status, "expression shorthand should apply: {}{}", result.stdout, result.stderr);
+    assert!(
+        !format!("{}{}", result.stdout, result.stderr).contains("unknown variable key"),
+        "the run variables must be bound, not empty: {}{}",
+        result.stdout, result.stderr
+    );
+}
+
+#[test]
 fn config_query_output_feeds_check_in_one_run() {
     // The multi-query pipeline in a single run: the query op materializes
     // repository class names to a JSON index, and the check op — whose

--- a/tractor/tests/cli.rs
+++ b/tractor/tests/cli.rs
@@ -2017,7 +2017,52 @@ check:
 }
 
 #[test]
+fn config_query_output_feeds_check_in_one_run() {
+    // The multi-query pipeline in a single run: the query op materializes
+    // repository class names to a JSON index, and the check op — whose
+    // $file source resolves at ITS start, after the query ran — asserts
+    // every entity class has a matching repository. Invoice has none.
+    let config = "operations:
+  - query:
+      files: [\"src/*.cs\"]
+      queries:
+        - xpath: \"//class/name[contains(., 'Repository')]\"
+      output: \"gathered/repos.json\"
+  - check:
+      files: [\"src/*.cs\"]
+      rules:
+        - id: entity-needs-repository
+          xpath: \"//class/name[not(contains(., 'Repository'))][not(concat(., 'Repository') = $variables?repos?files?*?*)]\"
+          severity: error
+          reason: \"entity class has no matching repository\"
+variables:
+  repos:
+    $file: \"gathered/repos.json\"
+";
+    let result = command(["run", "--config", "tractor.yml"])
+        .in_fixture("replace")
+        .temp_fixture()
+        .seed_file("tractor.yml", config)
+        .seed_file("src/UserRepository.cs", "class UserRepository {}\n")
+        .seed_file("src/User.cs", "class User {}\n")
+        .seed_file("src/Invoice.cs", "class Invoice {}\n")
+        .capture();
+
+    assert_eq!(1, result.status, "Invoice lacks a repository: {}{}", result.stdout, result.stderr);
+    assert!(result.stdout.contains("Invoice"), "Invoice should be flagged: {}", result.stdout);
+    assert!(
+        !result.stdout.contains("User.cs:1"),
+        "User has a repository and must pass: {}",
+        result.stdout
+    );
+}
+
+#[test]
 fn config_variable_file_source_missing_is_fatal() {
+    // Sources resolve when an operation references them — a rule consuming
+    // $variables forces the read, and the missing file fails the run.
+    // (An op that never references $variables skips resolution entirely,
+    // so a producer op can run before the file it creates exists.)
     let config = "variables:
   settings:
     $file: \"nope.yml\"
@@ -2025,7 +2070,7 @@ check:
   files: [\"app.js\"]
   rules:
     - id: r
-      xpath: \"//x\"
+      xpath: \"//x[. = $variables?settings?y]\"
 ";
     let result = command(["check", "--config", "tractor.yml"])
         .in_fixture("replace")

--- a/tractor/tests/cli.rs
+++ b/tractor/tests/cli.rs
@@ -1988,6 +1988,41 @@ test:
 }
 
 #[test]
+fn config_set_error_still_renders_advisory_warnings() {
+    // $rule.variables in a set mapping is an empty map, so the xpath matches
+    // nothing and the upsert insert path errors on the predicate. The
+    // advisory warning that explains WHY must still render before the error
+    // instead of being dropped with the report.
+    let config = "set:
+  files: [\"data.json\"]
+  mappings:
+    - xpath: \"//backup[. = $rule.variables?from]\"
+      value: \"1\"
+      variables:
+        from: 9090
+";
+    let result = command(["run", "--config", "tractor.yml"])
+        .in_fixture("replace")
+        .temp_fixture()
+        .seed_file("tractor.yml", config)
+        .seed_file("data.json", "{\"backup\": 9090}")
+        .capture();
+
+    assert_ne!(0, result.status, "the failed set must exit non-zero: {}{}", result.stdout, result.stderr);
+    let combined = format!("{}{}", result.stdout, result.stderr);
+    assert!(
+        combined.contains("only bound in check rules"),
+        "the cross-namespace warning must render despite the error: {}",
+        combined
+    );
+    assert!(
+        combined.contains("error"),
+        "the underlying error must still be reported: {}",
+        combined
+    );
+}
+
+#[test]
 fn config_query_variables_bound_per_query() {
     // A query entry's own `variables:` bind as $query.variables in that
     // expression only.

--- a/web/src/pages/docs/RunCommand.tsx
+++ b/web/src/pages/docs/RunCommand.tsx
@@ -138,8 +138,11 @@ example.js:3:3: error: getAll methods in repositories should use orderBy
       <h2>Variables</h2>
       <p>
         Declare values once and reference them from any query. Root-level <code>variables</code> are
-        bound as the <code>$variables</code> map in every operation's XPath context; a rule's own{' '}
-        <code>variables</code> are bound as <code>$rule.variables</code>. Both sit alongside the
+        bound as the <code>$variables</code> map in every operation's XPath context. Each operation
+        entry can also declare its own <code>variables</code>, bound under a namespace that mirrors
+        the config key the entry lives under: <code>$rule.variables</code> for check rules,{' '}
+        <code>$mapping.variables</code> for set mappings, <code>$query.variables</code> for query
+        entries, and <code>$assertion.variables</code> for test assertions. All sit alongside the
         built-in <code>$file</code> (the current file path).
       </p>
       <CodeBlock
@@ -169,9 +172,34 @@ check:
         with <code>?*</code> (<code>$variables?banned?*</code>), and nested mappings chain lookups
         (<code>$variables?limits?max</code>). Numbers compare numerically; a lookup on a key that
         isn't configured yields the empty sequence, so predicates simply don't match. Because a
-        typo'd key would silently disable a rule, <code>tractor check</code> emits an advisory
-        warning (never a failure) for literal lookups on keys the config doesn't define.
+        typo'd key would silently disable a rule, every operation emits an advisory warning (never
+        a failure) for literal lookups on keys the config doesn't define — and for references to an
+        entry namespace that isn't bound in the current operation (e.g.{' '}
+        <code>$rule.variables</code> inside a set mapping, which is an empty map there).
       </p>
+      <p>
+        The same pattern works in every operation. A set mapping can select its targets through its
+        own values, and a test assertion can parameterize its threshold:
+      </p>
+      <CodeBlock
+        language="yaml"
+        title="tractor.yml"
+        code={`set:
+  files: ["config/*.json"]
+  mappings:
+    - xpath: "//port[. = $mapping.variables?from]"
+      value: "3000"
+      variables:
+        from: 8080
+
+test:
+  files: ["src/**/*.js"]
+  assertions:
+    - xpath: "//function[count(params/param) > $assertion.variables?max]"
+      expect: none
+      variables:
+        max: 4`}
+      />
       <p>
         Rules also get <code>$rule.id</code> — the current rule's <code>id</code> string. This makes
         per-rule escape hatches a single shared pattern instead of hand-written per rule:

--- a/web/src/pages/docs/RunCommand.tsx
+++ b/web/src/pages/docs/RunCommand.tsx
@@ -224,9 +224,16 @@ test:
         file's directory); read it with the usual lookups, e.g.{' '}
         <code>$variables?settings?db?host</code>. File content is pure data — directives inside
         loaded files are not processed. <code>$literal</code> is the escape hatch for literal data
-        whose keys start with <code>$</code>: it keeps its content verbatim. A missing file or an
-        unknown directive (e.g. a typo like <code>$fiel</code>) fails the run at load time — a
-        declared source is a promise, unlike an optional key lookup.
+        whose keys start with <code>$</code>: it keeps its content verbatim.
+      </p>
+      <p>
+        Directives are validated when the config loads — an unknown directive (e.g. a typo like{' '}
+        <code>$fiel</code>) fails before anything runs. The file <em>read</em> happens at the start
+        of each operation that references the variable, and each operation sees one consistent
+        snapshot. Two consequences: an operation that never mentions{' '}
+        <code>$variables</code> cannot fail on a missing source file, and a file written by an{' '}
+        <em>earlier</em> operation in the same run is read fresh by the next one. A referenced
+        source whose file is missing fails the run at that operation.
       </p>
       <p>
         Rules also get <code>$rule.id</code> — the current rule's <code>id</code> string. This makes
@@ -242,6 +249,49 @@ xpath: >-
   [not(ancestor::function[.//comment[
     contains(., concat('tractor:allow(', $rule.id, ')'))]])]`}
       />
+
+      <h3>Materialized query results (multi-query rules)</h3>
+      <p>
+        A query operation can write its results to a JSON index with <code>output</code>, and a
+        later operation can consume that file as a variable — cross-file assertions in a single
+        run. Operations run strictly in the order of the <code>operations</code> list (root-level
+        shorthand keys run query first for exactly this reason), and because sources resolve at
+        each operation's start, the check below reads the file the query just wrote:
+      </p>
+      <CodeBlock
+        language="yaml"
+        title="tractor.yml"
+        code={`variables:
+  repos:
+    $file: "gathered/repos.json"
+
+operations:
+  - query:
+      files: ["src/**/*.cs"]
+      queries:
+        - xpath: "//class/name[contains(., 'Repository')]"
+      output: "gathered/repos.json"
+
+  - check:
+      files: ["src/**/*.cs"]
+      rules:
+        - id: entity-needs-repository
+          xpath: >-
+            //class/name[not(contains(., 'Repository'))]
+            [not(concat(., 'Repository') = $variables?repos?files?*?*)]
+          reason: "entity class has no matching repository"`}
+      />
+      <p>
+        The written file is an index keyed by source file:{' '}
+        <code>{'{ "files": { "<path>": [ ... ] } }'}</code>, with paths relative to the config
+        directory so the artifact is stable and committable. By default each entry is the match's
+        bare value; <code>{'output: { file: ..., view: [value, line] }'}</code> stores objects with
+        the chosen fields instead (<code>value</code>, <code>line</code>, <code>column</code>,{' '}
+        <code>tree</code>). Updates merge incrementally: entries for every queried file are
+        replaced wholesale, files outside the queried set (e.g. excluded by{' '}
+        <code>diff-files</code>) keep their entries, and entries whose file no longer exists are
+        pruned — so a diff-scoped gather stays correct without re-querying the whole tree.
+      </p>
 
       <h2>Multiple Operation Types</h2>
       <p>

--- a/web/src/pages/docs/RunCommand.tsx
+++ b/web/src/pages/docs/RunCommand.tsx
@@ -289,25 +289,26 @@ operations:
       <p>
         The written file is an index keyed by source file:{' '}
         <code>{'{ "files": { "<path>": [ ... ] } }'}</code>, with paths relative to the config
-        directory so the artifact is stable and committable. <code>view:</code> picks what each
-        entry holds — a <em>single</em> field is written directly (the default{' '}
-        <code>[value]</code> gives bare strings, <code>[tree]</code> gives each match's structure
-        itself), while several fields (<code>value</code>, <code>line</code>, <code>column</code>,{' '}
-        <code>tree</code>) are written as a labelled object. Updates merge incrementally: entries for every queried file are
+        directory so the artifact is stable and committable. Each entry is a labelled object;{' '}
+        <code>view:</code> chooses which keys it holds (<code>value</code> by default, plus{' '}
+        <code>line</code>, <code>column</code>, <code>tree</code>) and nothing else — the shape
+        never depends on how many fields you selected or on what a match contains, so adding a
+        field only adds a key. Updates merge incrementally: entries for every queried file are
         replaced wholesale, files outside the queried set (e.g. excluded by{' '}
         <code>diff-files</code>) keep their entries, and entries whose file no longer exists are
         pruned — so a diff-scoped gather stays correct without re-querying the whole tree.
       </p>
       <p>
-        <strong>Reading the index.</strong> Most rules just want the flat set of gathered values,
-        which is <code>?files?*?*</code> — the first <code>?*</code> expands every file key, the
-        second every entry in that file's array:
+        <strong>Reading the index.</strong> Most rules just want the flat set of gathered values.
+        That is <code>?files?*?*?value</code> — the first <code>?*</code> expands every file key,
+        the second every entry in that file's array, and <code>?value</code> takes the field:
       </p>
       <CodeBlock
         language="text"
-        code={`$variables?records?files?*?*        all values, provenance discarded
-$variables?records?files?("src/A.cs")?*   values from one specific file
-map:keys($variables?records?files)        the file paths themselves`}
+        code={`$variables?records?files?*?*?value              all values, provenance discarded
+$variables?records?files?("src/A.cs")?*?value  values from one specific file
+$variables?records?files?*?*?tree              the structured record of each entry
+map:keys($variables?records?files)             the file paths themselves`}
       />
       <p>
         Keep the file keys when a rule is <em>about</em> paths (e.g. "every file with an X must
@@ -337,7 +338,7 @@ operations:
             ! map { 'name': string(name), 'max': string(.//argument/int) }
       output:
         file: "gathered/records.json"
-        view: [tree]          # entries are the maps themselves
+        view: [tree]          # each entry holds its map under "tree"
 
   - check:
       files: ["**/*Dto.cs"]
@@ -346,7 +347,7 @@ operations:
           reason: "DTO MaxLength differs from the Record"
           xpath: >-
             //property[.//attribute/name/ref = 'MaxLength']
-            [not(some $r in $variables?records?files?*?*
+            [not(some $r in $variables?records?files?*?*?tree
                  satisfies $r?name = string(name) and $r?max = string(.//argument/int))]
             /name`}
       />

--- a/web/src/pages/docs/RunCommand.tsx
+++ b/web/src/pages/docs/RunCommand.tsx
@@ -289,10 +289,11 @@ operations:
       <p>
         The written file is an index keyed by source file:{' '}
         <code>{'{ "files": { "<path>": [ ... ] } }'}</code>, with paths relative to the config
-        directory so the artifact is stable and committable. By default each entry is the match's
-        bare value; <code>{'output: { file: ..., view: [value, line] }'}</code> stores objects with
-        the chosen fields instead (<code>value</code>, <code>line</code>, <code>column</code>,{' '}
-        <code>tree</code>). Updates merge incrementally: entries for every queried file are
+        directory so the artifact is stable and committable. <code>view:</code> picks what each
+        entry holds — a <em>single</em> field is written directly (the default{' '}
+        <code>[value]</code> gives bare strings, <code>[tree]</code> gives each match's structure
+        itself), while several fields (<code>value</code>, <code>line</code>, <code>column</code>,{' '}
+        <code>tree</code>) are written as a labelled object. Updates merge incrementally: entries for every queried file are
         replaced wholesale, files outside the queried set (e.g. excluded by{' '}
         <code>diff-files</code>) keep their entries, and entries whose file no longer exists are
         pruned — so a diff-scoped gather stays correct without re-querying the whole tree.
@@ -313,12 +314,12 @@ map:keys($variables?records?files)        the file paths themselves`}
         have a matching Y"); use the flat form for plain membership tests.
       </p>
 
-      <h3>Correspondence rules (composite keys)</h3>
+      <h3>Correspondence rules</h3>
       <p>
         The common shape is "this thing over here must agree with that thing over there" — a
-        DTO's <code>[MaxLength]</code> matching its Record's, say. XPath has no join, so build a{' '}
-        <strong>composite key</strong> string on both sides and compare the keys. Gather one side,
-        then test membership from the other:
+        DTO's <code>[MaxLength]</code> matching its Record's, say. Gather one side as{' '}
+        <strong>structured records</strong> with a <code>map{'{}'}</code> constructor and{' '}
+        <code>view: [tree]</code>, then compare field by field from the other side:
       </p>
       <CodeBlock
         language="yaml"
@@ -331,9 +332,12 @@ operations:
   - query:
       files: ["**/*Record.cs"]
       queries:
-        # key = property name + ':' + declared length
-        - xpath: "//property[.//attribute/name/ref = 'MaxLength'] ! concat(name, ':', .//argument/int)"
-      output: "gathered/records.json"
+        - xpath: >-
+            //property[.//attribute/name/ref = 'MaxLength']
+            ! map { 'name': string(name), 'max': string(.//argument/int) }
+      output:
+        file: "gathered/records.json"
+        view: [tree]          # entries are the maps themselves
 
   - check:
       files: ["**/*Dto.cs"]
@@ -342,15 +346,24 @@ operations:
           reason: "DTO MaxLength differs from the Record"
           xpath: >-
             //property[.//attribute/name/ref = 'MaxLength']
-            [not(concat(name, ':', .//argument/int) = $variables?records?files?*?*)]
+            [not(some $r in $variables?records?files?*?*
+                 satisfies $r?name = string(name) and $r?max = string(.//argument/int))]
             /name`}
       />
       <p>
-        Both sides must build the key <em>identically</em>; if the names differ between the two
-        shapes, normalize inside the key expression (<code>replace()</code>,{' '}
-        <code>substring-before()</code>) rather than after. Keys are compared as strings, so
-        include a separator that cannot appear in the parts — a bare concatenation makes{' '}
-        <code>a</code>+<code>bc</code> collide with <code>ab</code>+<code>c</code>.
+        Each field is compared on its own (<code>$r?name</code>, <code>$r?max</code>), so the
+        record stays self-describing and adding a third field doesn't change how the existing
+        ones match.
+      </p>
+      <p>
+        A single scalar per match — <code>concat(name, ':', .//argument/int)</code> with the
+        default <code>view: [value]</code> — is shorter, and fine for a plain membership test
+        against one value. Prefer the structured form for anything with more than one field:
+        packing fields into a string makes the parts positional and invisible to the reader, and
+        the separator becomes load-bearing (with no separator, <code>a</code>+<code>bc</code>{' '}
+        collides with <code>ab</code>+<code>c</code>). If the two sides name things differently,
+        normalize inside the field expression (<code>replace()</code>,{' '}
+        <code>substring-before()</code>) rather than after.
       </p>
       <p>
         <strong>Known limitation:</strong> matching is per file and syntactic, so an inherited

--- a/web/src/pages/docs/RunCommand.tsx
+++ b/web/src/pages/docs/RunCommand.tsx
@@ -297,6 +297,70 @@ operations:
         <code>diff-files</code>) keep their entries, and entries whose file no longer exists are
         pruned — so a diff-scoped gather stays correct without re-querying the whole tree.
       </p>
+      <p>
+        <strong>Reading the index.</strong> Most rules just want the flat set of gathered values,
+        which is <code>?files?*?*</code> — the first <code>?*</code> expands every file key, the
+        second every entry in that file's array:
+      </p>
+      <CodeBlock
+        language="text"
+        code={`$variables?records?files?*?*        all values, provenance discarded
+$variables?records?files?("src/A.cs")?*   values from one specific file
+map:keys($variables?records?files)        the file paths themselves`}
+      />
+      <p>
+        Keep the file keys when a rule is <em>about</em> paths (e.g. "every file with an X must
+        have a matching Y"); use the flat form for plain membership tests.
+      </p>
+
+      <h3>Correspondence rules (composite keys)</h3>
+      <p>
+        The common shape is "this thing over here must agree with that thing over there" — a
+        DTO's <code>[MaxLength]</code> matching its Record's, say. XPath has no join, so build a{' '}
+        <strong>composite key</strong> string on both sides and compare the keys. Gather one side,
+        then test membership from the other:
+      </p>
+      <CodeBlock
+        language="yaml"
+        title="tractor.yml"
+        code={`variables:
+  records:
+    $file: "gathered/records.json"
+
+operations:
+  - query:
+      files: ["**/*Record.cs"]
+      queries:
+        # key = property name + ':' + declared length
+        - xpath: "//property[.//attribute/name/ref = 'MaxLength'] ! concat(name, ':', .//argument/int)"
+      output: "gathered/records.json"
+
+  - check:
+      files: ["**/*Dto.cs"]
+      rules:
+        - id: dto-maxlength-drift
+          reason: "DTO MaxLength differs from the Record"
+          xpath: >-
+            //property[.//attribute/name/ref = 'MaxLength']
+            [not(concat(name, ':', .//argument/int) = $variables?records?files?*?*)]
+            /name`}
+      />
+      <p>
+        Both sides must build the key <em>identically</em>; if the names differ between the two
+        shapes, normalize inside the key expression (<code>replace()</code>,{' '}
+        <code>substring-before()</code>) rather than after. Keys are compared as strings, so
+        include a separator that cannot appear in the parts — a bare concatenation makes{' '}
+        <code>a</code>+<code>bc</code> collide with <code>ab</code>+<code>c</code>.
+      </p>
+      <p>
+        <strong>Known limitation:</strong> matching is per file and syntactic, so an inherited
+        member is invisible to the side that inherits it — a property declared on a shared base
+        class in another file will look "missing" to a rule that only inspects the derived
+        declaration. Gathering the base declarations into the same index (a second{' '}
+        <code>query</code> writing to the same <code>output:</code> file, or a wider{' '}
+        <code>files:</code> pattern) covers the common cases; full type resolution across files
+        is out of scope.
+      </p>
 
       <h2>Multiple Operation Types</h2>
       <p>

--- a/web/src/pages/docs/RunCommand.tsx
+++ b/web/src/pages/docs/RunCommand.tsx
@@ -200,6 +200,34 @@ test:
       variables:
         max: 4`}
       />
+      <h3>Variable sources</h3>
+      <p>
+        A value in any <code>variables</code> tree can come from an external source instead of
+        being written inline: a map with a single <code>$</code>-prefixed key names the source.
+        Each source binds under its own key — sources never merge, so two sources cannot collide.
+        Directives may appear at any depth, so one nested key can be file-sourced while its
+        siblings stay inline.
+      </p>
+      <CodeBlock
+        language="yaml"
+        title="tractor.yml"
+        code={`variables:
+  env: production            # inline literal
+  settings:
+    $file: "config/vars.yml" # whole file bound under this name
+  team:
+    prefixes:
+      $file: "prefixes.json" # nested directive; siblings stay inline`}
+      />
+      <p>
+        <code>$file</code> loads a JSON, YAML, or TOML document (path relative to the config
+        file's directory); read it with the usual lookups, e.g.{' '}
+        <code>$variables?settings?db?host</code>. File content is pure data — directives inside
+        loaded files are not processed. <code>$literal</code> is the escape hatch for literal data
+        whose keys start with <code>$</code>: it keeps its content verbatim. A missing file or an
+        unknown directive (e.g. a typo like <code>$fiel</code>) fails the run at load time — a
+        declared source is a promise, unlike an optional key lookup.
+      </p>
       <p>
         Rules also get <code>$rule.id</code> — the current rule's <code>id</code> string. This makes
         per-rule escape hatches a single shared pattern instead of hand-written per rule:

--- a/web/src/pages/docs/RunCommand.tsx
+++ b/web/src/pages/docs/RunCommand.tsx
@@ -108,6 +108,7 @@ example.js:3:3: error: getAll methods in repositories should use orderBy
           <tr><td><code>include</code></td><td>No</td><td>File patterns for this rule only (relative to config file directory)</td></tr>
           <tr><td><code>exclude</code></td><td>No</td><td>File patterns to exclude for this rule (relative to config file directory)</td></tr>
           <tr><td><code>expect</code></td><td>No</td><td>Test examples (see below)</td></tr>
+          <tr><td><code>variables</code></td><td>No</td><td>Rule-scoped values, available as <code>$rule.variables</code> in the query (see Variables)</td></tr>
         </tbody>
       </table>
 
@@ -133,6 +134,58 @@ example.js:3:3: error: getAll methods in repositories should use orderBy
       <p>
         When you run <code>tractor run</code>, the <code>expect</code> entries are also validated. If a <code>valid</code> example matches the rule (or an <code>invalid</code> example doesn't), the run fails.
       </p>
+
+      <h2>Variables</h2>
+      <p>
+        Declare values once and reference them from any query. Root-level <code>variables</code> are
+        bound as the <code>$variables</code> map in every operation's XPath context; a rule's own{' '}
+        <code>variables</code> are bound as <code>$rule.variables</code>. Both sit alongside the
+        built-in <code>$file</code> (the current file path).
+      </p>
+      <CodeBlock
+        language="yaml"
+        title="tractor.yml"
+        code={`variables:
+  env: production
+  banned: [eval, exec]
+
+check:
+  files:
+    - "src/**/*.js"
+  rules:
+    - id: no-banned-calls
+      xpath: "//call/name[. = $variables?banned?*]"
+      reason: "banned function call"
+
+    - id: not-too-many-params
+      xpath: "//function[count(params/param) > $rule.variables?max]"
+      reason: "too many parameters"
+      variables:
+        max: 4`}
+      />
+      <p>
+        Values follow the JSON data model: strings, numbers, booleans, <code>null</code>, lists, and
+        nested mappings. Scalars are read with map lookup (<code>$variables?env</code>), lists expand
+        with <code>?*</code> (<code>$variables?banned?*</code>), and nested mappings chain lookups
+        (<code>$variables?limits?max</code>). Numbers compare numerically; a lookup on a key that
+        isn't configured yields the empty sequence, so predicates simply don't match. Because a
+        typo'd key would silently disable a rule, <code>tractor check</code> emits an advisory
+        warning (never a failure) for literal lookups on keys the config doesn't define.
+      </p>
+      <p>
+        Rules also get <code>$rule.id</code> — the current rule's <code>id</code> string. This makes
+        per-rule escape hatches a single shared pattern instead of hand-written per rule:
+      </p>
+      <CodeBlock
+        language="yaml"
+        title="tractor.yml"
+        code={`# a comment \`tractor:allow(<rule-id>)\` in the enclosing function
+# suppresses exactly that rule
+xpath: >-
+  //call//object[.='console']
+  [not(ancestor::function[.//comment[
+    contains(., concat('tractor:allow(', $rule.id, ')'))]])]`}
+      />
 
       <h2>Multiple Operation Types</h2>
       <p>

--- a/web/src/pages/docs/RunCommand.tsx
+++ b/web/src/pages/docs/RunCommand.tsx
@@ -228,12 +228,17 @@ test:
       </p>
       <p>
         Directives are validated when the config loads — an unknown directive (e.g. a typo like{' '}
-        <code>$fiel</code>) fails before anything runs. The file <em>read</em> happens at the start
-        of each operation that references the variable, and each operation sees one consistent
-        snapshot. Two consequences: an operation that never mentions{' '}
-        <code>$variables</code> cannot fail on a missing source file, and a file written by an{' '}
-        <em>earlier</em> operation in the same run is read fresh by the next one. A referenced
-        source whose file is missing fails the run at that operation.
+        <code>$fiel</code>) fails before anything runs, with no file access. The file{' '}
+        <em>read</em> happens later, at the start of each operation, so a file written by an{' '}
+        <em>earlier</em> operation in the same run is read fresh by the next one; every rule
+        within one operation sees the same snapshot.
+      </p>
+      <p>
+        A source is only read where it is actually used. That is decided per entry: a rule reading{' '}
+        <code>$rule.variables</code> does not force a sibling rule's sources to load. So a source
+        that nothing reads never fails the run — which is what lets a config declare a file that a
+        later operation is about to write. A source that <em>is</em> read and whose file is missing
+        fails the run at that operation.
       </p>
       <p>
         Rules also get <code>$rule.id</code> — the current rule's <code>id</code> string. This makes

--- a/web/src/pages/docs/RunCommand.tsx
+++ b/web/src/pages/docs/RunCommand.tsx
@@ -259,9 +259,8 @@ xpath: >-
       <p>
         A query operation can write its results to a JSON index with <code>output</code>, and a
         later operation can consume that file as a variable — cross-file assertions in a single
-        run. Operations run strictly in the order of the <code>operations</code> list (root-level
-        shorthand keys run query first for exactly this reason), and because sources resolve at
-        each operation's start, the check below reads the file the query just wrote:
+        run. Because sources resolve at each operation's start, the check below reads the file
+        the query just wrote:
       </p>
       <CodeBlock
         language="yaml"
@@ -400,6 +399,33 @@ operations:
           expect: some
           message: "At least one class expected"`}
       />
+
+      <h3>Execution order</h3>
+      <p>
+        Operations run one after another, and each sees whatever the previous ones left behind
+        — files a <code>set</code> rewrote, an index a <code>query</code> materialized. Two ways
+        to arrange them:
+      </p>
+      <ul>
+        <li>
+          The <code>operations</code> list runs <strong>exactly in the order written</strong>.
+          This is how you express a dependency, and the only way to run two operations of the
+          same kind.
+        </li>
+        <li>
+          The root-level shorthand keys (<code>query</code>, <code>check</code>, <code>set</code>,{' '}
+          <code>test</code>) are a convenience for at most one operation of each kind. They run
+          in that fixed order — <strong>query first</strong>, so a gathered index is available to
+          the operations that consume it.
+        </li>
+      </ul>
+      <p>
+        <strong>Changed behaviour:</strong> the shorthand order was previously check, set, query.
+        A config that used root-level <code>set</code> and <code>query</code> together therefore
+        had the query observe files <em>after</em> the set rewrote them, and now observes them
+        before. If that ordering mattered, write the two as an explicit{' '}
+        <code>operations</code> list, which says what you mean and is unaffected.
+      </p>
 
       <h2>Set Operations</h2>
       <p>


### PR DESCRIPTION
## Summary

Config files can declare variables that are bound into every query's XPath dynamic context, alongside the built-in `$file`:

```yaml
variables:                # root → $variables map in every operation
  env: production
check:
  rules:
    - id: assertions-must-be-expect-prefixed
      variables:          # rule → $rule.variables map in this rule only
        prefixes: [Assert, Should]
      xpath: >-
        //call[member/name/ref[some $p in $rule.variables?prefixes?* satisfies starts-with(., $p)]]
        [$variables?env = 'production']
        [not(ancestor::method[.//comment[contains(., concat('tractor:allow(', $rule.id, ')'))]])]
```

- **`$variables`** — root `variables:` mapping, bound in every operation (check, set, query, test, update — including the set/update mutation path)
- **Per-entry namespaces** — each operation entry's own `variables:` bind under a namespace mirroring its config key: **`$rule.variables`** (check `rules:`), **`$mapping.variables`** (set `mappings:`), **`$query.variables`** (query `queries:`), **`$assertion.variables`** (test `assertions:`). Only the current entry's namespace is populated; the others are empty maps.
- **`$rule.id`** — the current rule's id; makes the `tractor:allow(<rule-id>)` escape hatch one uniform predicate instead of per-rule hand-written text

```yaml
set:
  mappings:
    - xpath: "//port[. = $mapping.variables?from]"
      value: "3000"
      variables:
        from: 8080
```

## Design

- Values mirror the **JSON data model** (`VariableValue`: scalars, lists, nested maps; untagged serde, so YAML/TOML map directly) — every variable source deserializes into the same type.
- Bound as XPath `map(*)` items through a cached `parse-json` evaluation — the only public xee API for constructing maps/arrays. JSON semantics inside: numbers are `xs:double`, `null` is the empty sequence.
- Namespaced maps keep the **static context constant** (`file`, `variables`, the four entry namespaces, `rule.id`) — no per-variable-set query compilation, no name validation or merge/shadowing rules; any key is legal (`$variables?("weird key")`).
- The current entry is a structural **`EntryContext { kind, variables, id }`** (one field on `XeeParseResult`, one binding chokepoint in the engine) rather than loose fields kept in sync by convention.
- `QueryVariables` is plain `Send + Sync` data shared via `Arc` (`LoadedConfig` → `RunContext`/`ExecCtx` → per-parse `XeeParseResult`); xee sequences are `Rc`-based and built per thread.
- Converted map sequences are **cached per thread**, keyed by their JSON serialization (content keying is ABA-safe where `Arc::as_ptr` would not be). The values are pure data items — never nodes — so they are valid across documents; per-query conversion collapses to cache hits after first use.

## Variable sources (`$`-directives)

Any value in a `variables:` tree may be a *source directive* instead of a literal — a map with a single `$`-prefixed key naming where the value comes from. Directives work at **any depth**, and each source binds under its own key: **no merge or shadowing semantics** — two sources cannot collide by construction.

```yaml
variables:
  env: production            # inline literal
  settings:
    $file: "config/vars.yml" # whole JSON/YAML/TOML document bound under this name
  team:
    prefixes:
      $file: "prefixes.json" # nested directive; siblings stay inline
```

- **`$file`** — loads a document (path relative to the config dir); content is pure data, directives inside loaded files are not processed. Read with the usual lookups: `$variables?settings?db?host`.
- **`$literal`** — verbatim escape hatch for literal data whose keys start with `$`.
- **`$query`** — reserved for binding tractor query results; errors as "not implemented yet" so it can never silently become data. Unknown directives (`$fiel`) and `$`-keys mixed into ordinary maps also fail loudly, with the lookup path in the message.

Directives are **validated statically at config load** (unknown `$fiel` fails before anything runs); the file *read* happens at the start of each operation that references the variable — resolution is referenced-only, so a producer op cannot fail on a source it is about to create, and each consumer sees one fresh, consistent snapshot. The now-unused `QueryVariables::merge` seam is deleted — named sources supersede merging.

## Multi-query rules in one run (`query` → `output:` → `$file`)

A query op can materialize its results, and a later op consumes them — cross-file assertions (“every entity has a repository”) in a single run:

```yaml
variables:
  repos:
    $file: "gathered/repos.json"

operations:
  - query:
      files: ["src/**/*.cs"]
      queries: [{ xpath: "//class/name[contains(., 'Repository')]" }]
      output: "gathered/repos.json"
  - check:
      files: ["src/**/*.cs"]
      rules:
        - id: entity-needs-repository
          xpath: "//class/name[not(contains(., 'Repository'))][not(concat(., 'Repository') = $variables?repos?files?*?*)]"
          reason: "entity class has no matching repository"
```

- The artifact is a JSON index keyed by source file (`{"files": {"<path>": […]}}`, paths relative to the config dir — stable and committable). `view:` picks per-entry fields (`value` default → bare strings; `line`/`column`/`tree` → objects).
- **Incremental by construction**: entries for every queried file are replaced wholesale, files outside the queried set (e.g. excluded by `--diff-files`) keep theirs, entries whose file vanished are pruned.
- Operations run strictly in list order (the ordered `operations:` list is the dependency mechanism); shorthand root keys normalize **query first** — gather-before-check as the sane default.

## Typo safety

A lookup on a missing key legally yields the empty sequence (EBV false) — which can silently disable a rule. Every operation therefore emits **advisory Warning diagnostics** (never failing the run) for:

- literal `$variables?key` / `$<entry>.variables?key` lookups on keys the config doesn't define,
- references to an entry namespace not bound in the current operation (e.g. `$rule.variables` inside a set mapping — an empty map there),
- `$rule.id` outside check rules.

Dynamic lookups (`?($expr)`, `?*`) are skipped; referencing a genuinely undeclared variable (`$typo`) remains a fatal compile diagnostic.

## Error paths stay self-diagnosing

When an operation fails mid-run (e.g. a set mapping whose variable-driven predicate matches nothing, sending the upsert insert path into a predicate error), the diagnostics accumulated so far — including the advisory warning that explains the failure — now render **before** the error propagates, instead of being dropped with the report.

## Changed behaviour: shorthand operation order

Root-level shorthand keys (`check:`, `set:`, `query:`, `test:`) now expand in a **fixed order — query first**, then check, set, test. Previously they expanded in source order (check, set, query, test). That order was an implementation artifact, not a stated contract: no ordering was documented in the docs or design docs, and none was tested. Query-first makes the new common case work without ceremony — a gathered index is on disk before the operations that consume it run.

**One config shape changes meaning:** root `set:` together with root `query:`. The query now observes files *before* the set rewrites them, where it previously observed them after.

To express a dependency, use an explicit `operations:` list. It runs exactly in the order written, is unaffected by this change, and is the only way to run two operations of the same kind.

## Testing

- 40+ new tests across engine (incl. cross-document reuse of cached variable sequences), variable-source resolution (files at depth, $literal, fail-loud errors, static-vs-runtime split), query output (config parsing, incremental merge, one-run gather→check pipeline e2e) (binding, structured lookups, null/missing keys, namespace separation and per-kind isolation, `$rule.id`, validation), config parsing (YAML+TOML, rule/mapping/query/assertion-level), matcher (undefined-key and cross-namespace diagnostics), executor (per-rule binding, warning severity/verdict, query cross-namespace warning), and CLI end-to-end (check/test/run, allow-marker suppression, set-through-mutation-path, per-query and per-assertion binding).
- Full suite green: 322 lib + 140 bin + 350 CLI + 32 integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



